### PR TITLE
Handle persistent resource stop before startup

### DIFF
--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -334,11 +334,6 @@ func handleNewContainer(
 ) objectChange {
 	change := noChange
 
-	if container.Spec.Stop {
-		// The container was started with a desired state of stopped, don't attempt to start it.
-		return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
-	}
-
 	status := r.orchestrator.CheckStatus(ctx, containers.CachedRuntimeStatusAllowed)
 	if !status.IsHealthy() {
 		// If the runtime isn't healthy, we will attempt to start the container later (in case the runtime recovers).
@@ -436,6 +431,31 @@ func handleNewContainer(
 				return change | r.setContainerState(container, apiv1.ContainerStateRunning)
 			}
 
+			if container.Spec.Stop {
+				stopRcd := newRunningContainerData(container)
+				stopRcd.updateFromInspectedContainer(inspected)
+				stopRcd.ensureStartupLogFiles(container, log)
+				if !inspected.StartedAt.IsZero() {
+					stopRcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
+				}
+
+				r.runningContainers.Store(container.NamespacedName(), stopRcd.containerID, stopRcd)
+				r.EnsureContainerWatchForResource(container.UID, log)
+				_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+
+				if inspected.Status == containers.ContainerStatusRunning ||
+					inspected.Status == containers.ContainerStatusPaused ||
+					inspected.Status == containers.ContainerStatusRestarting {
+					stopRcd.containerState = apiv1.ContainerStateStopping
+					return change | ensureContainerStoppingState(ctx, r, container, apiv1.ContainerStateStopping, stopRcd, log)
+				}
+
+				stopRcd.containerState = apiv1.ContainerStateExited
+				change |= stopRcd.applyTo(container, log)
+				r.disableEndpointsAndHealthProbes(ctx, container, stopRcd, log)
+				return change
+			}
+
 			if container.ShouldStart() {
 				log.V(1).Info("Removing existing container")
 				if removeErr := r.removeExistingContainer(ctx, containerID(inspected.Id), inspected, log); removeErr != nil {
@@ -451,6 +471,11 @@ func handleNewContainer(
 		log.V(1).Info("Waiting for the container to be started")
 		_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
 		return change
+	}
+
+	if container.Spec.Stop {
+		// The container was created with an inconsistent desired state: start it and stop it at the same time.
+		return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
 	}
 
 	if container.Spec.Build != nil {

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -359,6 +359,33 @@ func handleNewContainer(
 		}
 
 		if inspected != nil {
+			log = log.WithValues("ContainerID", GetShortId(inspected.Id))
+
+			if container.Spec.Stop {
+				stopRcd := newRunningContainerData(container)
+				stopRcd.updateFromInspectedContainer(inspected)
+				stopRcd.ensureStartupLogFiles(container, log)
+				if !inspected.StartedAt.IsZero() {
+					stopRcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
+				}
+
+				r.runningContainers.Store(container.NamespacedName(), stopRcd.containerID, stopRcd)
+				r.EnsureContainerWatchForResource(container.UID, log)
+				_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+
+				if inspected.Status == containers.ContainerStatusRunning ||
+					inspected.Status == containers.ContainerStatusPaused ||
+					inspected.Status == containers.ContainerStatusRestarting {
+					stopRcd.containerState = apiv1.ContainerStateStopping
+					return change | ensureContainerStoppingState(ctx, r, container, apiv1.ContainerStateStopping, stopRcd, log)
+				}
+
+				stopRcd.containerState = apiv1.ContainerStateExited
+				change |= stopRcd.applyTo(container, log)
+				r.disableEndpointsAndHealthProbes(ctx, container, stopRcd, log)
+				return change
+			}
+
 			// Produce a candidate RCD; this will only be persisted if we find an existing valid container.
 			rcd := newRunningContainerData(container)
 
@@ -399,8 +426,6 @@ func handleNewContainer(
 				change |= statusChanged
 			}
 
-			log = log.WithValues("ContainerID", GetShortId(inspected.Id))
-
 			_, dcpManaged := inspected.Labels[dcpBuildLabel]
 			oldLifecycleKey, found := inspected.Labels[lifecycleKeyLabel]
 			if dcpManaged && ((found && oldLifecycleKey != lifecycleKey) || (!found && lifecycleKey != "")) {
@@ -429,31 +454,6 @@ func handleNewContainer(
 
 				_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
 				return change | r.setContainerState(container, apiv1.ContainerStateRunning)
-			}
-
-			if container.Spec.Stop {
-				stopRcd := newRunningContainerData(container)
-				stopRcd.updateFromInspectedContainer(inspected)
-				stopRcd.ensureStartupLogFiles(container, log)
-				if !inspected.StartedAt.IsZero() {
-					stopRcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
-				}
-
-				r.runningContainers.Store(container.NamespacedName(), stopRcd.containerID, stopRcd)
-				r.EnsureContainerWatchForResource(container.UID, log)
-				_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-
-				if inspected.Status == containers.ContainerStatusRunning ||
-					inspected.Status == containers.ContainerStatusPaused ||
-					inspected.Status == containers.ContainerStatusRestarting {
-					stopRcd.containerState = apiv1.ContainerStateStopping
-					return change | ensureContainerStoppingState(ctx, r, container, apiv1.ContainerStateStopping, stopRcd, log)
-				}
-
-				stopRcd.containerState = apiv1.ContainerStateExited
-				change |= stopRcd.applyTo(container, log)
-				r.disableEndpointsAndHealthProbes(ctx, container, stopRcd, log)
-				return change
 			}
 
 			if container.ShouldStart() {

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -300,12 +300,6 @@ func handleNewExecutable(
 	runInfo *ExecutableRunInfo,
 	log logr.Logger,
 ) objectChange {
-	if exe.Spec.Stop && exe.Status.State == apiv1.ExecutableStateEmpty && runInfo == nil {
-		log.Info("Executable.Stop property was set to true before Executable was started, marking Executable as 'failed to start'...")
-		r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		return statusChanged
-	}
-
 	if exe.Spec.Persistent {
 		leaseErr := r.acquirePersistentExecutableResourceLease(ctx, exe, log)
 		if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
@@ -317,8 +311,8 @@ func handleNewExecutable(
 		}
 	}
 
-	if !exe.ShouldStart() && exe.Status.State == apiv1.ExecutableStateEmpty && runInfo == nil {
-		if exe.Spec.Persistent {
+	if exe.Status.State == apiv1.ExecutableStateEmpty && runInfo == nil {
+		if exe.Spec.Persistent && (exe.Spec.Stop || !exe.ShouldStart()) {
 			adopted, adoptionChange := r.tryAdoptExistingPersistentExecutable(ctx, exe, log)
 			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
 			if adopted || adoptionChange != noChange {
@@ -326,9 +320,17 @@ func handleNewExecutable(
 			}
 		}
 
-		// We should wait to create an executable until the user clears Start = false
-		log.V(1).Info("Waiting for the executable to be started")
-		return noChange
+		if !exe.ShouldStart() {
+			// We should wait to create an executable until the user clears Start = false
+			log.V(1).Info("Waiting for the executable to be started")
+			return noChange
+		}
+
+		if exe.Spec.Stop {
+			log.Info("Executable.Stop property was set to true before Executable was started, marking Executable as 'failed to start'...")
+			r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+			return statusChanged
+		}
 	}
 
 	change := r.startExecutable(ctx, exe, runInfo, log)

--- a/controllers/executable_persistence.go
+++ b/controllers/executable_persistence.go
@@ -160,6 +160,10 @@ func (r *ExecutableReconciler) tryAdoptExistingPersistentExecutable(ctx context.
 		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
+	if exe.Spec.Stop {
+		return r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
+	}
+
 	ri := NewRunInfo(exe)
 	computed, environmentChange := r.computeExecutableEnvironment(ctx, exe, log, ri)
 	if !computed {
@@ -319,6 +323,32 @@ func (r *ExecutableReconciler) finishPersistentExecutableStopWithoutStart(exe *a
 	exe.Status.ExecutionID = ""
 	exe.Status.PID = apiv1.UnknownPID
 	return change | r.setExecutableState(exe, apiv1.ExecutableStateFinished)
+}
+
+func (r *ExecutableReconciler) stopPersistentExecutableRecordWithoutLifecycle(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) (bool, objectChange) {
+	resourceKey := exe.GetLeaseKey()
+	if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr == nil {
+		stopErr := r.stopPersistentExecutableRecord(ctx, exe, record, log)
+		if stopErr != nil {
+			log.Error(stopErr, "Could not stop persistent Executable process", "PID", record.PID)
+			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+		}
+	} else {
+		log.Info("Persistent Executable process record is no longer running",
+			"PID", record.PID,
+			"Error", findErr.Error())
+	}
+
+	stateStore, stateStoreErr := r.getStateStore()
+	if stateStoreErr != nil {
+		log.Error(stateStoreErr, "Could not open state store to delete persistent Executable process record", "ResourceKey", resourceKey)
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+	}
+	if deleteErr := stateStore.DeletePersistentProcess(ctx, resourceKey); deleteErr != nil {
+		log.Error(deleteErr, "Could not delete persistent Executable process record", "ResourceKey", resourceKey)
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+	}
+	return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
 }
 
 func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {

--- a/controllers/executable_persistence.go
+++ b/controllers/executable_persistence.go
@@ -232,6 +232,9 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 			log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", resourceKey)
 			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 		}
+		if exe.Spec.Stop {
+			return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
+		}
 		return false, noChange
 	}
 
@@ -247,6 +250,9 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 		if deleteErr := stateStore.DeletePersistentProcess(ctx, resourceKey); deleteErr != nil {
 			log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", resourceKey)
 			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+		}
+		if exe.Spec.Stop {
+			return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
 		}
 		return false, noChange
 	}
@@ -298,6 +304,21 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 
 	log.Info("Adopted persistent Executable process", "PID", record.PID, "RunID", runID)
 	return true, ri.ApplyTo(exe, log) | r.setExecutableState(exe, apiv1.ExecutableStateRunning)
+}
+
+func (r *ExecutableReconciler) finishPersistentExecutableStopWithoutStart(exe *apiv1.Executable, record *statestore.PersistentProcessRecord) objectChange {
+	change := noChange
+	if exe.Status.StdOutFile != record.StdOutFile {
+		exe.Status.StdOutFile = record.StdOutFile
+		change |= statusChanged
+	}
+	if exe.Status.StdErrFile != record.StdErrFile {
+		exe.Status.StdErrFile = record.StdErrFile
+		change |= statusChanged
+	}
+	exe.Status.ExecutionID = ""
+	exe.Status.PID = apiv1.UnknownPID
+	return change | r.setExecutableState(exe, apiv1.ExecutableStateFinished)
 }
 
 func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -753,6 +753,248 @@ func TestNoExistingPersistentContainerDelayStart(t *testing.T) {
 	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
 }
 
+func TestNoExistingPersistentContainerStopWithoutStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "no-existing-persistent-container-stop-without-start"
+	const imageName = testName + "-image"
+
+	shouldStart := false
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Persistent:    true,
+			Start:         &shouldStart,
+			Stop:          true,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Logf("Ensure Container '%s' is observed without failing to start...", ctr.ObjectMeta.Name)
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		require.NotEqual(t, apiv1.ContainerStateFailedToStart, c.Status.State, "Stop-only Container should not fail startup when no persistent container exists")
+		return len(c.Finalizers) > 0 && (c.Status.State == apiv1.ContainerStateEmpty || c.Status.State == apiv1.ContainerStatePending), nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{testName},
+	})
+	require.Error(t, err, "expected no container resource to be created")
+	require.Len(t, inspected, 0, "expected no container resource to be created")
+}
+
+func TestExistingPersistentContainerStopWithoutStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "existing-persistent-container-stop-without-start"
+	const imageName = testName + "-image"
+
+	shouldStart := false
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Persistent:    true,
+			Start:         &shouldStart,
+			Stop:          true,
+		},
+	}
+
+	lifecycleKey, _, hashErr := ctr.Spec.GetLifecycleKey()
+	require.NoError(t, hashErr, "expected no error when generating lifecycle key")
+
+	createSpec := ctr.Spec
+	createSpec.Labels = []apiv1.ContainerLabel{
+		{
+			Key:   "com.microsoft.developer.usvc-dev.build",
+			Value: "test",
+		},
+		{
+			Key:   "com.microsoft.developer.usvc-dev.lifecycle-key",
+			Value: lifecycleKey,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: createSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Log("Ensure container state is 'Exited'...")
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.State == apiv1.ContainerStateExited, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not inspect the container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
+}
+
+func TestExistingPersistentContainerStopWithStartAllowed(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "existing-persistent-container-stop-with-start-allowed"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Persistent:    true,
+			Stop:          true,
+		},
+	}
+
+	lifecycleKey, _, hashErr := ctr.Spec.GetLifecycleKey()
+	require.NoError(t, hashErr, "expected no error when generating lifecycle key")
+
+	createSpec := ctr.Spec
+	createSpec.Stop = false
+	createSpec.Labels = []apiv1.ContainerLabel{
+		{
+			Key:   "com.microsoft.developer.usvc-dev.build",
+			Value: "test",
+		},
+		{
+			Key:   "com.microsoft.developer.usvc-dev.lifecycle-key",
+			Value: lifecycleKey,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: createSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Log("Ensure container state is 'Exited'...")
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.State == apiv1.ContainerStateExited, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not inspect the container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
+}
+
+func TestExitedPersistentContainerStopWithoutStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "exited-persistent-container-stop-without-start"
+	const imageName = testName + "-image"
+
+	shouldStart := false
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Persistent:    true,
+			Start:         &shouldStart,
+			Stop:          true,
+		},
+	}
+
+	lifecycleKey, _, hashErr := ctr.Spec.GetLifecycleKey()
+	require.NoError(t, hashErr, "expected no error when generating lifecycle key")
+
+	createSpec := ctr.Spec
+	createSpec.Labels = []apiv1.ContainerLabel{
+		{
+			Key:   "com.microsoft.developer.usvc-dev.build",
+			Value: "test",
+		},
+		{
+			Key:   "com.microsoft.developer.usvc-dev.lifecycle-key",
+			Value: lifecycleKey,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: createSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	_, err = containerOrchestrator.StopContainers(ctx, containers.StopContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not stop container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Log("Ensure container state is 'Exited'...")
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.State == apiv1.ContainerStateExited, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not inspect the container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
+}
+
 func TestExistingPersistentContainerDelayStart(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -924,6 +924,78 @@ func TestExistingPersistentContainerStopWithStartAllowed(t *testing.T) {
 	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
 }
 
+func TestExistingPersistentContainerStopWithUnresolvedTemplate(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "existing-persistent-container-stop-with-unresolved-template"
+	const imageName = testName + "-image"
+
+	shouldStart := false
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Persistent:    true,
+			Start:         &shouldStart,
+			Stop:          true,
+			Env: []apiv1.EnvVar{
+				{
+					Name:  "MISSING_SERVICE_PORT",
+					Value: fmt.Sprintf(`{{- portFor "%s" -}}`, testName+"-missing-service"),
+				},
+			},
+		},
+	}
+
+	createSpec := ctr.Spec
+	createSpec.Start = nil
+	createSpec.Stop = false
+	createSpec.Env = nil
+	createSpec.Labels = []apiv1.ContainerLabel{
+		{
+			Key:   "com.microsoft.developer.usvc-dev.build",
+			Value: "test",
+		},
+		{
+			Key:   "com.microsoft.developer.usvc-dev.lifecycle-key",
+			Value: "unresolved-template-lifecycle-key",
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: createSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "Could not create a Container")
+
+	t.Log("Ensure container state is 'Exited'...")
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.State == apiv1.ContainerStateExited, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not inspect the container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusExited, inspected[0].Status, "expected the container to be in 'exited' state")
+}
+
 func TestExitedPersistentContainerStopWithoutStart(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -279,6 +279,56 @@ func TestStalePersistentExecutableStopWithStartAllowed(t *testing.T) {
 	require.ErrorIs(t, err, statestore.ErrPersistentProcessNotFound, "stale persistent process record should be deleted")
 }
 
+func TestStalePersistentExecutableStopWithUnresolvedTemplate(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "stale-persistent-executable-stop-with-unresolved-template"
+	shouldStart := false
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Persistent:     true,
+			Start:          &shouldStart,
+			Stop:           true,
+			Env: []apiv1.EnvVar{
+				{
+					Name:  "MISSING_SERVICE_PORT",
+					Value: fmt.Sprintf(`{{- portFor "%s" -}}`, testName+"-missing-service"),
+				},
+			},
+		},
+	}
+
+	err := testStateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      "stale-lifecycle-key",
+		PID:               process.Pid_t(99999997),
+		IdentityTime:      time.Now().Add(-time.Hour),
+		RunID:             "stale-run-with-unresolved-template",
+		StdOutFile:        "stale-with-unresolved-template.out",
+		StdErrFile:        "stale-with-unresolved-template.err",
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, err, "could not create stale persistent process record")
+
+	t.Logf("Creating persistent Executable '%s' with Start=false, Stop=true, and unresolved template inputs", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	t.Logf("Waiting for Executable '%s' to report Finished without resolving template inputs", exe.ObjectMeta.Name)
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateFinished && !currentExe.Status.FinishTimestamp.IsZero(), nil
+	})
+
+	_, err = testStateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
+	require.ErrorIs(t, err, statestore.ErrPersistentProcessNotFound, "stale persistent process record should be deleted")
+}
+
 // Ensure exit code of processes/run sessions are captured correctly
 func TestExecutableExitCodeCaptured(t *testing.T) {
 	type testcase struct {

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/microsoft/dcp/controllers"
 	"github.com/microsoft/dcp/internal/health"
 	"github.com/microsoft/dcp/internal/networking"
+	"github.com/microsoft/dcp/internal/statestore"
 	internal_testutil "github.com/microsoft/dcp/internal/testutil"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
 	"github.com/microsoft/dcp/pkg/commonapi"
@@ -154,6 +155,128 @@ func TestPersistentExecutableDelayStart(t *testing.T) {
 		return currentExe.Status.State == apiv1.ExecutableStateRunning || currentExe.Status.State == apiv1.ExecutableStateFinished, nil
 	})
 	waitResourceLeaseReleased(t, ctx, updatedExe)
+}
+
+func TestNoExistingPersistentExecutableStopWithoutStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "no-existing-persistent-executable-stop-without-start"
+	shouldStart := false
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Persistent:     true,
+			Start:          &shouldStart,
+			Stop:           true,
+		},
+	}
+
+	t.Logf("Creating persistent Executable '%s' with Start=false and Stop=true", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	t.Logf("Waiting for Executable '%s' to be observed without failing to start", exe.ObjectMeta.Name)
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		require.NotEqual(t, apiv1.ExecutableStateFailedToStart, currentExe.Status.State, "Stop-only Executable should not fail startup when no persistent process exists")
+		return len(currentExe.Finalizers) > 0 && currentExe.Status.State == apiv1.ExecutableStateEmpty, nil
+	})
+
+	startedProcesses := testProcessExecutor.FindAll([]string{exe.Spec.ExecutablePath}, "", nil)
+	require.Empty(t, startedProcesses, "persistent Executable with Start=false and Stop=true should not start a process")
+}
+
+func TestStalePersistentExecutableStopWithoutStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "stale-persistent-executable-stop-without-start"
+	shouldStart := false
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Persistent:     true,
+			Start:          &shouldStart,
+			Stop:           true,
+		},
+	}
+
+	err := testStateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      "stale-lifecycle-key",
+		PID:               process.Pid_t(99999999),
+		IdentityTime:      time.Now().Add(-time.Hour),
+		RunID:             "stale-run",
+		StdOutFile:        "stale.out",
+		StdErrFile:        "stale.err",
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, err, "could not create stale persistent process record")
+
+	t.Logf("Creating persistent Executable '%s' with Start=false and Stop=true", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	t.Logf("Waiting for Executable '%s' to report Finished for the stale persistent process record", exe.ObjectMeta.Name)
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateFinished && !currentExe.Status.FinishTimestamp.IsZero(), nil
+	})
+
+	_, err = testStateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
+	require.ErrorIs(t, err, statestore.ErrPersistentProcessNotFound, "stale persistent process record should be deleted")
+}
+
+func TestStalePersistentExecutableStopWithStartAllowed(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "stale-persistent-executable-stop-with-start-allowed"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Persistent:     true,
+			Stop:           true,
+		},
+	}
+
+	err := testStateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      "stale-lifecycle-key",
+		PID:               process.Pid_t(99999998),
+		IdentityTime:      time.Now().Add(-time.Hour),
+		RunID:             "stale-run-with-start",
+		StdOutFile:        "stale-with-start.out",
+		StdErrFile:        "stale-with-start.err",
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, err, "could not create stale persistent process record")
+
+	t.Logf("Creating persistent Executable '%s' with Stop=true", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	t.Logf("Waiting for Executable '%s' to report Finished for the stale persistent process record", exe.ObjectMeta.Name)
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateFinished && !currentExe.Status.FinishTimestamp.IsZero(), nil
+	})
+
+	startedProcesses := testProcessExecutor.FindAll([]string{exe.Spec.ExecutablePath}, "", nil)
+	require.Empty(t, startedProcesses, "Stop=true should not start a replacement process when a persistent process record already existed")
+
+	_, err = testStateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
+	require.ErrorIs(t, err, statestore.ErrPersistentProcessNotFound, "stale persistent process record should be deleted")
 }
 
 // Ensure exit code of processes/run sessions are captured correctly


### PR DESCRIPTION
Aspire stop mode can send a model to DCP when the AppHost is only running long enough to describe resources. In that path, DCP needs to stop existing persistent resources without creating replacement instances or reporting startup failure just because the desired model includes `stop: true`.

This change makes persistent containers and executables inspect existing actual-state before falling back to start/failed-start behavior. For existing persistent resources, `stop: true` is applied before resolving effective environment, invocation args, or default lifecycle keys. That lets stop-only models succeed even when templates reference non-persistent dependencies that Aspire intentionally does not start.

Existing persistent containers now stop consistently and report `Exited` whether `start` is true or false. Persistent executables now stop or clean up existing process records for `stop: true` before reporting failed startup, using `Finished` for stopped or stale existing process records. When no existing persistent actual-state is found and `start: false` prevents creation, DCP leaves the resource in the not-started path instead of creating a replacement or reporting `FailedToStart`.

Added integration coverage for stop-mode cases with no existing resource, existing running/exited containers, stale executable records with both start-disabled and start-allowed models, and unresolved-template stop models for existing persistent resources.

Validation:
- `make test-prereqs`
- targeted `go test -count=1 -parallel 32 ./test/integration -run 'TestExistingPersistentContainerStopWithUnresolvedTemplate|TestExistingPersistentContainerStopWithoutStart|TestExistingPersistentContainerStopWithStartAllowed|TestStalePersistentExecutableStopWithUnresolvedTemplate|TestStalePersistentExecutableStopWithoutStart|TestStalePersistentExecutableStopWithStartAllowed'`
- `make lint`
- `make test`