### PR TITLE
Fix DCP executable discovery (backport #69)

### DIFF
--- a/internal/dcp/commands/start_api_server.go
+++ b/internal/dcp/commands/start_api_server.go
@@ -81,7 +81,6 @@ func startApiSrv(log logr.Logger) func(cmd *cobra.Command, _ []string) error {
 
 			usvc_io.PreserveSessionFolder() // The forked process will take care of cleaning up the session folder
 
-			// We assume os.Args[0] will be valid here because it is in all the scenarios we currently support.
 			forked := exec.Command(os.Args[0], args...)
 			forked.Env = os.Environ()    // Inherit the environment from the parent process
 			logger.WithSessionId(forked) // Ensure the session ID is passed to the forked process

--- a/internal/dcptun/image_builder_test.go
+++ b/internal/dcptun/image_builder_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/microsoft/dcp/internal/containers"
+	"github.com/microsoft/dcp/internal/dcppaths"
 	"github.com/microsoft/dcp/internal/dcptun"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
 	"github.com/microsoft/dcp/pkg/slices"
@@ -34,8 +35,7 @@ func TestClientProxyImageBuild(t *testing.T) {
 	co, coErr := ctrl_testutil.NewTestContainerOrchestrator(ctx, log, ctrl_testutil.TcoOptionNone)
 	require.NoError(t, coErr, "Failed to create test container orchestrator")
 
-	// Note: dcptunClientBinaryPath() will first look for dcptun_c next to the running binary (os.Args[0]),
-	// and if not found, will probe the filesystem from the current directory to find bin/dcptun_c.
+	dcppaths.EnableTestPathProbing()
 
 	path := filepath.Join(t.TempDir(), t.Name()+".imglist")
 	defer func() { _ = os.Remove(path) }() // Best effort cleanup
@@ -71,8 +71,7 @@ func TestConcurrentClientProxyImageBuild(t *testing.T) {
 	co, coErr := ctrl_testutil.NewTestContainerOrchestrator(ctx, log, ctrl_testutil.TcoOptionNone)
 	require.NoError(t, coErr, "Failed to create test container orchestrator")
 
-	// Note: dcptunClientBinaryPath() will first look for dcptun_c next to the running binary (os.Args[0]),
-	// and if not found, will probe the filesystem from the current directory to find bin/dcptun_c.
+	dcppaths.EnableTestPathProbing()
 
 	path := filepath.Join(t.TempDir(), t.Name()+".imglist")
 	defer func() { _ = os.Remove(path) }() // Best effort cleanup

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -133,7 +133,7 @@ func isRoot(path string) bool {
 	return false
 }
 
-// IsSimpleValidFilename checks whether name is a simple, OS-agnostic
+// HasOnlyValidFilenameChars checks whether name is a simple, OS-agnostic
 // valid filename according to the following rules:
 // - must not be empty
 // - must not contain control characters (ASCII < 32)

--- a/test/integration/container_network_tunnel_proxy_test.go
+++ b/test/integration/container_network_tunnel_proxy_test.go
@@ -780,11 +780,14 @@ func TestTunnelProxyServerStartupFailure(t *testing.T) {
 	err := serverInfo.Client.Create(ctx, &network)
 	require.NoError(t, err, "Could not create a ContainerNetwork object")
 
+	dcpPath, dcpPathErr := dcppaths.GetDcpExePath()
+	require.NoError(t, dcpPathErr, "Could not get DCP executable path")
+
 	t.Log("Installing server proxy auto execution with startup error...")
 	serverStartAttempted := &atomic.Bool{}
 	teInfo.TestProcessExecutor.InstallAutoExecution(internal_testutil.AutoExecution{
 		Condition: internal_testutil.ProcessSearchCriteria{
-			Command: []string{os.Args[0], "tunnel-server"},
+			Command: []string{dcpPath, "tunnel-server"},
 		},
 		StartupError: func(_ *internal_testutil.ProcessExecution) error {
 			serverStartAttempted.Store(true)
@@ -1301,9 +1304,12 @@ func simulateServerProxy(
 	serverControlPort int32,
 	tpe *internal_testutil.TestProcessExecutor,
 ) {
+	dcpPath, dcpPathErr := dcppaths.GetDcpExePath()
+	require.NoError(t, dcpPathErr, "Could not get DCP executable path")
+
 	tpe.InstallAutoExecution(internal_testutil.AutoExecution{
 		Condition: internal_testutil.ProcessSearchCriteria{
-			Command: []string{os.Args[0], "tunnel-server"},
+			Command: []string{dcpPath, "tunnel-server"},
 		},
 		RunCommand: func(pe *internal_testutil.ProcessExecution) int32 {
 			tc := dcptun.TunnelProxyConfig{

--- a/test/integration/standard_test_env.go
+++ b/test/integration/standard_test_env.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -57,7 +56,7 @@ func StartTestEnvironment(
 	// On Windows the process Executable runner uses the dcp stop-process-tree subcommand, so we need to simulate that.
 	pex.InstallAutoExecution(internal_testutil.AutoExecution{
 		Condition: internal_testutil.ProcessSearchCriteria{
-			Command: []string{os.Args[0], "stop-process-tree"},
+			Command: []string{"dcp", "stop-process-tree"},
 		},
 		RunCommand: dcpproc.SimulateStopProcessTreeCommand,
 	})


### PR DESCRIPTION
* Fix DCP executable discovery

* Fix some typos

* Use OnceValues to store DCP executable path

Thanks to @danegsta for very good suggestion