### PR TITLE
[release/0.22] Fix: Add --container-runtime flag to run-controllers command

### DIFF
--- a/internal/dcpctrl/commands/run_controllers.go
+++ b/internal/dcpctrl/commands/run_controllers.go
@@ -53,6 +53,8 @@ func NewRunControllersCommand(log logr.Logger) *cobra.Command {
 	kubeconfig.EnsureKubeconfigFlag(runControllersCmd.Flags())
 	kubeconfig.EnsureKubeconfigPortFlag(runControllersCmd.Flags())
 
+	container_flags.EnsureRuntimeFlag(runControllersCmd.Flags())
+
 	cmds.AddMonitorFlags(runControllersCmd)
 	notifications.AddNotificationSocketFlag(runControllersCmd.Flags())
 


### PR DESCRIPTION
Backport of #82 to release/0.22

/cc @danegsta @Copilot

## Customer Impact

Enables --container-runtime flag on run-controllers sub-command. 

## Testing

Automated suite

## Risk

Low

## Regression?

Yes, due to the move to a single binary, that flag didn’t make the move as it was defined on the dcpctrl root command. 