### PR TITLE
Fallback to local tunnel base image when pull fails

### DIFF
--- a/internal/dcptun/image_builder.go
+++ b/internal/dcptun/image_builder.go
@@ -229,7 +229,7 @@ func shouldBuildClientProxyImage(
 	}
 	defer imageBuildLock.Unlock()
 
-	haveImage, imageCheckErr := haveExistingImage(ctx, opts, ior, imageName)
+	haveImage, imageCheckErr := haveExistingImage(ctx, opts, ior, imageName, log)
 	if imageCheckErr != nil {
 		return proxyImageNeedUnknown, fmt.Errorf("failed to check if the client proxy image exists: %w", imageCheckErr)
 	}
@@ -292,20 +292,16 @@ func haveExistingImage(
 	opts BuildClientProxyImageOptions,
 	ior containers.ImageOrchestrator,
 	imageName string,
+	log logr.Logger,
 ) (bool, error) {
 	baseImageDigest, found := baseImageDigests[opts.BaseImage]
 	if !found {
-		baseImageID, pullErr := ior.PullImage(ctx, containers.PullImageOptions{Image: opts.BaseImage})
-		if pullErr != nil {
-			return false, fmt.Errorf("failed to pull client proxy base image %s: %w", opts.BaseImage, pullErr)
+		var digestErr error
+		baseImageDigest, digestErr = getBestEffortBaseImageDigest(ctx, opts.BaseImage, ior, log)
+		if digestErr != nil {
+			return false, digestErr
 		}
 
-		baseImageInspect, inspectErr := ior.InspectImages(ctx, containers.InspectImagesOptions{Images: []string{baseImageID}})
-		if inspectErr != nil {
-			return false, fmt.Errorf("failed to inspect client proxy base image %s: %w", opts.BaseImage, inspectErr)
-		}
-
-		baseImageDigest = imageDigest(baseImageInspect[0].Digest)
 		baseImageDigests[opts.BaseImage] = baseImageDigest
 	}
 
@@ -323,6 +319,55 @@ func haveExistingImage(
 	existing := images[0]
 	retval := imageDigest(existing.Labels[baseImageDigestLabel]) == baseImageDigest
 	return retval, nil
+}
+
+func getBestEffortBaseImageDigest(
+	ctx context.Context,
+	baseImage string,
+	ior containers.ImageOrchestrator,
+	log logr.Logger,
+) (imageDigest, error) {
+	baseImageID, pullErr := ior.PullImage(ctx, containers.PullImageOptions{Image: baseImage})
+	if pullErr == nil {
+		baseImageDigest, inspectErr := inspectBaseImageDigest(ctx, ior, baseImageID)
+		if inspectErr != nil {
+			return "", fmt.Errorf("failed to inspect client proxy base image %s: %w", baseImage, inspectErr)
+		}
+
+		return baseImageDigest, nil
+	}
+
+	baseImageDigest, inspectLocalErr := inspectBaseImageDigest(ctx, ior, baseImage)
+	if inspectLocalErr != nil {
+		return "", fmt.Errorf("failed to pull client proxy base image %s and no local copy was available: %w", baseImage, errors.Join(pullErr, inspectLocalErr))
+	}
+
+	log.V(1).Info("Failed to pull client proxy base image, using local image", "Image", baseImage, "Error", pullErr.Error())
+	return baseImageDigest, nil
+}
+
+func inspectBaseImageDigest(
+	ctx context.Context,
+	ior containers.ImageOrchestrator,
+	imageRef string,
+) (imageDigest, error) {
+	baseImageInspect, inspectErr := ior.InspectImages(ctx, containers.InspectImagesOptions{Images: []string{imageRef}})
+	if inspectErr != nil {
+		return "", inspectErr
+	}
+	if len(baseImageInspect) == 0 {
+		return "", fmt.Errorf("base image %s was not found", imageRef)
+	}
+
+	inspectedBaseImage := baseImageInspect[0]
+	if inspectedBaseImage.Digest != "" {
+		return imageDigest(inspectedBaseImage.Digest), nil
+	}
+	if inspectedBaseImage.Id != "" {
+		return imageDigest(inspectedBaseImage.Id), nil
+	}
+
+	return "", fmt.Errorf("base image %s has no digest or ID", imageRef)
 }
 
 // setupImageBuildContext creates a temporary directory for building the client proxy image,

--- a/internal/dcptun/image_builder_test.go
+++ b/internal/dcptun/image_builder_test.go
@@ -6,6 +6,7 @@
 package dcptun_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,8 @@ import (
 	"github.com/microsoft/dcp/pkg/slices"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
+
+const clientProxyBaseImageDigestLabel = "com.microsoft.developer.usvc-dev.base-image-digest"
 
 // Verifies that the client proxy image can be built successfully and has the expected tag prefix.
 func TestClientProxyImageBuild(t *testing.T) {
@@ -57,6 +60,78 @@ func TestClientProxyImageBuild(t *testing.T) {
 	const expectedTagPrefix = "dcptun_developer_ms:"
 	require.True(t, strings.HasPrefix(img.Tags[0], expectedTagPrefix))
 	require.Greater(t, len(img.Tags[0]), len(expectedTagPrefix), "Image tag should have a version suffix")
+}
+
+// Verifies that a pull failure for a locally available base image does not prevent building the client proxy image.
+func TestClientProxyImageBuildFallsBackToLocalBaseImageWhenPullFails(t *testing.T) {
+	t.Parallel()
+
+	const testTimeout = 20 * time.Second
+	ctx, cancel := testutil.GetTestContext(t, testTimeout)
+	defer cancel()
+
+	log := testutil.NewLogForTesting(t.Name())
+	co, coErr := ctrl_testutil.NewTestContainerOrchestrator(ctx, log, ctrl_testutil.TcoOptionNone)
+	require.NoError(t, coErr, "Failed to create test container orchestrator")
+
+	dcppaths.EnableTestPathProbing()
+
+	baseImage := testBaseImageName(t)
+	baseImageID, basePullErr := co.PullImage(ctx, containers.PullImageOptions{Image: baseImage})
+	require.NoError(t, basePullErr, "Failed to seed local base image")
+
+	baseImages, baseInspectErr := co.InspectImages(ctx, containers.InspectImagesOptions{
+		Images: []string{baseImageID},
+	})
+	require.NoError(t, baseInspectErr, "Failed to inspect seeded local base image")
+	require.Len(t, baseImages, 1, "Expected exactly one seeded local base image")
+
+	co.FailPullImage(errors.New("simulated base image pull failure"))
+
+	path := filepath.Join(t.TempDir(), t.Name()+".imglist")
+	defer func() { _ = os.Remove(path) }() // Best effort cleanup
+	opts := dcptun.BuildClientProxyImageOptions{
+		BaseImage:                     baseImage,
+		TimeoutOption:                 containers.TimeoutOption{Timeout: testTimeout / 2},
+		MostRecentImageBuildsFilePath: path,
+	}
+	imageName, buildErr := dcptun.EnsureClientProxyImage(ctx, opts, co, log)
+	require.NoError(t, buildErr, "Failed to ensure client proxy image using local base image")
+
+	imgs, inspectErr := co.InspectImages(ctx, containers.InspectImagesOptions{
+		Images: []string{imageName},
+	})
+	require.NoError(t, inspectErr, "Failed to inspect client proxy image")
+	require.Len(t, imgs, 1, "Expected exactly one inspected image")
+	require.Equal(t, baseImages[0].Digest, imgs[0].Labels[clientProxyBaseImageDigestLabel])
+}
+
+// Verifies that a pull failure still fails when there is no local base image to use.
+func TestClientProxyImageBuildFailsWhenPullFailsAndBaseImageIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	const testTimeout = 20 * time.Second
+	ctx, cancel := testutil.GetTestContext(t, testTimeout)
+	defer cancel()
+
+	log := testutil.NewLogForTesting(t.Name())
+	co, coErr := ctrl_testutil.NewTestContainerOrchestrator(ctx, log, ctrl_testutil.TcoOptionNone)
+	require.NoError(t, coErr, "Failed to create test container orchestrator")
+
+	dcppaths.EnableTestPathProbing()
+	co.FailPullImage(errors.New("simulated base image pull failure"))
+
+	path := filepath.Join(t.TempDir(), t.Name()+".imglist")
+	defer func() { _ = os.Remove(path) }() // Best effort cleanup
+	opts := dcptun.BuildClientProxyImageOptions{
+		BaseImage:                     testBaseImageName(t),
+		TimeoutOption:                 containers.TimeoutOption{Timeout: testTimeout / 2},
+		MostRecentImageBuildsFilePath: path,
+	}
+
+	_, buildErr := dcptun.EnsureClientProxyImage(ctx, opts, co, log)
+	require.Error(t, buildErr, "Expected client proxy image build to fail without a local base image")
+	require.ErrorContains(t, buildErr, "no local copy was available")
 }
 
 // Verifies that the client proxy image is built once even if EnsureClientProxyImage() is called concurrently multiple times.
@@ -109,4 +184,8 @@ func TestConcurrentClientProxyImageBuild(t *testing.T) {
 	require.Truef(t, slices.All(results, func(r imgBuildRes) bool {
 		return r.imageName == results[0].imageName
 	}), "All concurrent builds should return the same image name, but results are: %v", results)
+}
+
+func testBaseImageName(t *testing.T) string {
+	return "example.test/" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-")) + ":latest"
 }

--- a/internal/testutil/ctrlutil/test_container_orchestrator.go
+++ b/internal/testutil/ctrlutil/test_container_orchestrator.go
@@ -67,6 +67,7 @@ type TestContainerOrchestrator struct {
 	volumes                 map[string]containerVolume
 	networks                map[string]*containerNetwork
 	images                  []*testImage
+	pullImageErr            error
 	containers              map[string]*testContainer
 	startupLogs             map[string]containerStartupLogs
 	containersToFail        map[string]containerExit
@@ -1212,6 +1213,10 @@ func (to *TestContainerOrchestrator) PullImage(ctx context.Context, options cont
 		return "", errRuntimeUnhealthy
 	}
 
+	if to.pullImageErr != nil {
+		return "", to.pullImageErr
+	}
+
 	image, found := to.findImage(options.Image)
 	if found {
 		return image.id, nil
@@ -1234,6 +1239,17 @@ func (to *TestContainerOrchestrator) PullImage(ctx context.Context, options cont
 	to.images = append(to.images, image)
 
 	return image.id, nil
+}
+
+func (to *TestContainerOrchestrator) FailPullImage(pullImageErr error) {
+	to.mutex.Lock()
+	defer to.mutex.Unlock()
+
+	if pullImageErr == nil {
+		pullImageErr = errors.New("simulated image pull failure")
+	}
+
+	to.pullImageErr = pullImageErr
 }
 
 func (to *TestContainerOrchestrator) HasImage(id string) bool {


### PR DESCRIPTION
## Summary
- fall back to an existing local tunnel base image when refreshing the base image pull fails
- preserve failure when neither pull nor local base image inspection can provide an image digest
- add test orchestrator support and coverage for pull failure fallback behavior

Related to microsoft/aspire#16615.

## Testing
- make test