### PR TITLE
Bug fixes for resource stop scenario

### DIFF
--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -307,8 +307,7 @@ func ensureExecutableStoppingState(
 	}
 
 	if !runInfo.stopAttemptInitiated {
-		log.V(1).Info("Attempting to stop the Executable...",
-			"RunID", runInfo.RunID)
+		log.V(1).Info("Attempting to stop the Executable...", "RunID", runInfo.RunID)
 		runInfo.stopAttemptInitiated = true
 		runInfo.ExeState = apiv1.ExecutableStateStopping
 		runInfoCopy := runInfo.Clone()

--- a/controllers/executable_run_info.go
+++ b/controllers/executable_run_info.go
@@ -214,6 +214,13 @@ func (ri *ExecutableRunInfo) UpdateFrom(other *ExecutableRunInfo) bool {
 		updated = true
 	}
 
+	// stopAttemptInitiated is a one-way latch: once a stop has been initiated,
+	// stale clones replayed via deferred ops must not reset it back to false.
+	if other.stopAttemptInitiated && !ri.stopAttemptInitiated {
+		ri.stopAttemptInitiated = true
+		updated = true
+	}
+
 	if other.startupStage != StartupStageInitial && ri.startupStage != other.startupStage {
 		ri.startupStage = other.startupStage
 		updated = true

--- a/controllers/running_container_data.go
+++ b/controllers/running_container_data.go
@@ -172,8 +172,10 @@ func (rcd *runningContainerData) UpdateFrom(other *runningContainerData) bool {
 		updated = true
 	}
 
-	if rcd.stopAttemptInitiated != other.stopAttemptInitiated {
-		rcd.stopAttemptInitiated = other.stopAttemptInitiated
+	// stopAttemptInitiated is a one-way latch: once a stop has been initiated,
+	// stale clones replayed via deferred ops must not reset it back to false.
+	if other.stopAttemptInitiated && !rcd.stopAttemptInitiated {
+		rcd.stopAttemptInitiated = true
 		updated = true
 	}
 

--- a/internal/exerunners/ide_executable_runner.go
+++ b/internal/exerunners/ide_executable_runner.go
@@ -281,7 +281,7 @@ func (r *IdeExecutableRunner) doStartRun(
 func (r *IdeExecutableRunner) StopRun(ctx context.Context, runID controllers.RunID, log logr.Logger) error {
 	const runSessionCouldNotBeStopped = "run session could not be stopped: "
 
-	runState, found := r.activeRuns.Load(runID)
+	rd, found := r.activeRuns.Load(runID)
 	if !found {
 		r.log.Info("Attempted to stop IDE run session which was not found", "RunID", runID)
 		return nil
@@ -301,18 +301,29 @@ func (r *IdeExecutableRunner) StopRun(ctx context.Context, runID controllers.Run
 
 	if resp.StatusCode == http.StatusOK {
 		r.log.V(1).Info("IDE run session stopped", "RunID", runID)
-		// Wrap in a function to make it easier to ensure context cancel is called
-		return func() error {
-			// Wait up to 10 seconds for the IDE to send confirmation that the run session has been terminated (and stdio closed)
-			ideExitCtx, ideExitCancel := context.WithTimeout(ctx, 10*time.Second)
-			defer ideExitCancel()
-			select {
-			case <-ideExitCtx.Done():
-				return fmt.Errorf("timeout waiting for IDE to confirm run session termination: %w", ideExitCtx.Err())
-			case <-runState.exitCh:
-				return nil
-			}
-		}()
+
+		// Wait up to 10 seconds for the IDE to send confirmation that the run session has been terminated
+		// (and that we completed our run cleanup as a result).
+
+		ideExitCtx, ideExitCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer ideExitCancel()
+
+		select {
+		case <-ideExitCtx.Done():
+			// The IDE has not send a confirmation despite reporting the run as stopped successfully.
+			// Exit code will not be available, but otherwise we can assume everything else is OK and do the cleanup.
+			r.log.V(1).Info("timeout waiting for IDE to confirm run session termination", "RunID", runID)
+			r.lock.Lock()
+			defer r.lock.Unlock()
+			r.activeRuns.Delete(runID)
+			rd.CloseOutputWriters()
+			close(rd.exitCh)
+			rd.NotifyRunCompletedAsync(r.lock)
+		case <-rd.exitCh:
+			// Run termination notification received from the IDE, everything is cleaned up by the notification handler.
+		}
+
+		return nil
 	}
 
 	if resp.StatusCode == http.StatusNoContent {

--- a/internal/exerunners/ide_executable_runner.go
+++ b/internal/exerunners/ide_executable_runner.go
@@ -310,7 +310,7 @@ func (r *IdeExecutableRunner) StopRun(ctx context.Context, runID controllers.Run
 
 		select {
 		case <-ideExitCtx.Done():
-			// The IDE has not send a confirmation despite reporting the run as stopped successfully.
+			// The IDE has not sent a confirmation despite reporting the run as stopped successfully.
 			// Exit code will not be available, but otherwise we can assume everything else is OK and do the cleanup.
 			r.log.V(1).Info("timeout waiting for IDE to confirm run session termination", "RunID", runID)
 			r.lock.Lock()

--- a/internal/testutil/ctrlutil/test_ide_runner.go
+++ b/internal/testutil/ctrlutil/test_ide_runner.go
@@ -235,7 +235,7 @@ func (r *TestIdeRunner) doStopRun(runID controllers.RunID, exitCode int32) error
 		func(run *TestIdeRun) error {
 			if !run.FinishTimestamp.IsZero() {
 				// Real IDE runners typically forget the run after it is stopped and return "not found" error
-				// for any subsequent stop attempts.
+				// for any subsequent stop attempts. We simulate the same behavior here by returning an error.
 				return fmt.Errorf("run '%s' is already finished", runID)
 			}
 

--- a/internal/testutil/ctrlutil/test_ide_runner.go
+++ b/internal/testutil/ctrlutil/test_ide_runner.go
@@ -171,7 +171,7 @@ func (r *TestIdeRunner) SimulateRunStart(
 		return nil
 	})
 	if changeErr != nil {
-		return fmt.Errorf("could not start Executable '%s': %w", run.Exe.NamespacedName().String(), changeErr)
+		return fmt.Errorf("could not start Executable: %w", changeErr)
 	}
 
 	if run.ChangeHandler != nil {

--- a/internal/testutil/ctrlutil/test_ide_runner.go
+++ b/internal/testutil/ctrlutil/test_ide_runner.go
@@ -7,11 +7,13 @@ package ctrlutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -28,6 +30,7 @@ import (
 )
 
 const AutoStartExecutableAnnotation = "test.usvc-dev.developer.microsoft.com/auto-start-executable"
+const ideRunStopProcessingTime = time.Millisecond * 500
 
 type TestIdeRun struct {
 	ID                   controllers.RunID
@@ -163,11 +166,12 @@ func (r *TestIdeRunner) SimulateRunStart(
 	// Do not take a lock here. findAndChangeRun() will take a lock internally for the duration of its working.
 
 	var result controllers.ExecutableStartResult
-	run, found := r.findAndChangeRun(isDesiredRun, func(run *TestIdeRun) {
+	run, changeErr := r.findAndChangeRun(isDesiredRun, func(run *TestIdeRun) error {
 		changeToStarted(run, &result)
+		return nil
 	})
-	if !found {
-		return fmt.Errorf("run for Executable '%s' was not found", run.Exe.NamespacedName().String())
+	if changeErr != nil {
+		return fmt.Errorf("could not start Executable '%s': %w", run.Exe.NamespacedName().String(), changeErr)
 	}
 
 	if run.ChangeHandler != nil {
@@ -226,16 +230,30 @@ func (r *TestIdeRunner) FindAll(exePath string, cond func(run TestIdeRun) bool) 
 func (r *TestIdeRunner) doStopRun(runID controllers.RunID, exitCode int32) error {
 	// Do not take a lock here. findAndChangeRun() will take a lock internally for the duration of its working.
 
-	var run, found = r.findAndChangeRun(
+	var run, stopErr = r.findAndChangeRun(
 		func(_ types.NamespacedName, run *TestIdeRun) bool { return run.ID == runID },
-		func(run *TestIdeRun) {
+		func(run *TestIdeRun) error {
+			if !run.FinishTimestamp.IsZero() {
+				// Real IDE runners typically forget the run after it is stopped and return "not found" error
+				// for any subsequent stop attempts.
+				return fmt.Errorf("run '%s' is already finished", runID)
+			}
+
+			// Simulate processing time for the stop request.
+			select {
+			case <-r.lifetimeCtx.Done():
+				return r.lifetimeCtx.Err()
+			case <-time.After(ideRunStopProcessingTime):
+				// continue
+			}
+
 			run.FinishTimestamp = metav1.NowMicro()
 			pointers.SetValue(&run.ExitCode, int32(exitCode))
+			return nil
 		},
 	)
-
-	if !found {
-		return fmt.Errorf("run '%s' was not found, cannot be stopped", runID)
+	if stopErr != nil {
+		return fmt.Errorf("run '%s' could not be stopped: %w", runID, stopErr)
 	}
 
 	if run.ChangeHandler != nil {
@@ -257,15 +275,17 @@ func (r *TestIdeRunner) doStopRun(runID controllers.RunID, exitCode int32) error
 	return nil
 }
 
-func (r *TestIdeRunner) findAndChangeRun(matches func(types.NamespacedName, *TestIdeRun) bool, change func(*TestIdeRun)) (TestIdeRun, bool) {
+func (r *TestIdeRunner) findAndChangeRun(matches func(types.NamespacedName, *TestIdeRun) bool, change func(*TestIdeRun) error) (TestIdeRun, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
 	var foundRun *TestIdeRun
+	var changeErr error
+
 	r.Runs.Range(func(_ types.NamespacedName, run *TestIdeRun) bool {
 		if matches(run.Exe.NamespacedName(), run) {
-			change(run)
 			foundRun = run
+			changeErr = change(run)
 			return false
 		}
 
@@ -273,9 +293,9 @@ func (r *TestIdeRunner) findAndChangeRun(matches func(types.NamespacedName, *Tes
 	})
 
 	if foundRun == nil {
-		return TestIdeRun{}, false
+		return TestIdeRun{}, errors.New("run was not found")
 	} else {
-		return *foundRun, true
+		return *foundRun, changeErr
 	}
 }
 


### PR DESCRIPTION
A few fixes to make resource stopping behave correctly and more robustly:

1. The Executable run info did not correctly propagate `stopAttemptInitiated` flag, causing us to issue multiple stop requests for the same resource. Fixed.
2. Ensure that once resource stop is initiated, we never "forget" about it (applies to Exacutables and Containers).
3. VS Code has a bug that causes it to not send run termination notification when a Node app is stopped (even though the app IS stopped upon request). Changed our side so that we assume the app is stopped as long as IDE returns success code from stop request.

Related to https://github.com/microsoft/aspire/issues/15426