### PR TITLE
Restore correct way of stopping Executables on Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,23 +24,6 @@
         },
 
         {
-            "name": "dcpctrl run-controllers",
-            "type": "go",
-            "request": "launch",
-            "mode": "exec",
-            "program": "${workspaceFolder}/bin/ext/dcpctrl",
-            "args": [
-                "run-controllers",
-                "-v=1",
-                "--kubeconfig=${workspaceFolder}/kubeconfig.dev"
-            ],
-            "windows": {
-                "program": "${workspaceFolder}/bin/ext/dcpctrl.exe"
-            },
-            "preLaunchTask": "compile-debug"
-        },
-
-        {
             "name": "dcp start-apiserver",
             "type": "go",
             "request": "launch",
@@ -58,61 +41,11 @@
         },
 
         {
-            "name": "dcpproc process (lauch)",
-            "type": "go",
-            "request": "launch",
-            "mode": "exec",
-            "program": "${workspaceFolder}/bin/ext/bin/dcpproc",
-            "args": [
-                "process",
-                "--monitor", "${input:monitored-process-pid}",
-                "--child", "${input:child-process-pid}",
-                "--monitor-identity-time", "${input:monitored-process-start-time}",
-                "--child-identity-time", "${input:child-process-start-time}",
-            ],
-            "windows": {
-                "program": "${workspaceFolder}/bin/ext/bin/dcpproc",
-            },
-            "preLaunchTask": "compile-debug"
-        },
-
-        {
-            "name": "attach to dcp process",
-            "type": "go",
-            "request": "attach",
-            "mode": "local",
-            "processId": "dcp"
-        },
-
-        {
             "name": "attach to process...",
             "type": "go",
             "request": "attach",
             "mode": "local",
             "processId": "${command:pickProcess}"
-        }
-    ],
-
-    "inputs": [
-        {
-            "id": "monitored-process-pid",
-            "description": "Enter the PID of the monitored process",
-            "type": "promptString",
-        },
-        {
-            "id": "child-process-pid",
-            "description": "Enter the PID of the child process",
-            "type": "promptString",
-        },
-        {
-            "id": "monitored-process-start-time",
-            "description": "Enter the start time of the monitored process (RFC 3339 format)",
-            "type": "promptString",
-        },
-        {
-            "id": "child-process-start-time",
-            "description": "Enter the start time of the child process (RFC 3339 format)",
-            "type": "promptString",
         }
     ]
 }

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -294,7 +294,15 @@ func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers
 	errCh := make(chan error, 1)
 
 	go func() {
-		errCh <- process.StopViaConsole(stopLog, r.pe, runState.pid, runState.identityTime)
+		if osutil.IsWindows() {
+			// See StartRun() for why we need to use separate console for the app process on Windows.
+			// This means we cannot send Ctrl-C to that process directly and need to use dcpproc StopProcessTree facility instead.
+			stopCtx, stopCtxCancel := context.WithTimeout(ctx, ProcessStopTimeout)
+			defer stopCtxCancel()
+			errCh <- dcpproc.StopProcessTree(stopCtx, r.pe, runIdToPID(runID), runState.identityTime, stopLog)
+		} else {
+			errCh <- r.pe.StopProcess(runIdToPID(runID), runState.identityTime)
+		}
 	}()
 
 	var stopErr error = nil
@@ -386,6 +394,18 @@ func makeCommand(exe *apiv1.Executable) *exec.Cmd {
 
 func pidToRunID(pid process.Pid_t) controllers.RunID {
 	return controllers.RunID(strconv.FormatInt(int64(pid), 10))
+}
+
+func runIdToPID(runID controllers.RunID) process.Pid_t {
+	pid64, err := strconv.ParseInt(string(runID), 10, 64)
+	if err != nil {
+		return process.UnknownPID
+	}
+	pid, err := process.Int64_ToPidT(pid64)
+	if err != nil {
+		return process.UnknownPID
+	}
+	return pid
 }
 
 var _ controllers.ExecutableRunner = (*ProcessExecutableRunner)(nil)

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -71,6 +71,10 @@ type processRunState struct {
 type ProcessExecutableRunner struct {
 	pe               process.Executor
 	runningProcesses *syncmap.ComparableValueMap[controllers.RunID, *processRunState]
+
+	// Do not use dcpproc.StopProcessTree, always go directly to process runner for stoppin the process.
+	// Used for testing only.
+	disableConsoleStop bool
 }
 
 func NewProcessExecutableRunner(pe process.Executor) *ProcessExecutableRunner {
@@ -294,14 +298,14 @@ func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers
 	errCh := make(chan error, 1)
 
 	go func() {
-		if osutil.IsWindows() {
+		if osutil.IsWindows() && !r.disableConsoleStop {
 			// See StartRun() for why we need to use separate console for the app process on Windows.
 			// This means we cannot send Ctrl-C to that process directly and need to use dcpproc StopProcessTree facility instead.
 			stopCtx, stopCtxCancel := context.WithTimeout(ctx, ProcessStopTimeout)
 			defer stopCtxCancel()
-			errCh <- dcpproc.StopProcessTree(stopCtx, r.pe, runIdToPID(runID), runState.identityTime, stopLog)
+			errCh <- dcpproc.StopProcessTree(stopCtx, r.pe, runState.pid, runState.identityTime, stopLog)
 		} else {
-			errCh <- r.pe.StopProcess(runIdToPID(runID), runState.identityTime)
+			errCh <- r.pe.StopProcess(runState.pid, runState.identityTime)
 		}
 	}()
 
@@ -394,18 +398,6 @@ func makeCommand(exe *apiv1.Executable) *exec.Cmd {
 
 func pidToRunID(pid process.Pid_t) controllers.RunID {
 	return controllers.RunID(strconv.FormatInt(int64(pid), 10))
-}
-
-func runIdToPID(runID controllers.RunID) process.Pid_t {
-	pid64, err := strconv.ParseInt(string(runID), 10, 64)
-	if err != nil {
-		return process.UnknownPID
-	}
-	pid, err := process.Int64_ToPidT(pid64)
-	if err != nil {
-		return process.UnknownPID
-	}
-	return pid
 }
 
 var _ controllers.ExecutableRunner = (*ProcessExecutableRunner)(nil)

--- a/internal/exerunners/process_executable_runner_test.go
+++ b/internal/exerunners/process_executable_runner_test.go
@@ -85,7 +85,7 @@ func TestProcessExecutableRunnerStartsLifecycleMonitor(t *testing.T) {
 				},
 			}
 
-			result := runner.StartRun(ctx, exe, &testRunChangeHandler{}, logr.Discard())
+			result := runner.StartRun(ctx, exe, newRecordingRunChangeHandler(), logr.Discard())
 
 			require.Equal(t, apiv1.ExecutableStateRunning, result.ExeState)
 			t.Cleanup(func() {
@@ -186,7 +186,7 @@ func TestProcessExecutableRunnerSkipsTimestampsForPersistentOutput(t *testing.T)
 				},
 			}
 
-			result := runner.StartRun(ctx, exe, &testRunChangeHandler{}, logr.Discard())
+			result := runner.StartRun(ctx, exe, newRecordingRunChangeHandler(), logr.Discard())
 			require.Equal(t, apiv1.ExecutableStateRunning, result.ExeState)
 			t.Cleanup(func() {
 				require.NoError(t, runner.ReleaseRun(context.Background(), result.RunID, logr.Discard()))
@@ -222,23 +222,27 @@ func TestAdoptedProcessStopUsesAdoptedPID(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	processExecutor := &recordingProcessExecutor{}
+	processExecutor := testutil.NewTestProcessExecutor(ctx)
 	runner := NewProcessExecutableRunner(processExecutor)
-	pid := process.Pid_t(42)
-	identityTime := time.Now().UTC()
-	originalRunID := pidToRunID(pid)
-	adoptedRunID := controllers.RunID(fmt.Sprintf("%s-adopted", originalRunID))
+	runner.disableConsoleStop = true // We are just simulating the run, so stopping via dcpproc/console would fail.
+	pid, identityTime, _, startErr := processExecutor.StartProcess(ctx, exec.Command("./delay", "--delay=1s"), nil, process.CreationFlagsNone)
+	require.NoError(t, startErr)
+	adoptedRunID := controllers.RunID(pidToRunID(pid + 1))
+	changeHandler := newRecordingRunChangeHandler()
 	runner.runningProcesses.Store(adoptedRunID, &processRunState{
-		pid:          pid,
-		identityTime: identityTime,
-		cmdInfo:      "/test/app",
-		adopted:      true,
+		pid:              pid,
+		identityTime:     identityTime,
+		cmdInfo:          "./delay --delay=1s",
+		adopted:          true,
+		runChangeHandler: changeHandler,
 	})
 
 	require.NoError(t, runner.StopRun(ctx, adoptedRunID, logr.Discard()))
 
-	require.Equal(t, pid, processExecutor.stoppedPID)
-	require.Equal(t, identityTime, processExecutor.stoppedIdentityTime)
+	execution, found := processExecutor.FindByPid(pid)
+	require.True(t, found)
+	require.True(t, execution.Finished())
+	require.Equal(t, int32(testutil.KilledProcessExitCode), execution.ExitCode)
 }
 
 func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
@@ -261,7 +265,7 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 	identityTime := process.ProcessIdentityTime(pid)
 	require.False(t, identityTime.IsZero())
 
-	runner := NewProcessExecutableRunner(&recordingProcessExecutor{})
+	runner := NewProcessExecutableRunner(testutil.NewTestProcessExecutor(ctx))
 	runID := pidToRunID(pid)
 	changeHandler := newRecordingRunChangeHandler()
 
@@ -289,7 +293,9 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 func TestAdoptedProcessWatcherDoesNotDeleteReusedRunID(t *testing.T) {
 	t.Parallel()
 
-	runner := NewProcessExecutableRunner(&recordingProcessExecutor{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runner := NewProcessExecutableRunner(testutil.NewTestProcessExecutor(ctx))
 	runID := controllers.RunID("42")
 	watchedPID := process.Pid_t(42)
 	watchedIdentityTime := time.Unix(1, 0).UTC()
@@ -328,7 +334,9 @@ func TestReleaseRunClosesProcessRunFiles(t *testing.T) {
 		require.NoError(t, os.Remove(stdErrFile.Name()))
 	})
 
-	runner := NewProcessExecutableRunner(&recordingProcessExecutor{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runner := NewProcessExecutableRunner(testutil.NewTestProcessExecutor(ctx))
 	runID := controllers.RunID("run-1")
 	runner.runningProcesses.Store(runID, &processRunState{
 		stdOutFile: stdOutFile,
@@ -367,38 +375,6 @@ func removeFileIfExists(t *testing.T, path string) {
 		require.NoError(t, removeErr)
 	}
 }
-
-type recordingProcessExecutor struct {
-	stoppedPID          process.Pid_t
-	stoppedIdentityTime time.Time
-}
-
-func (e *recordingProcessExecutor) StartProcess(_ context.Context, _ *exec.Cmd, _ process.ProcessExitHandler, _ process.ProcessCreationFlag) (process.Pid_t, time.Time, func(), error) {
-	return process.UnknownPID, time.Time{}, nil, fmt.Errorf("process start is not supported by recordingProcessExecutor")
-}
-
-func (e *recordingProcessExecutor) StopProcess(pid process.Pid_t, processStartTime time.Time, _ ...process.ProcessStopOption) error {
-	e.stoppedPID = pid
-	e.stoppedIdentityTime = processStartTime
-	return nil
-}
-
-func (e *recordingProcessExecutor) StartAndForget(*exec.Cmd, process.ProcessCreationFlag) (process.Pid_t, time.Time, error) {
-	return process.UnknownPID, time.Time{}, fmt.Errorf("process start is not supported by recordingProcessExecutor")
-}
-
-func (e *recordingProcessExecutor) Dispose() {}
-
-type testRunChangeHandler struct{}
-
-func (*testRunChangeHandler) OnMainProcessChanged(controllers.RunID, process.Pid_t) {}
-
-func (*testRunChangeHandler) OnRunCompleted(controllers.RunID, *int32, error) {}
-
-func (*testRunChangeHandler) OnStartupCompleted(types.NamespacedName, *controllers.ExecutableStartResult) {
-}
-
-func (*testRunChangeHandler) OnRunMessage(controllers.RunID, controllers.RunMessageLevel, string) {}
 
 type completedRunNotification struct {
 	runID    controllers.RunID


### PR DESCRIPTION
Code was deleted/"simplified" by AI in https://github.com/microsoft/dcp/pull/142 and both reviewers and tests did not catch it.

Fixes https://github.com/microsoft/aspire/issues/17201

`launch.json` changes are unrelated, just cleaning up stale debug configurations