### PR TITLE
Stop scoped persistent containers without removal

### DIFF
--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -1928,7 +1928,13 @@ func (r *ContainerReconciler) runPersistentContainerLifecycleMonitor(rcd *runnin
 		return
 	}
 
-	dcpproc.RunContainerWatcherForMonitor(r.config.ProcessExecutor, monitor, string(rcd.containerID), log)
+	dcpproc.RunContainerWatcherForMonitorWithOptions(
+		r.config.ProcessExecutor,
+		monitor,
+		string(rcd.containerID),
+		dcpproc.ContainerWatcherOptions{StopOnly: true},
+		log,
+	)
 }
 
 // Connects the Container to networks as necessary, updating status.

--- a/internal/dcpproc/commands/container.go
+++ b/internal/dcpproc/commands/container.go
@@ -42,6 +42,7 @@ var (
 	// Container-specific flags
 	containerID           string
 	containerPollInterval time.Duration
+	containerStopOnly     bool
 )
 
 func NewContainerCommand(log logr.Logger) (*cobra.Command, error) {
@@ -51,7 +52,8 @@ func NewContainerCommand(log logr.Logger) (*cobra.Command, error) {
 		Long: `Ensures that a container is stopped and removed when the monitored process exits.
 
 This command is used to ensure that containers are properly cleaned up when
-DCP terminates unexpectedly. It performs a graceful stop followed by removal of the container.`,
+DCP terminates unexpectedly. It performs a graceful stop followed by removal of the container
+unless --stop-only is specified.`,
 		RunE:         monitorContainer(log),
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
@@ -67,6 +69,8 @@ DCP terminates unexpectedly. It performs a graceful stop followed by removal of 
 	if flagErr != nil {
 		return nil, flagErr
 	}
+
+	containerCmd.Flags().BoolVar(&containerStopOnly, "stop-only", false, "Stop the container when the monitored process exits, but do not remove it")
 
 	// Mostly for testing purposes.
 	containerCmd.Flags().DurationVar(&containerPollInterval, "containerPollInterval", defaultContainerPollInterval,
@@ -114,7 +118,7 @@ func monitorContainer(log logr.Logger) func(cmd *cobra.Command, args []string) e
 			if errors.Is(monitorCtxErr, os.ErrProcessDone) {
 				// If the monitor process is already terminated, cleanup the container immediately
 				log.Info("Monitored process already exited, cleaning up container")
-				return doCleanupContainer(cmd.Context(), containerID, log, co)
+				return doCleanupContainer(cmd.Context(), containerID, containerStopOnly, log, co)
 			} else {
 				log.Error(monitorCtxErr, "Process could not be monitored")
 				return monitorCtxErr
@@ -129,7 +133,7 @@ func monitorContainer(log logr.Logger) func(cmd *cobra.Command, args []string) e
 			return nil
 		case <-monitorCtx.Done():
 			log.Info("Monitored process exited, cleaning up container")
-			return doCleanupContainer(cmd.Context(), containerID, log, co)
+			return doCleanupContainer(cmd.Context(), containerID, containerStopOnly, log, co)
 		}
 	}
 }
@@ -157,6 +161,7 @@ func getContainerOrchestrator(ctx context.Context, log logr.Logger) (inspectStop
 func doCleanupContainer(
 	ctx context.Context,
 	containerID string,
+	stopOnly bool,
 	log logr.Logger,
 	co inspectStopRemoveContainers,
 ) error {
@@ -197,9 +202,16 @@ func doCleanupContainer(
 		})
 
 		if stopErr != nil && !errors.Is(stopErr, containers.ErrNotFound) {
-			log.Error(stopErr, "Failed to stop container gracefully")
-			// Continue with removal even if stop failed
+			log.Error(stopErr, "Failed to stop container")
+			if stopOnly {
+				return stopErr
+			}
+			// Continue with removal even if stop failed.
 		}
+	}
+
+	if stopOnly {
+		return nil
 	}
 
 	// Remove the container

--- a/internal/dcpproc/dcpproc_api.go
+++ b/internal/dcpproc/dcpproc_api.go
@@ -28,6 +28,11 @@ const (
 	DCP_DISABLE_MONITOR_PROCESS = "DCP_DISABLE_MONITOR_PROCESS"
 )
 
+type ContainerWatcherOptions struct {
+	// StopOnly stops the container when the monitored process exits, but leaves the container resource in place.
+	StopOnly bool
+}
+
 func MonitorTargetFromFields(monitorPID *int64, monitorTimestamp metav1.MicroTime) (process.ProcessTreeItem, bool, error) {
 	if monitorPID == nil {
 		return process.ProcessTreeItem{}, false, nil
@@ -112,6 +117,16 @@ func RunContainerWatcherForMonitor(
 	containerID string,
 	log logr.Logger,
 ) {
+	RunContainerWatcherForMonitorWithOptions(pe, monitor, containerID, ContainerWatcherOptions{}, log)
+}
+
+func RunContainerWatcherForMonitorWithOptions(
+	pe process.Executor,
+	monitor process.ProcessTreeItem,
+	containerID string,
+	options ContainerWatcherOptions,
+	log logr.Logger,
+) {
 	if _, found := os.LookupEnv(DCP_DISABLE_MONITOR_PROCESS); found {
 		return
 	}
@@ -121,6 +136,9 @@ func RunContainerWatcherForMonitor(
 	cmdArgs := []string{
 		"monitor-container",
 		"--containerID", containerID,
+	}
+	if options.StopOnly {
+		cmdArgs = append(cmdArgs, "--stop-only")
 	}
 	cmdArgs = append(cmdArgs, getMonitorCmdArgs(monitor)...)
 

--- a/internal/dcpproc/dcpproc_api_test.go
+++ b/internal/dcpproc/dcpproc_api_test.go
@@ -145,6 +145,30 @@ func TestRunContainerWatcherForMonitor(t *testing.T) {
 	require.Equal(t, monitor.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat), dcpProc.Cmd.Args[7], "Should include explicit monitor identity time")
 }
 
+func TestRunContainerWatcherForMonitorWithStopOnly(t *testing.T) {
+	log := testutil.NewLogForTesting(t.Name())
+	ctx, cancel := testutil.GetTestContext(t, 20*time.Second)
+	defer cancel()
+	pe := internal_testutil.NewTestProcessExecutor(ctx)
+	dcppaths.EnableTestPathProbing()
+
+	testContainerID := "test-container-123"
+	monitor := process.ProcessTreeItem{
+		Pid:          12345,
+		IdentityTime: time.Now().Add(-time.Minute),
+	}
+
+	RunContainerWatcherForMonitorWithOptions(pe, monitor, testContainerID, ContainerWatcherOptions{StopOnly: true}, log)
+
+	dcpProc, dcpProcErr := findRunningDcp(pe)
+	require.NoError(t, dcpProcErr)
+
+	require.Equal(t, "monitor-container", dcpProc.Cmd.Args[1], "Should use 'monitor-container' subcommand")
+	require.Equal(t, "--containerID", dcpProc.Cmd.Args[2], "Should include --containerID flag")
+	require.Equal(t, testContainerID, dcpProc.Cmd.Args[3], "Should include container ID")
+	require.Contains(t, dcpProc.Cmd.Args, "--stop-only", "Should include --stop-only flag")
+}
+
 func TestStopProcessTree(t *testing.T) {
 	log := testutil.NewLogForTesting(t.Name())
 	ctx, cancel := testutil.GetTestContext(t, 20*time.Second)

--- a/internal/dcpproc/dcpproc_test.go
+++ b/internal/dcpproc/dcpproc_test.go
@@ -316,6 +316,99 @@ func TestMonitorContainerTerminatesWatchedContainer(t *testing.T) {
 	require.NoError(t, waitErr, "Container cleanup did not complete in time")
 }
 
+func TestMonitorContainerStopsWatchedContainerWithoutRemoving(t *testing.T) {
+	t.Parallel()
+
+	dcpProc, dcpProcErr := getDcpProcExecutablePath()
+	require.NoError(t, dcpProcErr, "DCPPROC path should not be found")
+
+	delayToolDir, toolLaunchErr := int_testutil.GetTestToolDir("delay")
+	require.NoError(t, toolLaunchErr, "'delay' tool directory could not be found")
+
+	const testTimeout = time.Second * 30
+	testCtx, testCancel := context.WithTimeout(context.Background(), testTimeout)
+	defer testCancel()
+
+	log := testutil.NewLogForTesting(t.Name())
+	tco, tcoErr := ctrlutil.NewTestContainerOrchestrator(testCtx, log, ctrlutil.TcoOptionEnableSocketListener)
+	require.NoError(t, tcoErr)
+	defer func() {
+		closeErr := tco.Close()
+		require.NoError(t, closeErr)
+	}()
+
+	const containerName = "test-monitor-stops-watched-container-without-removing"
+	containerID, createErr := tco.CreateContainer(testCtx, containers.CreateContainerOptions{
+		Name: containerName,
+		ContainerSpec: apiv1.ContainerSpec{
+			Image: containerName + "-image",
+		},
+	})
+	require.NoError(t, createErr, "Test container could not be created")
+
+	_, startErr := tco.StartContainers(testCtx, containers.StartContainersOptions{
+		Containers: []string{containerID},
+	})
+	require.NoError(t, startErr, "Test container could not be started")
+
+	delayTimeout := testTimeout / 6
+	parentCmd := exec.CommandContext(testCtx, "./delay", fmt.Sprintf("--delay=%s", delayTimeout.String()))
+	parentCmd.Dir = delayToolDir
+	process.DecoupleFromParent(parentCmd)
+	parentCmdErr := parentCmd.Start()
+	require.NoError(t, parentCmdErr, "Monitored process should start without error")
+
+	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
+	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
+
+	dcpProcCmd := exec.CommandContext(testCtx, dcpProc,
+		"monitor-container",
+		"--monitor", strconv.Itoa(parentCmd.Process.Pid),
+		"--containerID", containerID,
+		"--monitor-identity-time", parentIdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
+		"--test-container-orchestrator-socket", tco.GetSocketFilePath(),
+		"--stop-only",
+	)
+	process.DecoupleFromParent(dcpProcCmd)
+	dcpProcCmdErr := dcpProcCmd.Start()
+	require.NoError(t, dcpProcCmdErr, "dcpproc command should start without error")
+
+	parentProcResultCh := make(chan error, 1)
+	go func() { parentProcResultCh <- parentCmd.Wait() }()
+
+	select {
+	case parentProcErr := <-parentProcResultCh:
+		require.NoError(t, parentProcErr, "Monitored process should exit without error")
+	case <-testCtx.Done():
+		require.Fail(t, "Monitored process did not exit in time")
+	}
+
+	waitErr := wait.PollUntilContextCancel(testCtx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		inspected, inspectErr := tco.InspectContainers(ctx, containers.InspectContainersOptions{
+			Containers: []string{containerID},
+		})
+		if inspectErr != nil {
+			return false, inspectErr
+		}
+		if len(inspected) != 1 {
+			return false, fmt.Errorf("expected one inspected container, got %d", len(inspected))
+		}
+		return inspected[0].Status == containers.ContainerStatusExited, nil
+	})
+	require.NoError(t, waitErr, "Container stop did not complete in time")
+
+	dcpProcResultCh := make(chan error, 1)
+	go func() { dcpProcResultCh <- dcpProcCmd.Wait() }()
+
+	select {
+	case dcpProcResult := <-dcpProcResultCh:
+		require.NoError(t, dcpProcResult, "dcpproc should exit cleanly after stopping the container")
+	case <-testCtx.Done():
+		require.Fail(t, "dcpproc did not exit after stopping container")
+	}
+}
+
 // Ensures that dcpproc exits when the monitored container is removed externally.
 func TestMonitorContainerExitWhenContainerRemoved(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Persistent containers scoped to a parent monitor PID should remain inspectable after the parent exits so the controller can observe the container's final exited state. The previous monitor cleanup path removed the container, which made the resource transition to Unknown instead.

This adds a stop-only option to `monitor-container` and wires scoped persistent containers to use it. The default monitor behavior still stops and removes containers, while the scoped persistent path now uses the existing stop timeout behavior so Docker/Podman can gracefully stop first and force-kill after the timeout without deleting the container.

Coverage includes the dcpproc command wrapper argument generation and an end-to-end monitor test that verifies `--stop-only` leaves the container present in Exited state.