### PR TITLE
Ensure that exit code is set as part of transitioning to final object state

### DIFF
--- a/controllers/container_common.go
+++ b/controllers/container_common.go
@@ -149,7 +149,7 @@ func verifyNetworkState(
 	}
 }
 
-func stopContainer(stopContext context.Context, o containers.ContainerOrchestrator, containerID string) error {
+func stopContainer(stopContext context.Context, o containers.ContainerOrchestrator, containerID string) (*containers.InspectedContainer, error) {
 	action := func(ctx context.Context) error {
 		_, stopErr := o.StopContainers(ctx, containers.StopContainersOptions{
 			Containers:    []string{containerID},
@@ -159,8 +159,8 @@ func stopContainer(stopContext context.Context, o containers.ContainerOrchestrat
 		return stopErr
 	}
 
-	verify := func(ctx context.Context) (any, error) {
-		_, verifyErr := verifyContainerState(ctx, o, containerID, func(i *containers.InspectedContainer) error {
+	verify := func(ctx context.Context) (*containers.InspectedContainer, error) {
+		inspected, verifyErr := verifyContainerState(ctx, o, containerID, func(i *containers.InspectedContainer) error {
 			if i.Status == containers.ContainerStatusExited {
 				return nil
 			} else {
@@ -172,11 +172,10 @@ func stopContainer(stopContext context.Context, o containers.ContainerOrchestrat
 			return nil, nil // Special case: treat missing container as "stopped"
 		}
 
-		return nil, verifyErr
+		return inspected, verifyErr
 	}
 
-	_, stopErr := callWithRetryAndVerification(stopContext, defaultContainerOrchestratorBackoff(), action, verify)
-	return stopErr
+	return callWithRetryAndVerification(stopContext, defaultContainerOrchestratorBackoff(), action, verify)
 }
 
 func removeContainer(removeContext context.Context, o containers.ContainerOrchestrator, containerID string) error {

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -780,12 +780,13 @@ func ensureContainerStoppingState(
 // states (Exited, Stopped, or Dead), the method does nothing and returns no error.
 // Returns containers.ErrNotFound if the container resource was not found.
 // Returns an error if the container resource could not be stopped.
+// On success, the most recent inspected container data is returned (nil if the container is gone).
 func (r *ContainerReconciler) stopContainerIfNecessary(
 	ctx context.Context,
 	containerID containerID,
 	inspected *containers.InspectedContainer,
 	log logr.Logger,
-) error {
+) (*containers.InspectedContainer, error) {
 	needsStopping := func() bool {
 		if inspected == nil {
 			return true // Assume the container needs stopping, worst case the stop attempt will fail/time out.
@@ -801,21 +802,24 @@ func (r *ContainerReconciler) stopContainerIfNecessary(
 		if inspectErr != nil {
 			if errors.Is(inspectErr, containers.ErrNotFound) {
 				log.Info("Container resource not found, assuming it was removed... ")
-				return containers.ErrNotFound
+				return nil, containers.ErrNotFound
 			}
 		}
 	}
 
 	if needsStopping() {
 		log.V(1).Info("Calling container orchestrator to stop the existing container...")
-		stopErr := stopContainer(ctx, r.orchestrator, string(containerID))
+		stopInspected, stopErr := stopContainer(ctx, r.orchestrator, string(containerID))
 		if stopErr != nil {
 			log.Error(stopErr, "Could not stop the running container")
+			return nil, stopErr
 		}
-		return stopErr
+		if stopInspected != nil {
+			inspected = stopInspected
+		}
 	}
 
-	return nil
+	return inspected, nil
 }
 
 func (r *ContainerReconciler) removeExistingContainer(
@@ -824,7 +828,7 @@ func (r *ContainerReconciler) removeExistingContainer(
 	inspected *containers.InspectedContainer,
 	log logr.Logger,
 ) error {
-	stopErr := r.stopContainerIfNecessary(ctx, containerID, inspected, log)
+	_, stopErr := r.stopContainerIfNecessary(ctx, containerID, inspected, log)
 	if errors.Is(stopErr, containers.ErrNotFound) {
 		// Already logged (at info level) by stopExistingContainer()
 		return nil // Nothing to do
@@ -1526,11 +1530,15 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 func (r *ContainerReconciler) stopContainerFunc(container *apiv1.Container, rcd *runningContainerData, log logr.Logger) func(context.Context) {
 	return func(stopCtx context.Context) {
 		log.V(1).Info("Calling container orchestrator to stop the container...")
-		err := r.stopContainerIfNecessary(stopCtx, rcd.containerID, nil, log)
+		inspected, err := r.stopContainerIfNecessary(stopCtx, rcd.containerID, nil, log)
 		if err != nil {
 			log.Error(err, "Could not stop the running container corresponding to Container object")
 			rcd.containerState = apiv1.ContainerStateUnknown
 		} else {
+			// Capture the exit code (and other final state) from the inspected container
+			if inspected != nil {
+				rcd.updateFromInspectedContainer(inspected)
+			}
 			rcd.containerState = apiv1.ContainerStateExited
 		}
 

--- a/controllers/executable_start_result.go
+++ b/controllers/executable_start_result.go
@@ -27,6 +27,10 @@ type ExecutableStartResult struct {
 	// Run ID for the Executable
 	RunID RunID
 
+	// Exit code of the Executable process.
+	// Populated when the run completed synchronously during startup (ExeState == Finished).
+	ExitCode *int32
+
 	// Paths to captured standard output and standard error files
 	StdOutFile string
 	StdErrFile string
@@ -50,6 +54,7 @@ func NewExecutableStartResult() *ExecutableStartResult {
 		ExeState: apiv1.ExecutableStateStarting,
 		Pid:      apiv1.UnknownPID,
 		RunID:    UnknownRunID,
+		ExitCode: apiv1.UnknownExitCode,
 	}
 }
 
@@ -70,6 +75,10 @@ func (res *ExecutableStartResult) Equal(other *ExecutableStartResult) bool {
 	}
 
 	if res.RunID != other.RunID {
+		return false
+	}
+
+	if !pointers.EqualValue(res.ExitCode, other.ExitCode) {
 		return false
 	}
 
@@ -112,6 +121,9 @@ func (res *ExecutableStartResult) applyTo(ri *ExecutableRunInfo) {
 	if res.ExeState == apiv1.ExecutableStateFinished {
 		ri.FinishTimestamp = res.CompletionTimestamp
 	}
+	if res.ExeState.IsTerminal() && res.ExitCode != apiv1.UnknownExitCode {
+		ri.ExitCode = pointers.Duplicate(res.ExitCode)
+	}
 }
 
 func (res *ExecutableStartResult) IsSuccessfullyCompleted() bool {
@@ -129,6 +141,7 @@ func (res *ExecutableStartResult) Clone() *ExecutableStartResult {
 		ExeState:                  res.ExeState,
 		Pid:                       pointers.Duplicate(res.Pid),
 		RunID:                     res.RunID,
+		ExitCode:                  pointers.Duplicate(res.ExitCode),
 		StdOutFile:                res.StdOutFile,
 		StdErrFile:                res.StdErrFile,
 		CompletionTimestamp:       res.CompletionTimestamp,
@@ -163,6 +176,11 @@ func (res *ExecutableStartResult) UpdateFrom(other *ExecutableStartResult) bool 
 		updated = true
 	}
 
+	if other.ExitCode != apiv1.UnknownExitCode && !pointers.EqualValue(res.ExitCode, other.ExitCode) {
+		pointers.SetValueFrom(&res.ExitCode, other.ExitCode)
+		updated = true
+	}
+
 	if other.StdOutFile != "" && res.StdOutFile != other.StdOutFile {
 		res.StdOutFile = other.StdOutFile
 		updated = true
@@ -193,10 +211,11 @@ func (res *ExecutableStartResult) String() string {
 		return "{}"
 	}
 
-	return fmt.Sprintf("{exeState: %s, pid: %v, runID: %s, stdOutFile: %s, stdErrFile: %s, startupCompletedTimestamp: %s, startupError: %s}",
+	return fmt.Sprintf("{exeState: %s, pid: %v, runID: %s, exitCode: %s, stdOutFile: %s, stdErrFile: %s, startupCompletedTimestamp: %s, startupError: %s}",
 		res.ExeState,
 		logger.IntPtrValToString(res.Pid),
 		logger.FriendlyString(string(res.RunID)),
+		logger.IntPtrValToString(res.ExitCode),
 		logger.FriendlyString(res.StdOutFile),
 		logger.FriendlyString(res.StdErrFile),
 		logger.FriendlyMetav1Timestamp(res.CompletionTimestamp),

--- a/internal/exerunners/ide_executable_runner.go
+++ b/internal/exerunners/ide_executable_runner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/microsoft/dcp/internal/logs"
 	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/osutil"
+	"github.com/microsoft/dcp/pkg/pointers"
 	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/slices"
 	"github.com/microsoft/dcp/pkg/syncmap"
@@ -241,6 +242,7 @@ func (r *IdeExecutableRunner) doStartRun(
 		r.activeRuns.Delete(runID)
 		r.lock.Unlock()
 
+		result.ExitCode = pointers.Duplicate(rd.exitCode)
 		if rd.state == runStateFailedToStart {
 			result.ExeState = apiv1.ExecutableStateFailedToStart
 		} else {

--- a/internal/testutil/ctrlutil/test_ide_runner.go
+++ b/internal/testutil/ctrlutil/test_ide_runner.go
@@ -189,6 +189,24 @@ func (r *TestIdeRunner) SimulateRunEnd(runID controllers.RunID, exitCode int32) 
 	return r.doStopRun(runID, exitCode)
 }
 
+// SimulateSynchronousFinish reports a Finished outcome (with the given exit code) directly from
+// the IDE runner's startup attempt, mirroring the case where the IDE delivers a session
+// termination notification before the run session creation request returns.
+func (r *TestIdeRunner) SimulateSynchronousFinish(runID controllers.RunID, exitCode int32) error {
+	return r.SimulateRunStart(
+		func(_ types.NamespacedName, run *TestIdeRun) bool { return run.ID == runID },
+		func(run *TestIdeRun, result *controllers.ExecutableStartResult) {
+			run.FinishTimestamp = metav1.NowMicro()
+			pointers.SetValue(&run.ExitCode, exitCode)
+
+			result.RunID = runID
+			result.ExeState = apiv1.ExecutableStateFinished
+			pointers.SetValue(&result.ExitCode, exitCode)
+			result.CompletionTimestamp = metav1.NowMicro()
+		},
+	)
+}
+
 func (r *TestIdeRunner) FindAll(exePath string, cond func(run TestIdeRun) bool) []TestIdeRun {
 	r.m.RLock()
 	defer r.m.RUnlock()

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -933,6 +933,55 @@ func TestContainerStop(t *testing.T) {
 	require.Len(t, inspected, 0, "expected the container to be gone")
 }
 
+// Verifies that when a Container reaches the Exited state in response to Spec.Stop = true,
+// the very first observation of State == Exited already carries Status.ExitCode,
+// rather than ExitCode being populated only by a subsequent status update.
+func TestContainerStopReportsExitCode(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-stop-reports-exit-code"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image: imageName,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	_, _ = ensureContainerRunning(t, ctx, &ctr)
+
+	t.Logf("Stopping Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflict(ctx, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		containerPatch := currentCtr.DeepCopy()
+		containerPatch.Spec.Stop = true
+		return client.Patch(ctx, containerPatch, ctrl_client.MergeFromWithOptions(currentCtr, ctrl_client.MergeFromWithOptimisticLock{}))
+	})
+	require.NoError(t, err, "Container object could not be patched")
+
+	t.Log("Ensure that the first observation of State=Exited also carries ExitCode...")
+	updatedCtr := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		if c.Status.State != apiv1.ContainerStateExited {
+			return false, nil
+		}
+		if c.Status.ExitCode == apiv1.UnknownExitCode {
+			return false, fmt.Errorf("Container reached state '%s' but Status.ExitCode is not populated; the stop path should publish State and ExitCode in the same Status update", apiv1.ContainerStateExited)
+		}
+		return true, nil
+	})
+	require.NotNil(t, updatedCtr.Status.ExitCode, "Status.ExitCode must be populated alongside State=Exited")
+	require.False(t, updatedCtr.Status.FinishTimestamp.IsZero(), "Status.FinishTimestamp must be populated alongside State=Exited")
+}
+
 func TestContainerDeletion(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -220,6 +220,52 @@ func TestExecutableExitCodeCaptured(t *testing.T) {
 	}
 }
 
+// Verifies that when an IDE run completes synchronously during startup (the IDE delivers a
+// session termination notification before the run session creation request returns),
+// the resulting ExecutableStartResult carries both ExeState=Finished and ExitCode,
+// and the Executable status reaches Finished with ExitCode populated in a single update --
+// not in a follow-up update.
+func TestExecutableSynchronousIdeFinish(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const expectedEC int32 = 7
+
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "executable-ide-synchronous-finish",
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/executable-ide-synchronous-finish",
+			ExecutionType:  apiv1.ExecutionTypeIDE,
+		},
+	}
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	runID, err := findIdeRun(ctx, exe.Spec.ExecutablePath)
+	require.NoError(t, err, "IDE run session was not created for Executable")
+
+	t.Log("Simulating synchronous IDE Finished outcome (with ExitCode) during startup...")
+	require.NoError(t, ideRunner.SimulateSynchronousFinish(runID, expectedEC), "Could not simulate synchronous IDE finish")
+
+	t.Log("Ensuring that the first observation of State=Finished also carries ExitCode...")
+	updatedExe := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(e *apiv1.Executable) (bool, error) {
+		if e.Status.State != apiv1.ExecutableStateFinished {
+			return false, nil
+		}
+		if e.Status.ExitCode == apiv1.UnknownExitCode {
+			return false, fmt.Errorf("Executable reached state '%s' but Status.ExitCode is not populated; the synchronous finish path should publish State and ExitCode in the same Status update", apiv1.ExecutableStateFinished)
+		}
+		return true, nil
+	})
+	require.NotNil(t, updatedExe.Status.ExitCode, "Status.ExitCode must be populated alongside State=Finished")
+	require.Equal(t, expectedEC, *updatedExe.Status.ExitCode, "Status.ExitCode must match the simulated exit code")
+}
+
 // Ensure the run is terminated if stop is set to true
 func TestExecutableStopState(t *testing.T) {
 	type testcase struct {


### PR DESCRIPTION
The exit code is not always available, but when it is, it should be set with the same update that transitions the object to final state (atomically). 

Fixes Aspire https://github.com/microsoft/aspire/issues/16319