### PR TITLE
Backport of PR 127: Fix "system" kind of resource logs

### DIFF
--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -1143,8 +1143,9 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 						isValid = isValid && !winNamedPipeRegex.MatchString(volume.Source)
 					}
 					if !isValid {
-						// This seems to be an invalid bind mount or a named pipe, so don't try to create it
-						// May be a reference to a linux mount point on Windows
+						// This seems to be an invalid bind mount or a named pipe, so don't try to create it.
+						// May be a reference to a linux mount point on Windows.
+						log.Info("Skipping creation of bind mount because the source path appears invalid on this platform", "Source", volume.Source, "Target", volume.Target)
 						continue
 					}
 

--- a/internal/apiserver/admin_http_handler_test.go
+++ b/internal/apiserver/admin_http_handler_test.go
@@ -8,6 +8,7 @@ package apiserver_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -239,7 +240,7 @@ func TestCannotChangeExecutionWhenNotAuthenticated(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultApiServerTestTimeout)
 	defer cancel()
 
-	serverInfo, startupErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, testutil.NewLogForTesting(t.Name()))
+	serverInfo, startupErr := createApiServerForHttpHandlerTests(t.Name(), ctx)
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer func() {
 		serverInfo.Dispose()
@@ -278,7 +279,7 @@ func TestCanStopApiServer(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultApiServerTestTimeout)
 	defer cancel()
 
-	serverInfo, startupErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, testutil.NewLogForTesting(t.Name()))
+	serverInfo, startupErr := createApiServerForHttpHandlerTests(t.Name(), ctx)
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer func() {
 		// Still want to call this because disposal is not limited to stopping the API server
@@ -316,7 +317,7 @@ func TestCanRunCleanupWithoutStoppingApiServer(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultApiServerTestTimeout)
 	defer cancel()
 
-	serverInfo, startupErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, testutil.NewLogForTesting(t.Name()))
+	serverInfo, startupErr := createApiServerForHttpHandlerTests(t.Name(), ctx)
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer func() {
 		// Still want to call this because disposal is not limited to stopping the API server
@@ -377,7 +378,7 @@ func TestCannotCreateNewObjectsAfterClenupStarted(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultApiServerTestTimeout)
 	defer cancel()
 
-	serverInfo, startupErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, testutil.NewLogForTesting(t.Name()))
+	serverInfo, startupErr := createApiServerForHttpHandlerTests(t.Name(), ctx)
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer func() {
 		// Still want to call this because disposal is not limited to stopping the API server
@@ -475,4 +476,16 @@ func TestCanCapturePerfTrace(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.True(t, perfTraceCaptured)
 	require.True(t, receivedPerfTraceNotification)
+}
+
+func createApiServerForHttpHandlerTests(testName string, ctx context.Context) (*ctrl_testutil.ApiServerInfo, error) {
+	sessionFolder, sessionFolderErr := testutil.CreateTestSessionDir()
+	if sessionFolderErr != nil {
+		return nil, fmt.Errorf("failed to create session folder for API server instance: %w", sessionFolderErr)
+	}
+
+	log := testutil.NewLogWithResourceSinkForTesting(testName, sessionFolder)
+
+	serverInfo, startupErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, log, sessionFolder)
+	return serverInfo, startupErr
 }

--- a/internal/dcp/commands/root.go
+++ b/internal/dcp/commands/root.go
@@ -64,7 +64,7 @@ func NewRootCmd(log *logger.Logger) (*cobra.Command, error) {
 	}
 
 	// Add dcpctrl sub-commands
-	rootCmd.AddCommand(dcpctrl_cmds.NewRunControllersCommand(log.Logger))
+	rootCmd.AddCommand(dcpctrl_cmds.NewRunControllersCommand(log))
 
 	// Add dcpproc sub-commands
 	if cmd, err = dcpproc_cmds.NewProcessCommand(log.Logger); err != nil {

--- a/internal/dcpctrl/commands/root.go
+++ b/internal/dcpctrl/commands/root.go
@@ -46,7 +46,7 @@ func NewRootCommand(log *logger.Logger) (*cobra.Command, error) {
 	}
 
 	rootCmd.AddCommand(NewGetCapabilitiesCommand(log.Logger))
-	rootCmd.AddCommand(NewRunControllersCommand(log.Logger))
+	rootCmd.AddCommand(NewRunControllersCommand(log))
 
 	ctrlruntime.SetLogger(log.V(1))
 

--- a/internal/dcpctrl/commands/run_controllers.go
+++ b/internal/dcpctrl/commands/run_controllers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/microsoft/dcp/internal/perftrace"
 	"github.com/microsoft/dcp/internal/proxy"
 	"github.com/microsoft/dcp/pkg/kubeconfig"
+	"github.com/microsoft/dcp/pkg/logger"
 	"github.com/microsoft/dcp/pkg/process"
 	"github.com/microsoft/dcp/pkg/resiliency"
 )
@@ -42,11 +43,12 @@ var (
 	shutdownPerftraceStarted atomic.Bool
 )
 
-func NewRunControllersCommand(log logr.Logger) *cobra.Command {
+func NewRunControllersCommand(log *logger.Logger) *cobra.Command {
+	controllerLog := log.WithResourceSink().Logger
 	runControllersCmd := &cobra.Command{
 		Use:   "run-controllers",
 		Short: "Runs the standard DCP controllers (for Executable, Container, and ContainerVolume objects)",
-		RunE:  runControllers(log),
+		RunE:  runControllers(controllerLog),
 		Args:  cobra.NoArgs,
 	}
 
@@ -104,6 +106,7 @@ func runControllers(log logr.Logger) func(cmd *cobra.Command, _ []string) error 
 		if err != nil {
 			log.Error(err, "failed to capture startup profile")
 		}
+		defer logger.ReleaseAllResourceLogs()
 
 		ctrlCtx, ctrlCtxCancel := cmds.GetMonitorContextFromFlags(cmd.Context(), log)
 		defer ctrlCtxCancel()

--- a/internal/logs/containerlogs/container_logstreamer.go
+++ b/internal/logs/containerlogs/container_logstreamer.go
@@ -184,7 +184,7 @@ func (c *containerLogStreamer) StreamLogs(
 
 	default:
 		// opts.Source has an unexpected value -- this should never happen, request parameter validation should have prevented this.
-		return apiv1.ResourceStreamStatusDone, nil, nil // Fail fast
+		return apiv1.ResourceStreamStatusDone, nil, apierrors.NewBadRequest(fmt.Sprintf("invalid log stream source %q", opts.Source)) // Fail fast
 	}
 
 	if logFilePath == "" {

--- a/internal/logs/containerlogs/container_logstreamer.go
+++ b/internal/logs/containerlogs/container_logstreamer.go
@@ -119,15 +119,20 @@ func (c *containerLogStreamer) StreamLogs(
 	var logFilePath string
 	cleanup := func() {}
 
-	if opts.Source == string(apiv1.LogStreamSourceStartupStdout) {
-		// Startup stdout log streaming
+	switch opts.Source {
+
+	case string(apiv1.LogStreamSourceStartupStdout):
 		logFilePath = ctr.Status.StartupStdOutFile
 		follow = follow && (ctr.Status.State == apiv1.ContainerStateStarting || ctr.Status.State == apiv1.ContainerStateBuilding)
-	} else if opts.Source == string(apiv1.LogStreamSourceStartupStderr) {
-		// Startup stderr log streaming
+
+	case string(apiv1.LogStreamSourceStartupStderr):
 		logFilePath = ctr.Status.StartupStdErrFile
 		follow = follow && (ctr.Status.State == apiv1.ContainerStateStarting || ctr.Status.State == apiv1.ContainerStateBuilding)
-	} else {
+
+	case string(apiv1.LogStreamSourceSystem):
+		logFilePath = logger.GetResourceLogPath(ctr.GetResourceId())
+
+	case "", string(apiv1.LogStreamSourceStdout), string(apiv1.LogStreamSourceStderr):
 		if ctr.Status.ContainerID == "" {
 			streamLog.V(1).Info("Container has no container ID yet, not ready to stream logs")
 			// We're not ready to start streaming logs for this container yet
@@ -139,7 +144,6 @@ func (c *containerLogStreamer) StreamLogs(
 			return apiv1.ResourceStreamStatusNotReady, nil, nil
 		}
 
-		// Standard stdout/stderr log streaming
 		hostLifetimeCtx := contextdata.GetHostLifetimeContext(ctx)
 		logDescriptorCtx, cancel := context.WithCancel(hostLifetimeCtx)
 		ld, stdOutWriter, stdErrWriter, newlyCreated, acquireErr := c.containerLogs.AcquireForResource(logDescriptorCtx, cancel, ctr.NamespacedName(), ctr.UID)
@@ -172,14 +176,15 @@ func (c *containerLogStreamer) StreamLogs(
 			// We just report not found in this case
 			return apiv1.ResourceStreamStatusNotReady, nil, apierrors.NewNotFound(ctr.GetGroupVersionResource().GroupResource(), ctr.NamespacedName().Name)
 		}
-
-		if opts.Source == string(apiv1.LogStreamSourceStdout) || opts.Source == "" {
-			logFilePath = stdOutPath
-		} else if opts.Source == string(apiv1.LogStreamSourceStderr) {
+		if opts.Source == string(apiv1.LogStreamSourceStderr) {
 			logFilePath = stdErrPath
-		} else if opts.Source == string(apiv1.LogStreamSourceSystem) {
-			logFilePath = logger.GetResourceLogPath(ctr.GetResourceId())
+		} else {
+			logFilePath = stdOutPath
 		}
+
+	default:
+		// opts.Source has an unexpected value -- this should never happen, request parameter validation should have prevented this.
+		return apiv1.ResourceStreamStatusDone, nil, nil // Fail fast
 	}
 
 	if logFilePath == "" {

--- a/internal/testutil/ctrlutil/apiserver_start.go
+++ b/internal/testutil/ctrlutil/apiserver_start.go
@@ -102,16 +102,12 @@ func StartApiServer(
 	testRunCtx context.Context,
 	flags ApiServerFlag,
 	log logr.Logger,
+	sessionFolder string,
 ) (*ApiServerInfo, error) {
 	info := ApiServerInfo{
 		lock:                      &sync.Mutex{},
 		ApiServerExited:           concurrency.NewAutoResetEvent(false),
 		ApiServerDisposalComplete: concurrency.NewAutoResetEvent(false),
-	}
-
-	sessionFolder, sessionFolderErr := testutil.CreateTestSessionDir()
-	if sessionFolderErr != nil {
-		return nil, fmt.Errorf("failed to create session folder for API server instance: %w", sessionFolderErr)
 	}
 
 	cleanup := func() {

--- a/internal/testutil/ctrlutil/apiserver_start.go
+++ b/internal/testutil/ctrlutil/apiserver_start.go
@@ -154,11 +154,13 @@ func StartApiServer(
 
 	dcpPath, dcpPathErr := getDcpExecutablePath()
 	if dcpPathErr != nil {
+		cleanup()
 		return nil, fmt.Errorf("failed to find the DCP executable: %w", dcpPathErr)
 	}
 
 	suffix, randErr := randdata.MakeRandomString(8)
 	if randErr != nil {
+		cleanup()
 		return nil, fmt.Errorf("failed to generate random string for kubeconfig file suffix: %w", randErr)
 	}
 	info.kubeconfigPath = filepath.Join(testutil.TestTempDir(), fmt.Sprintf("kubeconfig-test-%s", suffix))

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -135,7 +135,11 @@ func (l *Logger) WithName(name string) *Logger {
 }
 
 func (l *Logger) WithResourceSink() *Logger {
-	resourceSink := newResourceSink(l.atomicLevel, l.Logger.GetSink())
+	return l.WithResourceSinkInto("") // Use standard resource log path (session folder or temp dir)
+}
+
+func (l *Logger) WithResourceSinkInto(resourceLogFolder string) *Logger {
+	resourceSink := newResourceSink(l.atomicLevel, l.Logger.GetSink(), resourceLogFolder)
 	l.Logger = l.Logger.WithSink(resourceSink)
 	flushInner := l.flush
 	l.flush = func() {

--- a/pkg/logger/resource_sink.go
+++ b/pkg/logger/resource_sink.go
@@ -98,19 +98,19 @@ func ReleaseAllResourceLogs() {
 }
 
 type resourceSink struct {
-	resourceName             string
-	resourceId               string
-	values                   []any
-	atomicLevel              zap.AtomicLevel
-	innerSink                logr.LogSink
-	resouceLogFolderOverride string
+	resourceName              string
+	resourceId                string
+	values                    []any
+	atomicLevel               zap.AtomicLevel
+	innerSink                 logr.LogSink
+	resourceLogFolderOverride string
 }
 
 func newResourceSink(atomicLevel zap.AtomicLevel, innerSink logr.LogSink, resourceLogFolderOverride string) *resourceSink {
 	sink := &resourceSink{
-		atomicLevel:              zap.NewAtomicLevel(),
-		innerSink:                innerSink,
-		resouceLogFolderOverride: resourceLogFolderOverride,
+		atomicLevel:               zap.NewAtomicLevel(),
+		innerSink:                 innerSink,
+		resourceLogFolderOverride: resourceLogFolderOverride,
 	}
 	sink.atomicLevel.SetLevel(atomicLevel.Level())
 
@@ -165,12 +165,12 @@ func (s *resourceSink) WithName(name string) logr.LogSink {
 	}
 
 	newSink := &resourceSink{
-		resourceName:             name,
-		resourceId:               s.resourceId,
-		values:                   s.values,
-		atomicLevel:              zap.NewAtomicLevel(),
-		innerSink:                s.innerSink.WithName(name),
-		resouceLogFolderOverride: s.resouceLogFolderOverride,
+		resourceName:              name,
+		resourceId:                s.resourceId,
+		values:                    s.values,
+		atomicLevel:               zap.NewAtomicLevel(),
+		innerSink:                 s.innerSink.WithName(name),
+		resourceLogFolderOverride: s.resourceLogFolderOverride,
 	}
 	newSink.atomicLevel.SetLevel(s.atomicLevel.Level())
 
@@ -188,11 +188,11 @@ func (s *resourceSink) WithValues(keysAndValues ...any) logr.LogSink {
 	}
 
 	newSink := resourceSink{
-		resourceName:             s.resourceName,
-		resourceId:               resourceId,
-		atomicLevel:              zap.NewAtomicLevel(),
-		innerSink:                s.innerSink.WithValues(keysAndValues...),
-		resouceLogFolderOverride: s.resouceLogFolderOverride,
+		resourceName:              s.resourceName,
+		resourceId:                resourceId,
+		atomicLevel:               zap.NewAtomicLevel(),
+		innerSink:                 s.innerSink.WithValues(keysAndValues...),
+		resourceLogFolderOverride: s.resourceLogFolderOverride,
 	}
 	newSink.atomicLevel.SetLevel(s.atomicLevel.Level())
 	values := stdslices.Clone(s.values)
@@ -251,7 +251,7 @@ func (s *resourceSink) getSink(resourceId string) *resourceFileSink {
 }
 
 func (s *resourceSink) newResourceFileSink(resourceId string) (*resourceFileSink, error) {
-	resourceLogPath := makeResourceLogPath(resourceId, s.resouceLogFolderOverride)
+	resourceLogPath := makeResourceLogPath(resourceId, s.resourceLogFolderOverride)
 	file, err := usvc_io.OpenFile(resourceLogPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, osutil.PermissionOnlyOwnerReadWrite)
 	if err != nil {
 		return nil, err

--- a/pkg/logger/resource_sink.go
+++ b/pkg/logger/resource_sink.go
@@ -26,7 +26,7 @@ const (
 	// This values acts as a special key for any logger that has a resource sink enabled. If the first argument to WithValues is this key, the second argument
 	// will be treated as a resource log stream ID. In this case neither of the first two arguments will be included in the final log entries, but the resource
 	// sink will track the resource ID value and use it to route a copy of log entries to a separate log file named based on the resource ID (i.e. resource-<resource_id>.log).
-	// This log file will contain only the log entries partaining to that specific resource ID, allowing system logs pertaining to a given resource to be retrieved in isolation.
+	// This log file will contain only the log entries pertaining to that specific resource ID, allowing system logs pertaining to a given resource to be retrieved in isolation.
 	RESOURCE_LOG_STREAM_ID = "resource_log_stream_id"
 )
 

--- a/pkg/logger/resource_sink.go
+++ b/pkg/logger/resource_sink.go
@@ -44,11 +44,19 @@ type resourceFileSink struct {
 }
 
 func GetResourceLogPath(resourceId string) string {
+	return makeResourceLogPath(resourceId, tempDir)
+}
+
+func makeResourceLogPath(resourceId string, dir string) string {
 	if resourceId == "" {
 		return ""
 	}
 
-	return filepath.Join(tempDir, fmt.Sprintf("resource-%s.log", resourceId))
+	if dir == "" {
+		dir = tempDir
+	}
+
+	return filepath.Join(dir, fmt.Sprintf("resource-%s.log", resourceId))
 }
 
 func ReleaseResourceLog(resourceId string) {
@@ -90,17 +98,19 @@ func ReleaseAllResourceLogs() {
 }
 
 type resourceSink struct {
-	resourceName string
-	resourceId   string
-	values       []any
-	atomicLevel  zap.AtomicLevel
-	innerSink    logr.LogSink
+	resourceName             string
+	resourceId               string
+	values                   []any
+	atomicLevel              zap.AtomicLevel
+	innerSink                logr.LogSink
+	resouceLogFolderOverride string
 }
 
-func newResourceSink(atomicLevel zap.AtomicLevel, innerSink logr.LogSink) *resourceSink {
+func newResourceSink(atomicLevel zap.AtomicLevel, innerSink logr.LogSink, resourceLogFolderOverride string) *resourceSink {
 	sink := &resourceSink{
-		atomicLevel: zap.NewAtomicLevel(),
-		innerSink:   innerSink,
+		atomicLevel:              zap.NewAtomicLevel(),
+		innerSink:                innerSink,
+		resouceLogFolderOverride: resourceLogFolderOverride,
 	}
 	sink.atomicLevel.SetLevel(atomicLevel.Level())
 
@@ -155,11 +165,12 @@ func (s *resourceSink) WithName(name string) logr.LogSink {
 	}
 
 	newSink := &resourceSink{
-		resourceName: name,
-		resourceId:   s.resourceId,
-		values:       s.values,
-		atomicLevel:  zap.NewAtomicLevel(),
-		innerSink:    s.innerSink.WithName(name),
+		resourceName:             name,
+		resourceId:               s.resourceId,
+		values:                   s.values,
+		atomicLevel:              zap.NewAtomicLevel(),
+		innerSink:                s.innerSink.WithName(name),
+		resouceLogFolderOverride: s.resouceLogFolderOverride,
 	}
 	newSink.atomicLevel.SetLevel(s.atomicLevel.Level())
 
@@ -177,10 +188,11 @@ func (s *resourceSink) WithValues(keysAndValues ...any) logr.LogSink {
 	}
 
 	newSink := resourceSink{
-		resourceName: s.resourceName,
-		resourceId:   resourceId,
-		atomicLevel:  zap.NewAtomicLevel(),
-		innerSink:    s.innerSink.WithValues(keysAndValues...),
+		resourceName:             s.resourceName,
+		resourceId:               resourceId,
+		atomicLevel:              zap.NewAtomicLevel(),
+		innerSink:                s.innerSink.WithValues(keysAndValues...),
+		resouceLogFolderOverride: s.resouceLogFolderOverride,
 	}
 	newSink.atomicLevel.SetLevel(s.atomicLevel.Level())
 	values := stdslices.Clone(s.values)
@@ -239,7 +251,8 @@ func (s *resourceSink) getSink(resourceId string) *resourceFileSink {
 }
 
 func (s *resourceSink) newResourceFileSink(resourceId string) (*resourceFileSink, error) {
-	file, err := usvc_io.OpenFile(GetResourceLogPath(resourceId), os.O_RDWR|os.O_CREATE|os.O_APPEND, osutil.PermissionOnlyOwnerReadWrite)
+	resourceLogPath := makeResourceLogPath(resourceId, s.resouceLogFolderOverride)
+	file, err := usvc_io.OpenFile(resourceLogPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, osutil.PermissionOnlyOwnerReadWrite)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutil/logger.go
+++ b/pkg/testutil/logger.go
@@ -16,7 +16,17 @@ import (
 )
 
 func NewLogForTesting(name string) logr.Logger {
-	log := logger.New(name).WithResourceSink()
+	log := makeTestLogger(name)
+	return log.Logger
+}
+
+func NewLogWithResourceSinkForTesting(name string, resourceLogFolder string) logr.Logger {
+	log := makeTestLogger(name).WithResourceSinkInto(resourceLogFolder)
+	return log.Logger
+}
+
+func makeTestLogger(name string) *logger.Logger {
+	log := logger.New(name)
 	log.SetLevel(zapcore.ErrorLevel)
 	if !flag.Parsed() {
 		flag.Parse() // Needed to test if verbose flag was present.
@@ -24,6 +34,6 @@ func NewLogForTesting(name string) logr.Logger {
 	if testing.Verbose() {
 		log.SetLevel(zapcore.DebugLevel)
 	}
-	retval := log.Logger.WithValues("test", true)
-	return retval
+	log.WithValues("test", true)
+	return log
 }

--- a/pkg/testutil/logger.go
+++ b/pkg/testutil/logger.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewLogForTesting(name string) logr.Logger {
-	log := logger.New(name)
+	log := logger.New(name).WithResourceSink()
 	log.SetLevel(zapcore.ErrorLevel)
 	if !flag.Parsed() {
 		flag.Parse() // Needed to test if verbose flag was present.

--- a/pkg/testutil/logger.go
+++ b/pkg/testutil/logger.go
@@ -34,6 +34,6 @@ func makeTestLogger(name string) *logger.Logger {
 	if testing.Verbose() {
 		log.SetLevel(zapcore.DebugLevel)
 	}
-	log.WithValues("test", true)
+	log.Logger = log.Logger.WithValues("test", true)
 	return log
 }

--- a/test/integration/advanced_test_env.go
+++ b/test/integration/advanced_test_env.go
@@ -21,12 +21,14 @@ import (
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
 	"github.com/microsoft/dcp/pkg/concurrency"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/testutil"
 )
 
 // AdvancedTestEnvironmentInfo provides information about the test environment created via StartAdvancedTestEnvironment().
 type AdvancedTestEnvironmentInfo struct {
 	ProcessExecutor process.Executor
 	*ctrl_testutil.TestProcessExecutableRunner
+	Log logr.Logger
 }
 
 // Starts an test environment for advanced tests that use real process executor and true container orchestrator (Docker or Podman).
@@ -36,13 +38,20 @@ func StartAdvancedTestEnvironment(
 	inclCtrl IncludedController,
 	instanceTag string,
 	testTempDir string,
-	log logr.Logger,
 ) (
 	*ctrl_testutil.ApiServerInfo,
 	*AdvancedTestEnvironmentInfo,
 	error,
 ) {
-	serverInfo, serverErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerUseTrueContainerOrchestrator, log)
+	sessionFolder, sessionFolderErr := testutil.CreateTestSessionDir()
+	if sessionFolderErr != nil {
+		return nil, nil, fmt.Errorf("failed to create session folder for API server instance: %w", sessionFolderErr)
+	}
+
+	log := testutil.NewLogWithResourceSinkForTesting(instanceTag, sessionFolder)
+	ctrl.SetLogger(log)
+
+	serverInfo, serverErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerUseTrueContainerOrchestrator, log, sessionFolder)
 	if serverErr != nil {
 		return nil, nil, fmt.Errorf("failed to start the API server: %w", serverErr)
 	}
@@ -217,6 +226,7 @@ func StartAdvancedTestEnvironment(
 	teInfo := &AdvancedTestEnvironmentInfo{
 		ProcessExecutor:             pe,
 		TestProcessExecutableRunner: exeRunner,
+		Log:                         log,
 	}
 	return serverInfo, teInfo, nil
 }

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -288,12 +288,10 @@ func TestContainerRuntimeUnhealthy(t *testing.T) {
 	const testName = "container-runtime-unhealthy"
 	const imageName = testName + "-image"
 
-	log := testutil.NewLogForTesting(t.Name())
-
 	// We are going to use a separate instance of the API server because we need to simulate container runtime being unhealthy,
 	// and that might interfere with other tests if we used the shared container orchestrator.
 
-	serverInfo, _, startupErr := StartTestEnvironment(ctx, ContainerController, t.Name(), NoSeparateWorkingDir, log)
+	serverInfo, _, startupErr := StartTestEnvironment(ctx, ContainerController, t.Name(), NoSeparateWorkingDir)
 	require.NoError(t, startupErr, "Failed to start the API server")
 
 	defer func() {
@@ -2478,6 +2476,50 @@ func TestContainerLogsFollowStreamEndsOnDelete(t *testing.T) {
 	if scanner.Err() != nil {
 		require.ErrorContains(t, scanner.Err(), "response body closed", "The log stream for Container '%s' was not closed as expected")
 	}
+}
+
+// Verify that system logs (source=system) are available for a Container that fails to start.
+func TestContainerSystemLogsOnStartupFailure(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-system-logs-startup-failure"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image: imageName,
+		},
+	}
+
+	// Cause the orchestrator to fail to create the container
+	errMsg := fmt.Sprintf("Simulating container '%s' startup failure for system log test", testName)
+	containerOrchestrator.FailMatchingContainers(ctx, testName, 1, errMsg)
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Log("Waiting for container to reach 'failed to start' state...")
+	updatedCtr := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.State == apiv1.ContainerStateFailedToStart, nil
+	})
+
+	t.Log("Verifying system logs are available for the failed Container...")
+	opts := apiv1.LogOptions{
+		Follow: false,
+		Source: string(apiv1.LogStreamSourceSystem),
+	}
+	expectedLines := [][]byte{
+		[]byte(errMsg),
+	}
+	logsErr := waitForObjectLogs(ctx, updatedCtr, opts, expectedLines, nil)
+	require.NoError(t, logsErr, "System logs should be available for Container '%s' that failed to start", ctr.ObjectMeta.Name)
 }
 
 // Ensure that the Container health status changes according to its state (no health probes).

--- a/test/integration/container_network_tunnel_proxy_test.go
+++ b/test/integration/container_network_tunnel_proxy_test.go
@@ -52,12 +52,11 @@ func TestTunnelProxyCreateDelete(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-create-delete"
-	log := testutil.NewLogForTesting(t.Name())
 
 	// Use dedicated test environment because otherwise it is difficult to differentiate
 	// between different server proxy processes running in parallel tests.
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -120,10 +119,9 @@ func TestTunnelProxyDelayedNetworkCreation(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-delayed-network-creation"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -184,10 +182,9 @@ func TestTunnelProxyRunningStatus(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-running-status"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -281,10 +278,9 @@ func TestTunnelProxyCleanup(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-cleanup"
-	log := testutil.NewLogForTesting(t.Name())
 
 	controllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, controllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, controllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -376,10 +372,9 @@ func TestTunnelProxyTunnelCreate(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-tunnel-management"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := NetworkController | ContainerNetworkTunnelProxyController | ServiceController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -436,10 +431,9 @@ func TestTunnelProxyTunnelFailure(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-tunnel-failure"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := NetworkController | ContainerNetworkTunnelProxyController | ServiceController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -498,10 +492,9 @@ func TestTunnelProxyServerServiceTransition(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-server-service-transition"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := NetworkController | ContainerNetworkTunnelProxyController | ServiceController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -609,10 +602,9 @@ func TestTunnelProxyMultipleTunnels(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-multiple-tunnels"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := NetworkController | ContainerNetworkTunnelProxyController | ServiceController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -696,10 +688,9 @@ func TestTunnelProxyClientProxyAliases(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-client-proxy-aliases"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -762,10 +753,9 @@ func TestTunnelProxyServerStartupFailure(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-server-startup-failure"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -839,10 +829,9 @@ func TestTunnelProxyClientContainerStartupFailure(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-client-container-startup-failure"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, _, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, _, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -903,10 +892,9 @@ func TestTunnelProxyServerUnexpectedExit(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-server-unexpected-exit"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -998,10 +986,9 @@ func TestTunnelProxyClientUnexpectedExit(t *testing.T) {
 	defer cancel()
 	dcppaths.EnableTestPathProbing()
 	const testName = "test-tunnel-proxy-client-unexpected-exit"
-	log := testutil.NewLogForTesting(t.Name())
 
 	includedControllers := ServiceController | NetworkController | ContainerNetworkTunnelProxyController
-	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartTestEnvironment(ctx, includedControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	defer shutdownTestEnvironment(serverInfo, cancel)
 
@@ -1111,10 +1098,9 @@ func TestTunnelProxyWithRealOrchestrator(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, testTimeout)
 	defer cancel()
 	const testName = "test-tunnel-proxy-with-real-orchestrator"
-	log := testutil.NewLogForTesting(t.Name())
 	dcppaths.EnableTestPathProbing()
 
-	serverInfo, teInfo, startupErr := StartAdvancedTestEnvironment(ctx, AllControllers, t.Name(), t.TempDir(), log)
+	serverInfo, teInfo, startupErr := StartAdvancedTestEnvironment(ctx, AllControllers, t.Name(), t.TempDir())
 	require.NoError(t, startupErr, "Failed to start the API server")
 	t.Logf("API server started with PID %d", serverInfo.ApiServerPID)
 	defer teInfo.ProcessExecutor.Dispose()

--- a/test/integration/controllers_common_test.go
+++ b/test/integration/controllers_common_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgorest "k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
@@ -38,7 +37,6 @@ import (
 	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/slices"
-	"github.com/microsoft/dcp/pkg/testutil"
 )
 
 var (
@@ -53,24 +51,22 @@ var (
 const pollImmediately = true // Don't wait before polling for the first time
 
 func TestMain(m *testing.M) {
-	log := testutil.NewLogForTesting("IntegrationTests")
-	ctrl.SetLogger(log)
-
-	networking.EnableStrictMruPortHandling(log)
-
 	ctx, cancel := context.WithCancel(context.Background())
 
-	serverInfo, teInfo, envStartErr := StartTestEnvironment(ctx, AllControllers, "IntegrationTests", "", log)
+	serverInfo, teInfo, envStartErr := StartTestEnvironment(ctx, AllControllers, "IntegrationTests", "")
 	if envStartErr != nil {
 		cancel()
 		panic(envStartErr)
 	}
+	log := teInfo.Log
 	client = serverInfo.Client
 	restClient = serverInfo.RestClient
 	containerOrchestrator = serverInfo.ContainerOrchestrator.(*ctrl_testutil.TestContainerOrchestrator)
 	testProcessExecutor = teInfo.TestProcessExecutor
 	testProcessExecutableRunner = teInfo.TestProcessExecutableRunner
 	ideRunner = teInfo.TestIdeRunner
+
+	networking.EnableStrictMruPortHandling(log)
 
 	var code int = 0
 	defer func() {

--- a/test/integration/controllers_common_test.go
+++ b/test/integration/controllers_common_test.go
@@ -189,17 +189,22 @@ func waitForObjectLogs[T commonapi.ObjectStruct, PT commonapi.PObjectStruct[T]](
 			return false, nil // Not enough data yet
 		}
 
-		var matchErr error
-		allLinesMatch := std_slices.EqualFunc(receivedLines[len(receivedLines)-len(expectedLines):], expectedLines, func(read, pattern []byte) bool {
-			var matched bool
-			matched, matchErr = regexp.Match(string(pattern), read)
-			return matched
-		})
-		if matchErr != nil {
-			return false, fmt.Errorf("error occurred while matching logs: %w", matchErr)
+		for i := 0; i <= len(receivedLines)-len(expectedLines); i++ {
+			var matchErr error
+			allLinesMatch := std_slices.EqualFunc(receivedLines[i:i+len(expectedLines)], expectedLines, func(read, pattern []byte) bool {
+				var matched bool
+				matched, matchErr = regexp.Match(string(pattern), read)
+				return matched
+			})
+			if matchErr != nil {
+				return false, fmt.Errorf("error occurred while matching logs: %w", matchErr)
+			}
+			if allLinesMatch {
+				return true, nil
+			}
 		}
 
-		return allLinesMatch, nil
+		return false, nil
 	}
 
 	if opts.Follow {

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -8,6 +8,7 @@ package integration_test
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -2728,6 +2729,60 @@ func TestExecutableLogsTimestampedNumbered(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// Verify that system logs (source=system) are available for an Executable that fails to start.
+func TestExecutableSystemLogsOnStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	exeName := "executable-system-logs-startup-failure"
+
+	exe := &apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      exeName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + exeName,
+		},
+	}
+
+	t.Logf("Preparing run for Executable '%s'... (should fail)", exeName)
+	errMsg := fmt.Sprintf("simulated startup failure for Executable '%s'", exeName)
+	testProcessExecutor.InstallAutoExecution(internal_testutil.AutoExecution{
+		Condition: internal_testutil.ProcessSearchCriteria{
+			Command: []string{exe.Spec.ExecutablePath},
+		},
+		StartupError: func(_ *internal_testutil.ProcessExecution) error {
+			return errors.New(errMsg)
+		},
+	})
+	defer testProcessExecutor.RemoveAutoExecution(internal_testutil.ProcessSearchCriteria{
+		Command: []string{exe.Spec.ExecutablePath},
+	})
+
+	t.Logf("Creating Executable '%s'", exeName)
+	createErr := client.Create(ctx, exe)
+	require.NoError(t, createErr, "Could not create Executable '%s'", exeName)
+
+	t.Logf("Waiting for Executable '%s' to end up in 'failed to start' state...", exeName)
+	updatedExe := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateFailedToStart, nil
+	})
+
+	t.Logf("Verifying system logs are available for the failed Executable '%s'...", exeName)
+	opts := apiv1.LogOptions{
+		Follow: false,
+		Source: string(apiv1.LogStreamSourceSystem),
+	}
+	expectedLines := [][]byte{
+		[]byte(errMsg),
+	}
+	logsErr := waitForObjectLogs(ctx, updatedExe, opts, expectedLines, nil)
+	require.NoError(t, logsErr, "System logs should be available for Executable '%s' that failed to start", exeName)
 }
 
 // Verify that logs in follow mode end when Executable is deleted

--- a/test/integration/standard_test_env.go
+++ b/test/integration/standard_test_env.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microsoft/dcp/internal/testutil/ctrlutil"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
 	"github.com/microsoft/dcp/pkg/concurrency"
+	"github.com/microsoft/dcp/pkg/testutil"
 )
 
 // TestEnvironmentInfo provides information about the test environment created via StartTestEnvironment().
@@ -33,6 +34,7 @@ type TestEnvironmentInfo struct {
 	*ctrl_testutil.TestProcessExecutableRunner
 	*ctrl_testutil.TestIdeRunner
 	*ctrl_testutil.TestTunnelControlClient
+	Log logr.Logger
 }
 
 // Starts the DCP API server (separate process) and standard controllers (in-proc).
@@ -41,13 +43,20 @@ func StartTestEnvironment(
 	inclCtrl IncludedController,
 	instanceTag string,
 	testTempDir string,
-	log logr.Logger,
 ) (
 	*ctrl_testutil.ApiServerInfo,
 	*TestEnvironmentInfo,
 	error,
 ) {
-	serverInfo, serverErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, log)
+	sessionFolder, sessionFolderErr := testutil.CreateTestSessionDir()
+	if sessionFolderErr != nil {
+		return nil, nil, fmt.Errorf("failed to create session folder for API server instance: %w", sessionFolderErr)
+	}
+
+	log := testutil.NewLogWithResourceSinkForTesting(instanceTag, sessionFolder)
+	ctrl.SetLogger(log)
+
+	serverInfo, serverErr := ctrl_testutil.StartApiServer(ctx, ctrl_testutil.ApiServerFlagsNone, log, sessionFolder)
 	if serverErr != nil {
 		return nil, nil, fmt.Errorf("failed to start the API server: %w", serverErr)
 	}
@@ -247,6 +256,7 @@ func StartTestEnvironment(
 		TestProcessExecutableRunner: exeRunner,
 		TestIdeRunner:               ir,
 		TestTunnelControlClient:     tcc,
+		Log:                         log,
 	}
 	return serverInfo, teInfo, nil
 }

--- a/test/integration/volume_controller_test.go
+++ b/test/integration/volume_controller_test.go
@@ -189,9 +189,8 @@ func TestContainerVolumeCleanup(t *testing.T) {
 	const testName = "container-volume-cleanup"
 
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
-	log := testutil.NewLogForTesting(t.Name())
 
-	serverInfo, _, startupErr := StartTestEnvironment(ctx, VolumeController, t.Name(), NoSeparateWorkingDir, log)
+	serverInfo, _, startupErr := StartTestEnvironment(ctx, VolumeController, t.Name(), NoSeparateWorkingDir)
 	require.NoError(t, startupErr, "Failed to start the API server")
 
 	defer func() {
@@ -283,12 +282,11 @@ func TestContainerVolumeRuntimeUnhealthy(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
 	const testName = "container-volume-runtime-unhealthy"
-	log := testutil.NewLogForTesting(t.Name())
 
 	// We are going to use a separate instance of the API server because we need to simulate container runtime being unhealthy,
 	// and that might interfere with other tests if we used the shared container orchestrator.
 
-	serverInfo, _, startupErr := StartTestEnvironment(ctx, VolumeController, t.Name(), NoSeparateWorkingDir, log)
+	serverInfo, _, startupErr := StartTestEnvironment(ctx, VolumeController, t.Name(), NoSeparateWorkingDir)
 	require.NoError(t, startupErr, "Failed to start the API server")
 
 	defer func() {


### PR DESCRIPTION
For some reason (yesterday's GH snafu?) GH insisted on backporting https://github.com/microsoft/dcp/pull/127 manually.

@danegsta in your original review automated tests were not there. I added them, but as part of that I also needed to do some gymnastics with test environments, loggers and session folders to make sure that both sides (controllers/test process and the API server process) agree on where the logs are and that the session folder cleanup logic does not interfere with other tests. It is all not too complicated at the end, but a lot of additional files were touched as a result.