### PR TITLE
Improve error reporting related to container tunnel

### DIFF
--- a/api/v1/container_network_tunnel_proxy_types.go
+++ b/api/v1/container_network_tunnel_proxy_types.go
@@ -205,6 +205,9 @@ type ContainerNetworkTunnelProxyStatus struct {
 
 	// Server proxy control port (for controlling the proxy pair).
 	ServerProxyControlPort int32 `json:"serverProxyControlPort,omitempty"`
+
+	// A human-readable message that provides additional information about ContainerNetworkTunnelProxy state.
+	Message string `json:"message,omitempty"`
 }
 
 func (s ContainerNetworkTunnelProxyStatus) CopyTo(dest apiserver_resource.ObjectWithStatusSubResource) {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -8,7 +8,6 @@ package v1
 
 import (
 	"io/fs"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -1477,7 +1477,11 @@ func (r *ContainerNetworkTunnelProxyReconciler) onServerProcessExit(
 		pd.ServerProxyProcessID = nil
 		pd.ServerProxyStartupTimestamp = metav1.MicroTime{} // Zero value
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
-		pd.Message = fmt.Sprintf("Server proxy process '%d' exited unexpectedly with exit code %d: %v", pid, exitCode, err)
+		message := fmt.Sprintf("Server proxy process '%d' exited unexpectedly with exit code %d", pid, exitCode)
+		if err != nil {
+			message = fmt.Sprintf("Server proxy process '%d' exited unexpectedly with exit code %d: %v", pid, exitCode, err)
+		}
+		pd.Message = message
 		pdMap.Update(pName, pName, pd)
 	})
 	r.ScheduleReconciliation(pName)

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -875,7 +875,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) ensureContainerProxyImage(
 				return
 			}
 
-			log.Error(imageCheckErr, "Container image for container netwwork tunnel could not be built, or its presence could not be verified")
+			log.Error(imageCheckErr, "Container image for container network tunnel could not be built, or its presence could not be verified")
 			pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
 			pd.Message = fmt.Sprintf("Container image for container network tunnel could not be built, or its presence could not be verified: %v", imageCheckErr)
 		} else {

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -875,8 +875,9 @@ func (r *ContainerNetworkTunnelProxyReconciler) ensureContainerProxyImage(
 				return
 			}
 
-			log.Error(imageCheckErr, "Container image check for container network tunnel could not be queued")
+			log.Error(imageCheckErr, "Container image for container netwwork tunnel could not be built, or its presence could not be verified")
 			pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+			pd.Message = fmt.Sprintf("Container image for container network tunnel could not be built, or its presence could not be verified: %v", imageCheckErr)
 		} else {
 			log.V(1).Info("Container image check for container network tunnel completed successfully", "Image", image)
 			pd.State = apiv1.ContainerNetworkTunnelProxyStateStarting
@@ -908,6 +909,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startProxyPair(
 		if certErr != nil {
 			log.Error(certErr, "Failed to create tunnel proxy connection certificates")
 			pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+			pd.Message = fmt.Sprintf("Failed to create tunnel proxy connection certificates: %v", certErr)
 		} else {
 			var clientCtrCreated bool
 			clientCtrCreated, reconciliationDelay = r.startClientProxy(ctx, tunnelProxy, pd, log)
@@ -949,6 +951,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) createProxyConnectionCertificate
 	if secConfErr != nil {
 		log.Error(secConfErr, "Failed to create security configuration for tunnel proxy connection")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to create tunnel proxy connection certificates: %v", secConfErr)
 		return secConfErr
 	}
 
@@ -1064,6 +1067,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if createErr != nil {
 		log.Error(createErr, "Failed to create client proxy container")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to create client proxy container: %v", createErr)
 		return false, NoDelay
 	}
 
@@ -1088,6 +1092,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if disconnectErr != nil {
 		log.Error(disconnectErr, "Failed to disconnect client proxy container from default network")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to disconnect client proxy container from default network: %v", disconnectErr)
 		return false, NoDelay
 	}
 
@@ -1146,6 +1151,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if connectionWaitErr != nil {
 		log.Error(connectionWaitErr, "Error waiting for client proxy container to be connected to target network")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Client proxy container '%s' (id: %s) failed to connect to target network '%s': %v", created.Name, created.Id, containerNetworkName.String(), connectionWaitErr)
 		return false, NoDelay
 	}
 
@@ -1159,6 +1165,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if startErr != nil {
 		log.Error(startErr, "Failed to start client proxy container")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to start client proxy container '%s' (id: %s): %v", created.Name, created.Id, startErr)
 		return false, NoDelay
 	}
 
@@ -1166,6 +1173,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if controlEndpointErr != nil {
 		log.Error(controlEndpointErr, "Failed to determine control connection host port for the client proxy container")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to determine control connection host port for the client proxy container '%s' (id: %s): %v", created.Name, created.Id, controlEndpointErr)
 		return false, NoDelay
 	}
 
@@ -1173,6 +1181,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	if dataEndpointErr != nil {
 		log.Error(dataEndpointErr, "Failed to determine data connection host port for the client proxy container")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to determine data connection host port for the client proxy container '%s' (id: %s): %v", created.Name, created.Id, dataEndpointErr)
 		return false, NoDelay
 	}
 
@@ -1199,6 +1208,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 	if dcpExePathErr != nil {
 		log.Error(dcpExePathErr, "Failed to get DCP executable path")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to get DCP executable path: %v", dcpExePathErr)
 		return false
 	}
 
@@ -1224,6 +1234,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 		startFailed = true
 		log.Error(stdoutErr, "Failed to create stdout temp file for container tunnel server proxy")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to create stdout temp file for container tunnel server proxy: %v", stdoutErr)
 		return false
 	} else {
 		pd.ServerProxyStdOutFile = stdoutFile.Name()
@@ -1235,6 +1246,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 		startFailed = true
 		log.Error(stderrErr, "Failed to create stderr temp file for container tunnel server proxy")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to create stderr temp file for container tunnel server proxy: %v", stderrErr)
 		return false
 	} else {
 		pd.ServerProxyStdErrFile = stderrFile.Name()
@@ -1264,6 +1276,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 		log.Error(startErr, "Failed to start server proxy process")
 		startFailed = true
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Failed to start server proxy process: %v", startErr)
 		return false
 	}
 	startWaitForExit()
@@ -1464,6 +1477,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) onServerProcessExit(
 		pd.ServerProxyProcessID = nil
 		pd.ServerProxyStartupTimestamp = metav1.MicroTime{} // Zero value
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+		pd.Message = fmt.Sprintf("Server proxy process '%d' exited unexpectedly with exit code %d: %v", pid, exitCode, err)
 		pdMap.Update(pName, pName, pd)
 	})
 	r.ScheduleReconciliation(pName)
@@ -1486,6 +1500,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) processContainerEvent(em contain
 				pdMap.QueueDeferredOp(pName, func(types.NamespacedName, types.NamespacedName, *apiv1.ContainerNetworkTunnelProxy) {
 					_, pd = pdMap.BorrowByNamespacedName(pName)
 					pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
+					pd.Message = fmt.Sprintf("Client proxy container (id: %s) stopped unexpectedly", containerID)
 					pdMap.Update(pName, pName, pd)
 				})
 				r.ScheduleReconciliation(pName)

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -951,7 +951,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) createProxyConnectionCertificate
 	if secConfErr != nil {
 		log.Error(secConfErr, "Failed to create security configuration for tunnel proxy connection")
 		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
-		pd.Message = fmt.Sprintf("Failed to create tunnel proxy connection certificates: %v", secConfErr)
+		pd.Message = fmt.Sprintf("Failed to create security configuration for tunnel proxy connection: %v", secConfErr)
 		return secConfErr
 	}
 

--- a/controllers/container_network_tunnel_proxy_data.go
+++ b/controllers/container_network_tunnel_proxy_data.go
@@ -179,6 +179,11 @@ func (tpd *containerNetworkTunnelProxyData) UpdateFrom(other *containerNetworkTu
 		updated = true
 	}
 
+	if tpd.Message != other.Message {
+		tpd.Message = other.Message
+		updated = true
+	}
+
 	if tpd.startupScheduled != other.startupScheduled {
 		tpd.startupScheduled = other.startupScheduled
 		updated = true
@@ -279,6 +284,11 @@ func (tpd *containerNetworkTunnelProxyData) applyTo(tunnelProxy *apiv1.Container
 
 	if tpd.ServerProxyControlPort != tunnelProxy.Status.ServerProxyControlPort {
 		tunnelProxy.Status.ServerProxyControlPort = tpd.ServerProxyControlPort
+		change |= statusChanged
+	}
+
+	if tpd.Message != tunnelProxy.Status.Message {
+		tunnelProxy.Status.Message = tpd.Message
 		change |= statusChanged
 	}
 

--- a/internal/docker/cli_orchestrator.go
+++ b/internal/docker/cli_orchestrator.go
@@ -262,10 +262,10 @@ func (dco *DockerCliOrchestrator) GetDiagnostics(ctx context.Context) (container
 
 func (dco *DockerCliOrchestrator) CreateVolume(ctx context.Context, options containers.CreateVolumeOptions) error {
 	cmd := makeDockerCommand("volume", "create", options.Name)
-	outBuf, _, err := dco.runBufferedDockerCommand(ctx, "CreateVolume", cmd, nil, nil, ordinaryDockerCommandTimeout)
+	outBuf, errBuf, err := dco.runBufferedDockerCommand(ctx, "CreateVolume", cmd, nil, nil, ordinaryDockerCommandTimeout)
 	if err != nil {
 		// Note: unlike Podman, Docker does not return an error if the volume already exists.
-		return err
+		return errors.Join(err, normalizeCliErrors(errBuf))
 	}
 
 	return containers.ExpectCliStrings(outBuf, []string{options.Name})
@@ -410,9 +410,9 @@ func (dco *DockerCliOrchestrator) BuildImage(ctx context.Context, options contai
 	if options.Timeout == 0 {
 		options.Timeout = defaultBuildImageTimeout
 	}
-	_, _, err := dco.runBufferedDockerCommand(ctx, "BuildImage", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	_, errBuf, err := dco.runBufferedDockerCommand(ctx, "BuildImage", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
-		return err
+		return errors.Join(err, normalizeCliErrors(errBuf))
 	}
 
 	return nil
@@ -598,8 +598,9 @@ func (dco *DockerCliOrchestrator) CreateContainer(ctx context.Context, options c
 		options.Timeout = defaultCreateContainerTimeout
 	}
 
-	outBuf, _, err := dco.runBufferedDockerCommand(ctx, "CreateContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	outBuf, errBuf, err := dco.runBufferedDockerCommand(ctx, "CreateContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
+		err = errors.Join(err, normalizeCliErrors(errBuf))
 		if id, err2 := asId(outBuf); err2 == nil {
 			// We got an ID, so the container was created, but the command failed.
 			return id, err
@@ -631,9 +632,9 @@ func (dco *DockerCliOrchestrator) RunContainer(ctx context.Context, options cont
 		options.Timeout = defaultRunContainerTimeout
 	}
 
-	outBuf, _, err := dco.runBufferedDockerCommand(ctx, "RunContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	outBuf, errBuf, err := dco.runBufferedDockerCommand(ctx, "RunContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
-		return "", err
+		return "", errors.Join(err, normalizeCliErrors(errBuf))
 	}
 	return asId(outBuf)
 }

--- a/internal/podman/cli_orchestrator.go
+++ b/internal/podman/cli_orchestrator.go
@@ -396,9 +396,9 @@ func (pco *PodmanCliOrchestrator) BuildImage(ctx context.Context, options contai
 	if options.Timeout == 0 {
 		options.Timeout = defaultBuildImageTimeout
 	}
-	_, _, err := pco.runBufferedPodmanCommand(ctx, "BuildImage", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	_, errBuf, err := pco.runBufferedPodmanCommand(ctx, "BuildImage", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
-		return err
+		return errors.Join(err, normalizeCliErrors(errBuf))
 	}
 
 	return nil
@@ -583,8 +583,9 @@ func (pco *PodmanCliOrchestrator) CreateContainer(ctx context.Context, options c
 		options.Timeout = defaultCreateContainerTimeout
 	}
 
-	outBuf, _, err := pco.runBufferedPodmanCommand(ctx, "CreateContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	outBuf, errBuf, err := pco.runBufferedPodmanCommand(ctx, "CreateContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
+		err = errors.Join(err, normalizeCliErrors(errBuf))
 		if id, err2 := asId(outBuf); err2 == nil {
 			// We got an ID, so the container was created, but the command failed.
 			return id, err
@@ -616,9 +617,9 @@ func (pco *PodmanCliOrchestrator) RunContainer(ctx context.Context, options cont
 		options.Timeout = defaultRunContainerTimeout
 	}
 
-	outBuf, _, err := pco.runBufferedPodmanCommand(ctx, "RunContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
+	outBuf, errBuf, err := pco.runBufferedPodmanCommand(ctx, "RunContainer", cmd, options.StdOutStream, options.StdErrStream, options.Timeout)
 	if err != nil {
-		return "", err
+		return "", errors.Join(err, normalizeCliErrors(errBuf))
 	}
 
 	return asId(outBuf)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1428,6 +1428,13 @@ func schema_microsoft_dcp_api_v1_ContainerNetworkTunnelProxyStatus(ref common.Re
 							Format:      "int32",
 						},
 					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human-readable message that provides additional information about ContainerNetworkTunnelProxy state.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
1. Added a new tunnel status property to capture detailed errors when tunnel fails.
2. Also made sure that output of the failing Docker/Podman command is captured and reported (if a command fails).

This will help fix https://github.com/microsoft/aspire/issues/13892