### PR TITLE
fix: make log messages more AI-friendly

### DIFF
--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -453,7 +453,7 @@ func (r *ExecutableReconciler) startExecutable(
 		runner, runnerNotFoundErr := r.getExecutableRunner(exe, ri.startupStage)
 		if runnerNotFoundErr != nil {
 			log.V(1).Info("Executable runner is not available for current startup stage, will try next stage if available",
-				"StartupStage", ri.startupStage, "reason", runnerNotFoundErr.Error())
+				"StartupStage", ri.startupStage, "Error", runnerNotFoundErr)
 			continue
 		}
 

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -452,7 +452,8 @@ func (r *ExecutableReconciler) startExecutable(
 
 		runner, runnerNotFoundErr := r.getExecutableRunner(exe, ri.startupStage)
 		if runnerNotFoundErr != nil {
-			log.Error(runnerNotFoundErr, "The Executable runner is not available", "StartupStage", ri.startupStage)
+			log.V(1).Info("Executable runner is not available for current startup stage, will try next stage if available",
+				"StartupStage", ri.startupStage, "reason", runnerNotFoundErr.Error())
 			continue
 		}
 

--- a/internal/containers/runtimes/runtime.go
+++ b/internal/containers/runtimes/runtime.go
@@ -83,7 +83,10 @@ func FindAvailableContainerRuntime(ctx context.Context, log logr.Logger, executo
 		return nil, errNoRuntimeFound
 	}
 
-	log.V(1).Info("Runtime status", "Runtime", availableRuntime.orchestrator.Name(), "Status", availableRuntime.status)
+	log.V(1).Info("Container runtime selected (non-installed runtimes are expected and can be ignored)",
+		"SelectedRuntime", availableRuntime.orchestrator.Name(),
+		"Installed", availableRuntime.status.Installed,
+		"Running", availableRuntime.status.Running)
 
 	return availableRuntime.orchestrator, nil
 }

--- a/internal/exerunners/ide_connection_info.go
+++ b/internal/exerunners/ide_connection_info.go
@@ -44,8 +44,8 @@ type ideConnectionInfo struct {
 }
 
 func NewIdeConnectionInfo(lifetimeCtx context.Context, log logr.Logger) (*ideConnectionInfo, error) {
-	const runnerNotAvailable = "Executables cannot be started via IDE: "
-	const missingRequiredEnvVar = "missing required environment variable '%s'"
+	const runnerNotAvailable = "IDE execution is not configured (this is expected in non-IDE environments): "
+	const missingRequiredEnvVar = "environment variable '%s' is not set"
 
 	createAndLogError := func(format string, a ...any) error {
 		err := fmt.Errorf(format, a...)

--- a/internal/exerunners/ide_notification_handler.go
+++ b/internal/exerunners/ide_notification_handler.go
@@ -109,7 +109,7 @@ func NewIdeNotificationHandler(
 }
 
 func (nh *ideNotificationHandler) WaitConnected(ctx context.Context) error {
-	const errDisposed = "the IDE session endpoint is not available"
+	const errDisposed = "IDE session endpoint has been disposed (this is expected during shutdown)"
 
 	nhState := nh.getState()
 	switch nhState {


### PR DESCRIPTION
Reword log messages that AI tools commonly misinterpret as errors when analyzing test failures and logs:

- IDE runner unavailability: Clarify that missing IDE environment variables are expected in non-IDE environments (CI, tests), not errors
- Runtime status: Add context that non-installed runtimes (e.g. Podman when only Docker is available) are expected and can be ignored
- Executable runner fallback: Downgrade from Error to Info log level since progressing through startup stages is normal behavior
- IDE notification handler: Clarify that disposed endpoint is expected during shutdown

Fixes #20