### PR TITLE
Improve container log stream cancellation logic

### DIFF
--- a/internal/logs/containerlogs/container_logstreamer.go
+++ b/internal/logs/containerlogs/container_logstreamer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	apiserver_resource "github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
@@ -115,7 +116,6 @@ func (c *containerLogStreamer) StreamLogs(
 		return apiv1.ResourceStreamStatusNotReady, nil, err
 	}
 
-	follow := opts.Follow
 	var logFilePath string
 	cleanup := func() {}
 
@@ -123,11 +123,9 @@ func (c *containerLogStreamer) StreamLogs(
 
 	case string(apiv1.LogStreamSourceStartupStdout):
 		logFilePath = ctr.Status.StartupStdOutFile
-		follow = follow && (ctr.Status.State == apiv1.ContainerStateStarting || ctr.Status.State == apiv1.ContainerStateBuilding)
 
 	case string(apiv1.LogStreamSourceStartupStderr):
 		logFilePath = ctr.Status.StartupStdErrFile
-		follow = follow && (ctr.Status.State == apiv1.ContainerStateStarting || ctr.Status.State == apiv1.ContainerStateBuilding)
 
 	case string(apiv1.LogStreamSourceSystem):
 		logFilePath = logger.GetResourceLogPath(ctr.GetResourceId())
@@ -263,15 +261,9 @@ func (c *containerLogStreamer) StreamLogs(
 		}
 	}()
 
-	if !follow {
-		// FollowWriter will keep pushing data until EOF (it will not stop immediately when we call StopFollow()).
-		followWriter.StopFollow()
-	} else if ctr.Done() {
-		logs.DelayCancelFollowStreams([]*usvc_io.FollowWriter{followWriter}, (*usvc_io.FollowWriter).StopFollow)
-	}
+	appropriatelyCancel(followWriter, ctr, opts)
 
 	return apiv1.ResourceStreamStatusStreaming, followWriter.Done(), nil
-
 }
 
 // OnResourceUpdated implements v1.ResourceLogStreamer.
@@ -338,6 +330,29 @@ func stopLogStreamsForContainer(
 		}
 
 		logs.DelayCancelFollowStreams(maps.Values(ctrStreams), (*usvc_io.FollowWriter).StopFollow)
+	}
+}
+
+// Cancels the follow writer depending on Container state and requested log options
+func appropriatelyCancel(fw *usvc_io.FollowWriter, ctr *apiv1.Container, opts *apiv1.LogOptions) {
+	follow := opts.Follow
+
+	if opts.Source == string(apiv1.LogStreamSourceStartupStdout) || opts.Source == string(apiv1.LogStreamSourceStartupStderr) {
+		// Only follow startup logs while the container is still starting or building
+		follow = follow && (ctr.Status.State == apiv1.ContainerStateStarting || ctr.Status.State == apiv1.ContainerStateBuilding)
+	}
+
+	if ctr.Done() && !ctr.Status.FinishTimestamp.IsZero() {
+		// Do not follow logs of finished containers if they have been finished for longer than the follow stream cancellation delay
+		now := metav1.NowMicro()
+		longFinished := ctr.Status.FinishTimestamp.Add(logs.FollowStreamCancellationDelay).Before(now.Time)
+		follow = follow && !longFinished
+	}
+
+	if !follow {
+		fw.StopFollow() // Will stop writing after first EOF is reached
+	} else if ctr.Done() {
+		logs.DelayCancelFollowStreams([]*usvc_io.FollowWriter{fw}, (*usvc_io.FollowWriter).StopFollow)
 	}
 }
 

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/microsoft/dcp/controllers"
 	"github.com/microsoft/dcp/internal/containers"
 	"github.com/microsoft/dcp/internal/health"
+	"github.com/microsoft/dcp/internal/logs"
 	"github.com/microsoft/dcp/internal/networking"
 	internal_testutil "github.com/microsoft/dcp/internal/testutil"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
@@ -2227,8 +2228,23 @@ func TestContainerLogsFollowFromStart(t *testing.T) {
 
 // Verify that logs can be captured in follow mode when log stream is opened after the Container has exited.
 func TestContainerLogsFollowAfterExit(t *testing.T) {
-	const containerName = "test-container-logs-follow-after-exit"
-	const imageName = containerName + "-image"
+	const testName = "test-container-logs-follow-after-exit"
+
+	type testcase struct {
+		description   string
+		waitAfterExit time.Duration
+	}
+
+	testcases := []testcase{
+		{
+			description:   "immediately",
+			waitAfterExit: 0,
+		},
+		{
+			description:   "after-cancellation-delay",
+			waitAfterExit: logs.FollowStreamCancellationDelay + time.Second,
+		},
+	}
 
 	lines := [][]byte{
 		[]byte("Standard output log line 1"),
@@ -2238,44 +2254,61 @@ func TestContainerLogsFollowAfterExit(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
-	defer cancel()
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 
-	ctr := apiv1.Container{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      containerName,
-			Namespace: metav1.NamespaceNone,
-		},
-		Spec: apiv1.ContainerSpec{
-			Image: imageName,
-		},
+			ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+			defer cancel()
+
+			containerName := testName + "-" + tc.description
+
+			ctr := apiv1.Container{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      containerName,
+					Namespace: metav1.NamespaceNone,
+				},
+				Spec: apiv1.ContainerSpec{
+					Image: containerName + "-image",
+				},
+			}
+
+			t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+			err := client.Create(ctx, &ctr)
+			require.NoError(t, err, "Could not create Container '%s'", ctr.ObjectMeta.Name)
+
+			updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+
+			t.Logf("Simulating logging for Container '%s'...", ctr.ObjectMeta.Name)
+			for _, line := range lines {
+				logErr := containerOrchestrator.SimulateContainerLogging(updatedCtr.Status.ContainerID, apiv1.LogStreamSourceStdout, osutil.WithNewline(line))
+				require.NoError(t, logErr, "could not simulate logging to stdout")
+			}
+
+			t.Logf("Transitioning Container '%s' to 'Exited' state...", ctr.ObjectMeta.Name)
+			exitErr := containerOrchestrator.SimulateContainerExit(ctx, updatedCtr.Status.ContainerID, 0)
+			require.NoError(t, exitErr)
+			updatedCtr = ensureContainerState(t, ctx, client, updatedCtr, apiv1.ContainerStateExited)
+
+			if tc.waitAfterExit > 0 {
+				t.Logf("Waiting %v after container exit before requesting logs...", tc.waitAfterExit)
+				select {
+				case <-time.After(tc.waitAfterExit):
+				case <-ctx.Done():
+					require.NoError(t, ctx.Err())
+				}
+			}
+
+			t.Logf("Start following logs for Container '%s'...", ctr.ObjectMeta.Name)
+			opts := apiv1.LogOptions{
+				Follow:     true,
+				Source:     "stdout",
+				Timestamps: false,
+			}
+			logsErr := waitForObjectLogs(ctx, updatedCtr, opts, lines, nil)
+			require.NoError(t, logsErr, "Could not follow logs for Container '%s'", ctr.ObjectMeta.Name)
+		})
 	}
-
-	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
-	err := client.Create(ctx, &ctr)
-	require.NoError(t, err, "Could not create Container '%s'", ctr.ObjectMeta.Name)
-
-	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
-
-	t.Logf("Simulating logging for Container '%s'...", ctr.ObjectMeta.Name)
-	for _, line := range lines {
-		logErr := containerOrchestrator.SimulateContainerLogging(updatedCtr.Status.ContainerID, apiv1.LogStreamSourceStdout, osutil.WithNewline(line))
-		require.NoError(t, logErr, "could not simulate logging to stdout")
-	}
-
-	t.Logf("Transitioning Container '%s' to 'Exited' state...", ctr.ObjectMeta.Name)
-	exitErr := containerOrchestrator.SimulateContainerExit(ctx, updatedCtr.Status.ContainerID, 0)
-	require.NoError(t, exitErr)
-	updatedCtr = ensureContainerState(t, ctx, client, updatedCtr, apiv1.ContainerStateExited)
-
-	t.Logf("Start following logs for Container '%s'...", ctr.ObjectMeta.Name)
-	opts := apiv1.LogOptions{
-		Follow:     true,
-		Source:     "stdout",
-		Timestamps: false,
-	}
-	logsErr := waitForObjectLogs(ctx, updatedCtr, opts, lines, nil)
-	require.NoError(t, logsErr, "Could not follow logs for Container '%s'", ctr.ObjectMeta.Name)
 }
 
 // Verify that Container startup logs can be captured.


### PR DESCRIPTION
While working on related Aspire bug I noticed that we experience a delayed closure of log stream for containers that have finished running and aren't producing new logs anymore. Tracked it to the fact that we delay-close the `FollowWriter` used to stream logs for all types of containes, so meade a change that closes it faster if a container has been finished for a while. Streamlined follow/non follow logic in the process. 