### PR TITLE
Fix test-ci.ps1 compatibility with PowerShell 5.1

### DIFF
--- a/scripts/test-ci.ps1
+++ b/scripts/test-ci.ps1
@@ -110,7 +110,7 @@ function Invoke-GenerateGrpc {
     Push-Location $RepoRoot
     try {
         foreach ($proto in $protoSources) {
-            $rel = Resolve-Path -Relative $proto
+            $rel = Resolve-Path -Relative -LiteralPath $proto
             Write-Host "protoc (go) $rel"
             Invoke-Native -Description "protoc-gen-go on $rel" -Script {
                 & $ProtocExe `

--- a/scripts/test-ci.ps1
+++ b/scripts/test-ci.ps1
@@ -110,7 +110,7 @@ function Invoke-GenerateGrpc {
     Push-Location $RepoRoot
     try {
         foreach ($proto in $protoSources) {
-            $rel = [System.IO.Path]::GetRelativePath($RepoRoot, $proto)
+            $rel = Resolve-Path -Relative $proto
             Write-Host "protoc (go) $rel"
             Invoke-Native -Description "protoc-gen-go on $rel" -Script {
                 & $ProtocExe `


### PR DESCRIPTION
## Problem

The \	est-ci.ps1\ script fails in Azure DevOps pipelines because it uses \[System.IO.Path]::GetRelativePath()\, a .NET Core API that is not available in Windows PowerShell 5.1. The AzDO agents run \powershell.exe\ (5.1), not \pwsh\ (7+).

## Fix

Replace \[System.IO.Path]::GetRelativePath(\, \)\ with \Resolve-Path -Relative \\, which is available in both PowerShell 5.1 and 7+. The script already sets the current directory to \\\ via \Push-Location\ before the loop, so \Resolve-Path -Relative\ produces the equivalent relative path.