### PR TITLE
[release/0.25] Bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/dcp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
Backport of #186 to release/0.25

/cc @danegsta

## Customer Impact

## Testing

## Risk

## Regression?