### PR TITLE
Add lifecycle modes for persistent resources

### DIFF
--- a/api/v1/container_network_types.go
+++ b/api/v1/container_network_types.go
@@ -37,17 +37,52 @@ const (
 	ContainerNetworkStateNotFound ContainerNetworkState = "NotFound"
 )
 
+// +kubebuilder:validation:Enum=session;persistent;existing;cleanup
+type ContainerNetworkMode string
+
+const (
+	// ContainerNetworkModeSession creates the network with the ContainerNetwork resource and removes it when the resource is deleted.
+	ContainerNetworkModeSession ContainerNetworkMode = "session"
+	// ContainerNetworkModePersistent creates or reuses the network and leaves it running when the resource is deleted.
+	ContainerNetworkModePersistent ContainerNetworkMode = "persistent"
+	// ContainerNetworkModeExisting reuses an existing network but does not create or delete it.
+	ContainerNetworkModeExisting ContainerNetworkMode = "existing"
+	// ContainerNetworkModeCleanup reuses an existing network without creating it, then removes it when the resource is deleted.
+	ContainerNetworkModeCleanup ContainerNetworkMode = "cleanup"
+)
+
+var supportedContainerNetworkModes = []string{
+	string(ContainerNetworkModeSession),
+	string(ContainerNetworkModePersistent),
+	string(ContainerNetworkModeExisting),
+	string(ContainerNetworkModeCleanup),
+}
+
 // ContainerNetworkSpec defines the desired state of a ContainerNetwork
 // +k8s:openapi-gen=true
 type ContainerNetworkSpec struct {
 	// Name of the network (if omitted, a name is generated based on the resource name)
 	NetworkName string `json:"networkName,omitempty"`
 
-	// Shouild IPv6 be enabled for the network?
+	// Should IPv6 be enabled for the network?
 	IPv6 bool `json:"ipv6,omitempty"`
+
+	// Controls how the network is created, reused, and cleaned up.
+	// Ignored when persistent is true.
+	Mode ContainerNetworkMode `json:"mode,omitempty"`
 
 	// Should this network be created and persisted between DCP runs?
 	Persistent bool `json:"persistent,omitempty"`
+}
+
+func (cns ContainerNetworkSpec) EffectiveMode() ContainerNetworkMode {
+	if cns.Persistent {
+		return ContainerNetworkModePersistent
+	}
+	if cns.Mode == "" {
+		return ContainerNetworkModeSession
+	}
+	return cns.Mode
 }
 
 // ContainerNetworkStatus defines the current state of a ContainerNetwork
@@ -156,11 +191,34 @@ func (cn *ContainerNetwork) Validate(ctx context.Context) field.ErrorList {
 		errorList = append(errorList, field.Forbidden(nil, errResourceCreationProhibited.Error()))
 	}
 
-	if cn.Spec.Persistent && cn.Spec.NetworkName == "" {
-		errorList = append(errorList, field.Required(field.NewPath("spec", "networkName"), "networkName must be set to a value when persistent is true"))
+	if cn.Spec.Persistent {
+		if cn.Spec.NetworkName == "" {
+			errorList = append(errorList, field.Required(field.NewPath("spec", "networkName"), "networkName must be set to a value when persistent is true"))
+		}
+		return errorList
+	}
+
+	if cn.Spec.Mode != "" && !containerNetworkModeSupported(cn.Spec.Mode) {
+		errorList = append(errorList, field.NotSupported(field.NewPath("spec", "mode"), cn.Spec.Mode, supportedContainerNetworkModes))
+	}
+
+	if cn.Spec.EffectiveMode() != ContainerNetworkModeSession && cn.Spec.NetworkName == "" {
+		errorList = append(errorList, field.Required(field.NewPath("spec", "networkName"), "networkName must be set to a value when mode requires an existing or persistent network"))
 	}
 
 	return errorList
+}
+
+func containerNetworkModeSupported(mode ContainerNetworkMode) bool {
+	switch mode {
+	case ContainerNetworkModeSession,
+		ContainerNetworkModePersistent,
+		ContainerNetworkModeExisting,
+		ContainerNetworkModeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 func (cn *ContainerNetwork) ValidateUpdate(ctx context.Context, obj runtime.Object) field.ErrorList {
@@ -173,6 +231,10 @@ func (cn *ContainerNetwork) ValidateUpdate(ctx context.Context, obj runtime.Obje
 
 	if oldNetwork.Spec.IPv6 != cn.Spec.IPv6 {
 		errorList = append(errorList, field.Invalid(field.NewPath("spec", "ipv6"), cn.Spec.IPv6, "ipv6 is immutable"))
+	}
+
+	if oldNetwork.Spec.EffectiveMode() != cn.Spec.EffectiveMode() {
+		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "mode"), "mode cannot be changed"))
 	}
 
 	// Make sure Persistent isn't changed after the network is created

--- a/api/v1/container_types.go
+++ b/api/v1/container_types.go
@@ -62,6 +62,27 @@ const (
 	RestartPolicyAlways ContainerRestartPolicy = "always"
 )
 
+// +kubebuilder:validation:Enum=session;persistent;existing;cleanup
+type ContainerMode string
+
+const (
+	// ContainerModeSession creates the container with the Container resource and removes it when the resource is deleted.
+	ContainerModeSession ContainerMode = "session"
+	// ContainerModePersistent creates or reuses the container and leaves it running when the resource is deleted.
+	ContainerModePersistent ContainerMode = "persistent"
+	// ContainerModeExisting reuses an existing container but does not create or delete it.
+	ContainerModeExisting ContainerMode = "existing"
+	// ContainerModeCleanup reuses an existing container without creating it, then removes it when the resource is deleted.
+	ContainerModeCleanup ContainerMode = "cleanup"
+)
+
+var supportedContainerModes = []string{
+	string(ContainerModeSession),
+	string(ContainerModePersistent),
+	string(ContainerModeExisting),
+	string(ContainerModeCleanup),
+}
+
 type VolumeMountType string
 
 const (
@@ -650,11 +671,15 @@ type ContainerSpec struct {
 	// +listType=atomic
 	Networks *[]ContainerNetworkConnectionConfig `json:"networks,omitempty"`
 
+	// Controls how the container is created, reused, and cleaned up.
+	// Ignored when persistent is true.
+	Mode ContainerMode `json:"mode,omitempty"`
+
 	// Should this container be created and persisted between DCP runs?
 	Persistent bool `json:"persistent,omitempty"`
 
 	// Optional parent process PID used to scope persistent Container cleanup to a process lifecycle.
-	// When set, MonitorTimestamp must also be set and Persistent must be true.
+	// When set, MonitorTimestamp must also be set and the effective mode must be persistent.
 	// +optional
 	MonitorPID *int64 `json:"monitorPid,omitempty"`
 
@@ -702,6 +727,28 @@ type ContainerSpec struct {
 	// instead of the container being run detached with separate log capture.
 	// +optional
 	Terminal *TerminalSpec `json:"terminal,omitempty"`
+}
+
+func (cs ContainerSpec) EffectiveMode() ContainerMode {
+	if cs.Persistent {
+		return ContainerModePersistent
+	}
+	if cs.Mode == "" {
+		return ContainerModeSession
+	}
+	return cs.Mode
+}
+
+func containerModeSupported(mode ContainerMode) bool {
+	switch mode {
+	case ContainerModeSession,
+		ContainerModePersistent,
+		ContainerModeExisting,
+		ContainerModeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 func (cs *ContainerSpec) Equal(other *ContainerSpec) bool {
@@ -772,6 +819,10 @@ func (cs *ContainerSpec) Equal(other *ContainerSpec) bool {
 			return cncc1.Equal(&cncc2)
 		})
 	}) {
+		return false
+	}
+
+	if cs.Mode != other.Mode {
 		return false
 	}
 
@@ -1300,32 +1351,47 @@ func (c *Container) Validate(ctx context.Context) field.ErrorList {
 		errorList = append(errorList, field.Invalid(field.NewPath("spec", "containerName"), c.Spec.ContainerName, fmt.Sprintf("containerName must match regex '%s'", validContainerName)))
 	}
 
-	if c.Spec.Persistent && c.Spec.ContainerName == "" {
-		errorList = append(errorList, field.Required(field.NewPath("spec", "containerName"), "containerName must be set to a value when persistent is true"))
+	specPath := field.NewPath("spec")
+	if !c.Spec.Persistent && c.Spec.Mode != "" && !containerModeSupported(c.Spec.Mode) {
+		errorList = append(errorList, field.NotSupported(specPath.Child("mode"), c.Spec.Mode, supportedContainerModes))
 	}
 
-	if c.Spec.Persistent && c.Spec.Terminal != nil {
-		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "terminal"), "Persistent Containers cannot use a terminal."))
+	effectiveMode := c.Spec.EffectiveMode()
+	if effectiveMode != ContainerModeSession {
+		if c.Spec.ContainerName == "" {
+			message := "containerName must be set to a value when mode requires an existing or persistent container"
+			if c.Spec.Persistent {
+				message = "containerName must be set to a value when persistent is true"
+			}
+			errorList = append(errorList, field.Required(specPath.Child("containerName"), message))
+		}
+		if c.Spec.Terminal != nil {
+			message := "Container modes that reuse existing containers cannot use a terminal."
+			if c.Spec.Persistent {
+				message = "Persistent Containers cannot use a terminal."
+			}
+			errorList = append(errorList, field.Forbidden(specPath.Child("terminal"), message))
+		}
 	}
 
 	monitorTimestampSet := !c.Spec.MonitorTimestamp.IsZero()
 	if c.Spec.MonitorPID != nil && *c.Spec.MonitorPID <= 0 {
-		errorList = append(errorList, field.Invalid(field.NewPath("spec", "monitorPid"), *c.Spec.MonitorPID, "monitorPid must be positive"))
+		errorList = append(errorList, field.Invalid(specPath.Child("monitorPid"), *c.Spec.MonitorPID, "monitorPid must be positive"))
 	}
-	if !c.Spec.Persistent && c.Spec.MonitorPID != nil {
-		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "monitorPid"), "monitorPid can only be set when persistent is true"))
+	if effectiveMode != ContainerModePersistent && c.Spec.MonitorPID != nil {
+		errorList = append(errorList, field.Forbidden(specPath.Child("monitorPid"), "monitorPid can only be set for persistent containers"))
 	}
-	if !c.Spec.Persistent && monitorTimestampSet {
-		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "monitorTimestamp"), "monitorTimestamp can only be set when persistent is true"))
+	if effectiveMode != ContainerModePersistent && monitorTimestampSet {
+		errorList = append(errorList, field.Forbidden(specPath.Child("monitorTimestamp"), "monitorTimestamp can only be set for persistent containers"))
 	}
 	if c.Spec.MonitorPID != nil && !monitorTimestampSet {
-		errorList = append(errorList, field.Required(field.NewPath("spec", "monitorTimestamp"), "monitorTimestamp must be set when monitorPid is set"))
+		errorList = append(errorList, field.Required(specPath.Child("monitorTimestamp"), "monitorTimestamp must be set when monitorPid is set"))
 	}
 	if c.Spec.MonitorPID == nil && monitorTimestampSet {
-		errorList = append(errorList, field.Required(field.NewPath("spec", "monitorPid"), "monitorPid must be set when monitorTimestamp is set"))
+		errorList = append(errorList, field.Required(specPath.Child("monitorPid"), "monitorPid must be set when monitorTimestamp is set"))
 	}
 
-	healthProbesPath := field.NewPath("spec", "healthProbes")
+	healthProbesPath := specPath.Child("healthProbes")
 	for i, probe := range c.Spec.HealthProbes {
 		errorList = append(errorList, probe.Validate(healthProbesPath.Index(i))...)
 	}
@@ -1415,6 +1481,10 @@ func (c *Container) ValidateUpdate(ctx context.Context, obj runtime.Object) fiel
 	// Make sure Persistent isn't changed after the container is created
 	if oldContainer.Spec.Persistent != c.Spec.Persistent {
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "persistent"), "persistent cannot be changed"))
+	}
+
+	if oldContainer.Spec.EffectiveMode() != c.Spec.EffectiveMode() {
+		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "mode"), "mode cannot be changed"))
 	}
 
 	if !pointers.EqualValue(oldContainer.Spec.MonitorPID, c.Spec.MonitorPID) {

--- a/api/v1/container_types.go
+++ b/api/v1/container_types.go
@@ -83,6 +83,37 @@ var supportedContainerModes = []string{
 	string(ContainerModeCleanup),
 }
 
+func (mode ContainerMode) ShouldReuseExisting() bool {
+	switch mode {
+	case ContainerModePersistent,
+		ContainerModeExisting,
+		ContainerModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mode ContainerMode) ShouldCreateIfMissing() bool {
+	switch mode {
+	case ContainerModeSession,
+		ContainerModePersistent:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mode ContainerMode) ShouldDeleteContainer() bool {
+	switch mode {
+	case ContainerModeSession,
+		ContainerModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
 type VolumeMountType string
 
 const (

--- a/api/v1/container_types.go
+++ b/api/v1/container_types.go
@@ -1143,6 +1143,9 @@ const (
 	// Container is in the process of starting
 	ContainerStateStarting ContainerState = "Starting"
 
+	// ContainerStateNotFound indicates the Container is waiting for an existing container that does not exist.
+	ContainerStateNotFound ContainerState = "NotFound"
+
 	// A start attempt was made, but it failed
 	ContainerStateFailedToStart ContainerState = "FailedToStart"
 

--- a/api/v1/container_types.go
+++ b/api/v1/container_types.go
@@ -1296,7 +1296,9 @@ func (c *Container) Validate(ctx context.Context) field.ErrorList {
 		errorList = append(errorList, field.Forbidden(nil, errResourceCreationProhibited.Error()))
 	}
 
-	if c.Spec.Build == nil && c.Spec.Image == "" {
+	effectiveMode := c.Spec.EffectiveMode()
+	requiresContainerImage := effectiveMode == ContainerModeSession || effectiveMode == ContainerModePersistent
+	if requiresContainerImage && c.Spec.Build == nil && c.Spec.Image == "" {
 		errorList = append(errorList, field.Required(field.NewPath("spec", "image"), "image must be set to a non-empty value"))
 	}
 
@@ -1356,7 +1358,6 @@ func (c *Container) Validate(ctx context.Context) field.ErrorList {
 		errorList = append(errorList, field.NotSupported(specPath.Child("mode"), c.Spec.Mode, supportedContainerModes))
 	}
 
-	effectiveMode := c.Spec.EffectiveMode()
 	if effectiveMode != ContainerModeSession {
 		if c.Spec.ContainerName == "" {
 			message := "containerName must be set to a value when mode requires an existing or persistent container"

--- a/api/v1/container_types_test.go
+++ b/api/v1/container_types_test.go
@@ -205,6 +205,76 @@ func TestContainerValidateTerminalPersistentCombination(t *testing.T) {
 	}
 }
 
+func TestContainerValidateImageOnlyRequiredForCreationModes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		spec        ContainerSpec
+		expectError bool
+	}{
+		{
+			name:        "session mode requires image or build",
+			spec:        ContainerSpec{},
+			expectError: true,
+		},
+		{
+			name: "persistent mode requires image or build",
+			spec: ContainerSpec{
+				ContainerName: "api",
+				Mode:          ContainerModePersistent,
+			},
+			expectError: true,
+		},
+		{
+			name: "persistent override requires image or build",
+			spec: ContainerSpec{
+				ContainerName: "api",
+				Persistent:    true,
+			},
+			expectError: true,
+		},
+		{
+			name: "existing mode does not require image or build",
+			spec: ContainerSpec{
+				ContainerName: "api",
+				Mode:          ContainerModeExisting,
+			},
+		},
+		{
+			name: "cleanup mode does not require image or build",
+			spec: ContainerSpec{
+				ContainerName: "api",
+				Mode:          ContainerModeCleanup,
+			},
+		},
+		{
+			name: "cleanup mode still validates explicit build",
+			spec: ContainerSpec{
+				ContainerName: "api",
+				Mode:          ContainerModeCleanup,
+				Build:         &ContainerBuildContext{},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			container := &Container{Spec: testCase.spec}
+			errors := container.Validate(nil)
+
+			if testCase.expectError {
+				require.NotEmpty(t, errors)
+			} else {
+				require.Empty(t, errors)
+			}
+		})
+	}
+}
+
 func TestImageLayerValidate(t *testing.T) {
 	t.Parallel()
 

--- a/api/v1/executable_types.go
+++ b/api/v1/executable_types.go
@@ -51,6 +51,9 @@ const (
 	// The Executable was successfully started and was running last time we checked.
 	ExecutableStateRunning ExecutableState = "Running"
 
+	// ExecutableStateNotFound indicates the Executable is waiting for an existing process record that does not exist.
+	ExecutableStateNotFound ExecutableState = "NotFound"
+
 	// Executable is stopping (DCP is trying to stop the process)
 	ExecutableStateStopping ExecutableState = "Stopping"
 
@@ -79,6 +82,13 @@ func (es ExecutableState) CanUpdateTo(newState ExecutableState) bool {
 
 	switch {
 	case es == ExecutableStateEmpty:
+		return newState == ExecutableStateStarting ||
+			newState == ExecutableStateRunning ||
+			newState == ExecutableStateNotFound ||
+			newState == ExecutableStateTerminated ||
+			newState == ExecutableStateFailedToStart
+
+	case es == ExecutableStateNotFound:
 		return newState == ExecutableStateStarting ||
 			newState == ExecutableStateRunning ||
 			newState == ExecutableStateTerminated ||

--- a/api/v1/executable_types.go
+++ b/api/v1/executable_types.go
@@ -68,14 +68,12 @@ const (
 
 	// Unknown means we are not tracking the actual-state counterpart of the Executable (process or IDE run session).
 	// As a result, we do not know whether it already finished, and what is the exit code, if any.
-	// This can happen if a controller launches a process and then terminates.
-	// When a new controller instance comes online, it may see non-zero ExecutionID Status,
-	// but it does not track the corresponding process or IDE session.
+	// Non-persistent processes are also guarded by a monitor process so they are stopped if DCP exits unexpectedly.
 	ExecutableStateUnknown ExecutableState = "Unknown"
 )
 
 func (es ExecutableState) CanUpdateTo(newState ExecutableState) bool {
-	// We live in imperfect world, and losing track of Executable state is always a possibility.
+	// Unknown is an error fallback for paths that cannot determine the Executable's actual state.
 	if newState == ExecutableStateUnknown {
 		return true
 	}
@@ -160,6 +158,36 @@ var supportedExecutableModes = []string{
 	string(ExecutableModeSession),
 	string(ExecutableModePersistent),
 	string(ExecutableModeCleanup),
+}
+
+func (mode ExecutableMode) ShouldReuseExisting() bool {
+	switch mode {
+	case ExecutableModePersistent,
+		ExecutableModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mode ExecutableMode) ShouldCreateIfMissing() bool {
+	switch mode {
+	case ExecutableModeSession,
+		ExecutableModePersistent:
+		return true
+	default:
+		return false
+	}
+}
+
+func (mode ExecutableMode) ShouldStopProcessOnDelete() bool {
+	switch mode {
+	case ExecutableModeSession,
+		ExecutableModeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 type EnvironmentBehavior string

--- a/api/v1/executable_types.go
+++ b/api/v1/executable_types.go
@@ -134,6 +134,24 @@ func (et ExecutionType) IsValidOrDefault() bool {
 	return et == "" || et.IsValid()
 }
 
+// +kubebuilder:validation:Enum=session;persistent;cleanup
+type ExecutableMode string
+
+const (
+	// ExecutableModeSession creates the process with the Executable resource and stops it when the resource is deleted.
+	ExecutableModeSession ExecutableMode = "session"
+	// ExecutableModePersistent creates or reuses the process and leaves it running when the resource is deleted.
+	ExecutableModePersistent ExecutableMode = "persistent"
+	// ExecutableModeCleanup reuses an existing process without creating it, then stops it when the resource is deleted.
+	ExecutableModeCleanup ExecutableMode = "cleanup"
+)
+
+var supportedExecutableModes = []string{
+	string(ExecutableModeSession),
+	string(ExecutableModePersistent),
+	string(ExecutableModeCleanup),
+}
+
 type EnvironmentBehavior string
 
 const (
@@ -268,6 +286,10 @@ type ExecutableSpec struct {
 	// +kubebuilder:default:=false
 	Stop bool `json:"stop,omitempty"`
 
+	// Controls how the Executable process is created, reused, and cleaned up.
+	// Ignored when persistent is true.
+	Mode ExecutableMode `json:"mode,omitempty"`
+
 	// Should this Executable be created and persisted between DCP runs?
 	Persistent bool `json:"persistent,omitempty"`
 
@@ -276,7 +298,7 @@ type ExecutableSpec struct {
 	LifecycleKey string `json:"lifecycleKey,omitempty"`
 
 	// Optional parent process PID used to scope persistent Executable cleanup to a process lifecycle.
-	// When set, MonitorTimestamp must also be set and Persistent must be true.
+	// When set, MonitorTimestamp must also be set and the effective mode must be persistent.
 	// +optional
 	MonitorPID *int64 `json:"monitorPid,omitempty"`
 
@@ -300,6 +322,27 @@ type ExecutableSpec struct {
 	// and API requests to fetch logs will fail.
 	// +optional
 	Terminal *TerminalSpec `json:"terminal,omitempty"`
+}
+
+func (es ExecutableSpec) EffectiveMode() ExecutableMode {
+	if es.Persistent {
+		return ExecutableModePersistent
+	}
+	if es.Mode == "" {
+		return ExecutableModeSession
+	}
+	return es.Mode
+}
+
+func executableModeSupported(mode ExecutableMode) bool {
+	switch mode {
+	case ExecutableModeSession,
+		ExecutableModePersistent,
+		ExecutableModeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 func (es ExecutableSpec) Equal(other ExecutableSpec) bool {
@@ -340,6 +383,10 @@ func (es ExecutableSpec) Equal(other ExecutableSpec) bool {
 	}
 
 	if es.Stop != other.Stop {
+		return false
+	}
+
+	if es.Mode != other.Mode {
 		return false
 	}
 
@@ -580,29 +627,51 @@ func (es ExecutableSpec) Validate(specPath *field.Path) field.ErrorList {
 		errorList = append(errorList, field.Invalid(specPath.Child("ambientEnvironment", "behavior"), es.AmbientEnvironment.Behavior, "Ambient environment behavior must be either Inherit or DoNotInherit."))
 	}
 
+	if !es.Persistent && es.Mode != "" && !executableModeSupported(es.Mode) {
+		errorList = append(errorList, field.NotSupported(specPath.Child("mode"), es.Mode, supportedExecutableModes))
+	}
+
+	effectiveMode := es.EffectiveMode()
+	reusesExisting := effectiveMode != ExecutableModeSession
 	effectiveExecutionType := es.ExecutionType
 	if effectiveExecutionType == "" {
 		effectiveExecutionType = ExecutionTypeProcess
 	}
-	if es.Persistent && effectiveExecutionType != ExecutionTypeProcess {
-		errorList = append(errorList, field.Invalid(specPath.Child("persistent"), es.Persistent, "Persistent Executables only support Process execution type."))
+	if reusesExisting && effectiveExecutionType != ExecutionTypeProcess {
+		message := "Executable modes that reuse existing processes only support Process execution type."
+		path := specPath.Child("mode")
+		value := any(es.Mode)
+		if es.Persistent {
+			message = "Persistent Executables only support Process execution type."
+			path = specPath.Child("persistent")
+			value = es.Persistent
+		}
+		errorList = append(errorList, field.Invalid(path, value, message))
 	}
-	if es.Persistent && len(es.FallbackExecutionTypes) > 0 {
-		errorList = append(errorList, field.Invalid(specPath.Child("fallbackExecutionTypes"), es.FallbackExecutionTypes, "Persistent Executables cannot use fallback execution types."))
+	if reusesExisting && len(es.FallbackExecutionTypes) > 0 {
+		message := "Executable modes that reuse existing processes cannot use fallback execution types."
+		if es.Persistent {
+			message = "Persistent Executables cannot use fallback execution types."
+		}
+		errorList = append(errorList, field.Invalid(specPath.Child("fallbackExecutionTypes"), es.FallbackExecutionTypes, message))
 	}
-	if es.Persistent && es.Terminal != nil {
-		errorList = append(errorList, field.Forbidden(specPath.Child("terminal"), "Persistent Executables cannot use a terminal."))
+	if reusesExisting && es.Terminal != nil {
+		message := "Executable modes that reuse existing processes cannot use a terminal."
+		if es.Persistent {
+			message = "Persistent Executables cannot use a terminal."
+		}
+		errorList = append(errorList, field.Forbidden(specPath.Child("terminal"), message))
 	}
 
 	monitorTimestampSet := !es.MonitorTimestamp.IsZero()
 	if es.MonitorPID != nil && *es.MonitorPID <= 0 {
 		errorList = append(errorList, field.Invalid(specPath.Child("monitorPid"), *es.MonitorPID, "monitorPid must be positive"))
 	}
-	if !es.Persistent && es.MonitorPID != nil {
-		errorList = append(errorList, field.Forbidden(specPath.Child("monitorPid"), "monitorPid can only be set when persistent is true"))
+	if effectiveMode != ExecutableModePersistent && es.MonitorPID != nil {
+		errorList = append(errorList, field.Forbidden(specPath.Child("monitorPid"), "monitorPid can only be set for persistent executables"))
 	}
-	if !es.Persistent && monitorTimestampSet {
-		errorList = append(errorList, field.Forbidden(specPath.Child("monitorTimestamp"), "monitorTimestamp can only be set when persistent is true"))
+	if effectiveMode != ExecutableModePersistent && monitorTimestampSet {
+		errorList = append(errorList, field.Forbidden(specPath.Child("monitorTimestamp"), "monitorTimestamp can only be set for persistent executables"))
 	}
 	if es.MonitorPID != nil && !monitorTimestampSet {
 		errorList = append(errorList, field.Required(specPath.Child("monitorTimestamp"), "monitorTimestamp must be set when monitorPid is set"))
@@ -803,6 +872,10 @@ func (e *Executable) ValidateUpdate(ctx context.Context, obj runtime.Object) fie
 
 	if oldExe.Spec.Persistent != e.Spec.Persistent {
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "persistent"), "persistent cannot be changed"))
+	}
+
+	if oldExe.Spec.EffectiveMode() != e.Spec.EffectiveMode() {
+		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "mode"), "mode cannot be changed"))
 	}
 
 	if !pointers.EqualValue(oldExe.Spec.MonitorPID, e.Spec.MonitorPID) {

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -301,19 +301,13 @@ func (r *ContainerReconciler) handleDeletionRequest(ctx context.Context, contain
 	switch {
 	case rcd == nil:
 		log.V(1).Info("Container is being deleted (deleting finalizer only)...")
-		if shouldDeleteContainer(container.Spec.EffectiveMode()) && container.Status.ContainerID != "" {
-			r.cleanupDcpContainerResources(ctx, container, log)
-			r.removeContainerNetworkConnections(ctx, container, log)
-			_ = r.removeExistingContainer(ctx, containerID(container.Status.ContainerID), nil, log)
-			logger.ReleaseResourceLog(container.GetResourceId())
-		}
 		change = deleteFinalizer(container, containerFinalizer, log)
 
 	case rcd.containerState == apiv1.ContainerStateBuilding || rcd.containerState == apiv1.ContainerStateStarting || rcd.containerState == apiv1.ContainerStateStopping:
 		log.V(1).Info("Container is being deleted, waiting for it to exit transient state...", "CurrentState", rcd.containerState)
 		change = r.manageContainer(ctx, container, log)
 
-	case (rcd.containerState == apiv1.ContainerStateRunning || rcd.containerState == apiv1.ContainerStatePaused) && shouldDeleteContainer(container.Spec.EffectiveMode()):
+	case (rcd.containerState == apiv1.ContainerStateRunning || rcd.containerState == apiv1.ContainerStatePaused) && container.Spec.EffectiveMode().ShouldDeleteContainer():
 		log.V(1).Info("Container is being deleted, but it needs to be stopped first...", "CurrentState", rcd.containerState)
 		rcd.containerState = apiv1.ContainerStateStopping
 		stoppingInitializer := getStateInitializer(containerStateInitializers, apiv1.ContainerStateStopping, log)
@@ -362,7 +356,7 @@ func handleNewContainer(
 
 	}
 
-	if shouldReuseExisting(effectiveMode) {
+	if effectiveMode.ShouldReuseExisting() {
 		// Check for an existing container
 		inspected, inspectedErr := inspectContainerIfExists(ctx, r.orchestrator, container.Spec.ContainerName)
 		if inspectedErr != nil && !errors.Is(inspectedErr, containers.ErrNotFound) {
@@ -401,7 +395,7 @@ func handleNewContainer(
 			// Produce a candidate RCD; this will only be persisted if we find an existing valid container.
 			rcd := newRunningContainerData(container)
 
-			if shouldCreateIfMissing(effectiveMode) {
+			if effectiveMode.ShouldCreateIfMissing() {
 				// We compute the effective environment and invocation args here because we need them
 				// to generate a stable lifecycle key.
 				envErr := r.computeEffectiveEnvironment(ctx, container, rcd, log)
@@ -458,7 +452,7 @@ func handleNewContainer(
 				return change | r.adoptExistingContainer(ctx, container, rcd, inspected, log)
 			}
 
-			if container.ShouldStart() && shouldCreateIfMissing(effectiveMode) {
+			if container.ShouldStart() && effectiveMode.ShouldCreateIfMissing() {
 				log.V(1).Info("Removing existing container")
 				if removeErr := r.removeExistingContainer(ctx, containerID(inspected.Id), inspected, log); removeErr != nil {
 					log.Error(removeErr, "Could not remove existing container")
@@ -468,9 +462,9 @@ func handleNewContainer(
 		}
 	}
 
-	if !shouldCreateIfMissing(effectiveMode) {
+	if !effectiveMode.ShouldCreateIfMissing() {
 		_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-		return change | r.setContainerState(container, apiv1.ContainerStateNotFound)
+		return change | r.setContainerState(container, apiv1.ContainerStateNotFound) | additionalReconciliationNeeded
 	}
 
 	if !container.ShouldStart() {
@@ -504,6 +498,7 @@ func (r *ContainerReconciler) adoptExistingContainer(
 	log.Info("Found existing Container")
 
 	rcd.updateFromInspectedContainer(inspected)
+	r.runContainerLifecycleMonitor(rcd, log)
 
 	rcd.ensureStartupLogFiles(container, log)
 	rcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
@@ -1282,6 +1277,7 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 
 			log.V(1).Info("Container created")
 			rcd.updateFromInspectedContainer(inspected)
+			r.runContainerLifecycleMonitor(rcd, log)
 
 			// Copy any general files specified in the container spec to the container's filesystem
 			fileModTime := time.Now()
@@ -1793,7 +1789,6 @@ func (r *ContainerReconciler) finishCreatedContainerStartup(
 			log.V(1).Info("Container started and exited shortly after", "ContainerStatus", startedContainer.Status)
 			rcd.containerState = apiv1.ContainerStateExited
 		}
-		r.runPersistentContainerLifecycleMonitor(rcd, log)
 		return nil
 	}
 
@@ -1851,7 +1846,7 @@ func (r *ContainerReconciler) deleteContainer(ctx context.Context, container *ap
 	defer rcd.deleteStartupLogFiles(log)
 	defer rcd.closeTerminalResources(r.config.ProcessExecutor, log)
 
-	if !shouldDeleteContainer(container.Spec.EffectiveMode()) {
+	if !container.Spec.EffectiveMode().ShouldDeleteContainer() {
 		log.V(1).Info("Container is being deleted, leaving underlying resources")
 		return
 	}
@@ -2069,36 +2064,51 @@ func (r *ContainerReconciler) handleInitialNetworkConnections(
 			return nil, attachErr
 		}
 	}
-	r.runPersistentContainerLifecycleMonitor(rcd, log)
+	if inspected != nil {
+		rcd.updateFromInspectedContainer(inspected)
+	}
 
 	return inspected, nil
 }
 
-func (r *ContainerReconciler) runPersistentContainerLifecycleMonitor(rcd *runningContainerData, log logr.Logger) {
-	if rcd == nil || rcd.runSpec == nil || rcd.runSpec.EffectiveMode() != apiv1.ContainerModePersistent {
+func (r *ContainerReconciler) runContainerLifecycleMonitor(rcd *runningContainerData, log logr.Logger) {
+	if rcd == nil || rcd.runSpec == nil || !rcd.hasValidContainerID() {
 		return
 	}
 
-	monitor, found, monitorErr := dcpproc.MonitorTargetFromFields(rcd.runSpec.MonitorPID, rcd.runSpec.MonitorTimestamp)
-	if monitorErr != nil {
-		log.Error(monitorErr, "Could not start persistent Container lifecycle monitor")
-		return
-	}
-	if !found {
-		return
-	}
-	if r.config.ProcessExecutor == nil {
-		log.Error(fmt.Errorf("process executor is not configured"), "Could not start persistent Container lifecycle monitor")
-		return
-	}
+	effectiveMode := rcd.runSpec.EffectiveMode()
+	switch {
+	case effectiveMode.ShouldDeleteContainer():
+		if r.config.ProcessExecutor == nil {
+			log.Error(fmt.Errorf("process executor is not configured"), "Could not start Container cleanup monitor")
+			return
+		}
+		dcpproc.RunContainerWatcher(r.config.ProcessExecutor, string(rcd.containerID), log)
 
-	dcpproc.RunContainerWatcherForMonitorWithOptions(
-		r.config.ProcessExecutor,
-		monitor,
-		string(rcd.containerID),
-		dcpproc.ContainerWatcherOptions{StopOnly: true},
-		log,
-	)
+	case effectiveMode == apiv1.ContainerModePersistent:
+		monitor, found, monitorErr := dcpproc.MonitorTargetFromFields(rcd.runSpec.MonitorPID, rcd.runSpec.MonitorTimestamp)
+		if monitorErr != nil {
+			log.Error(monitorErr, "Could not start persistent Container lifecycle monitor")
+			return
+		}
+		if !found {
+			return
+		}
+		if r.config.ProcessExecutor == nil {
+			log.Error(fmt.Errorf("process executor is not configured"), "Could not start persistent Container lifecycle monitor")
+			return
+		}
+		dcpproc.RunContainerWatcherForMonitorWithOptions(
+			r.config.ProcessExecutor,
+			monitor,
+			string(rcd.containerID),
+			dcpproc.ContainerWatcherOptions{StopOnly: true},
+			log,
+		)
+
+	default:
+		return
+	}
 }
 
 // Connects the Container to networks as necessary, updating status.
@@ -2141,7 +2151,7 @@ func (r *ContainerReconciler) removeContainerNetworkConnections(
 	container *apiv1.Container,
 	log logr.Logger,
 ) {
-	if !shouldDeleteContainer(container.Spec.EffectiveMode()) {
+	if !container.Spec.EffectiveMode().ShouldDeleteContainer() {
 		return
 	}
 
@@ -2492,37 +2502,6 @@ func persistentContainerLeaseReleaseState(state apiv1.ContainerState) bool {
 		apiv1.ContainerStatePaused,
 		apiv1.ContainerStateExited,
 		apiv1.ContainerStateUnknown:
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldReuseExisting(mode apiv1.ContainerMode) bool {
-	switch mode {
-	case apiv1.ContainerModePersistent,
-		apiv1.ContainerModeExisting,
-		apiv1.ContainerModeCleanup:
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldCreateIfMissing(mode apiv1.ContainerMode) bool {
-	switch mode {
-	case apiv1.ContainerModeSession,
-		apiv1.ContainerModePersistent:
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldDeleteContainer(mode apiv1.ContainerMode) bool {
-	switch mode {
-	case apiv1.ContainerModeSession,
-		apiv1.ContainerModeCleanup:
 		return true
 	default:
 		return false

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -300,6 +300,11 @@ func (r *ContainerReconciler) handleDeletionRequest(ctx context.Context, contain
 
 	switch {
 	case rcd == nil:
+		if container.Spec.EffectiveMode() == apiv1.ContainerModeCleanup && container.Status.State != apiv1.ContainerStateNotFound {
+			log.V(1).Info("Container is being deleted, resolving cleanup target before deleting finalizer")
+			return handleNewContainer(ctx, r, container, apiv1.ContainerStateEmpty, nil, log) | additionalReconciliationNeeded
+		}
+
 		log.V(1).Info("Container is being deleted (deleting finalizer only)...")
 		change = deleteFinalizer(container, containerFinalizer, log)
 
@@ -1277,7 +1282,9 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 
 			log.V(1).Info("Container created")
 			rcd.updateFromInspectedContainer(inspected)
-			r.runContainerLifecycleMonitor(rcd, log)
+			if rcd.runSpec.EffectiveMode() != apiv1.ContainerModePersistent {
+				r.runContainerLifecycleMonitor(rcd, log)
+			}
 
 			// Copy any general files specified in the container spec to the container's filesystem
 			fileModTime := time.Now()
@@ -1296,6 +1303,9 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 			finishErr := r.finishCreatedContainerStartup(startupCtx, container, containerName, rcd, inspected, streamOptions, startupStdoutWriter, startupStderrWriter, log)
 			if finishErr != nil {
 				return finishErr
+			}
+			if rcd.runSpec.EffectiveMode() == apiv1.ContainerModePersistent {
+				r.runContainerLifecycleMonitor(rcd, log)
 			}
 
 			return nil

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -300,13 +300,19 @@ func (r *ContainerReconciler) handleDeletionRequest(ctx context.Context, contain
 	switch {
 	case rcd == nil:
 		log.V(1).Info("Container is being deleted (deleting finalizer only)...")
+		if shouldDeleteContainer(container.Spec.EffectiveMode()) && container.Status.ContainerID != "" {
+			r.cleanupDcpContainerResources(ctx, container, log)
+			r.removeContainerNetworkConnections(ctx, container, log)
+			_ = r.removeExistingContainer(ctx, containerID(container.Status.ContainerID), nil, log)
+			logger.ReleaseResourceLog(container.GetResourceId())
+		}
 		change = deleteFinalizer(container, containerFinalizer, log)
 
 	case rcd.containerState == apiv1.ContainerStateBuilding || rcd.containerState == apiv1.ContainerStateStarting || rcd.containerState == apiv1.ContainerStateStopping:
 		log.V(1).Info("Container is being deleted, waiting for it to exit transient state...", "CurrentState", rcd.containerState)
 		change = r.manageContainer(ctx, container, log)
 
-	case (rcd.containerState == apiv1.ContainerStateRunning || rcd.containerState == apiv1.ContainerStatePaused) && !container.Spec.Persistent:
+	case (rcd.containerState == apiv1.ContainerStateRunning || rcd.containerState == apiv1.ContainerStatePaused) && shouldDeleteContainer(container.Spec.EffectiveMode()):
 		log.V(1).Info("Container is being deleted, but it needs to be stopped first...", "CurrentState", rcd.containerState)
 		rcd.containerState = apiv1.ContainerStateStopping
 		stoppingInitializer := getStateInitializer(containerStateInitializers, apiv1.ContainerStateStopping, log)
@@ -342,7 +348,8 @@ func handleNewContainer(
 		return r.setContainerState(container, apiv1.ContainerStateRuntimeUnhealthy)
 	}
 
-	if container.Spec.Persistent {
+	effectiveMode := container.Spec.EffectiveMode()
+	if effectiveMode == apiv1.ContainerModePersistent {
 		leaseErr := r.acquirePersistentContainerResourceLease(ctx, container, log)
 		if leaseErr != nil {
 			if !errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
@@ -352,7 +359,10 @@ func handleNewContainer(
 			return change | additionalReconciliationNeeded
 		}
 
-		// Check for an existing persistent container
+	}
+
+	if shouldReuseExisting(effectiveMode) {
+		// Check for an existing container
 		inspected, inspectedErr := inspectContainerIfExists(ctx, r.orchestrator, container.Spec.ContainerName)
 		if inspectedErr != nil && !errors.Is(inspectedErr, containers.ErrNotFound) {
 			log.Error(inspectedErr, "Could not inspect existing container")
@@ -390,74 +400,64 @@ func handleNewContainer(
 			// Produce a candidate RCD; this will only be persisted if we find an existing valid container.
 			rcd := newRunningContainerData(container)
 
-			// We compute the effective environment and invocation args here because we need them
-			// to generate a stable lifecycle key.
-			envErr := r.computeEffectiveEnvironment(ctx, container, rcd, log)
-			if envErr != nil {
-				if templating.IsTransientTemplateError(envErr) {
-					log.Info("Could not compute effective environment for the Container, retrying startup...", "Cause", envErr.Error())
+			if shouldCreateIfMissing(effectiveMode) {
+				// We compute the effective environment and invocation args here because we need them
+				// to generate a stable lifecycle key.
+				envErr := r.computeEffectiveEnvironment(ctx, container, rcd, log)
+				if envErr != nil {
+					if templating.IsTransientTemplateError(envErr) {
+						log.Info("Could not compute effective environment for the Container, retrying startup...", "Cause", envErr.Error())
+						return change | additionalReconciliationNeeded
+					} else {
+						log.Error(envErr, "Could not compute effective environment for the Container")
+						_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+						return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
+					}
+				}
+
+				invocErr := r.computeEffectiveInvocationArgs(ctx, container, rcd, log)
+				if invocErr != nil {
+					if templating.IsTransientTemplateError(invocErr) {
+						log.Info("Could not compute effective invocation arguments for the Container, retrying startup...", "Cause", invocErr.Error())
+						return change | additionalReconciliationNeeded
+					} else {
+						log.Error(invocErr, "Could not compute effective invocation arguments for the Container")
+						_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+						return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
+					}
+				}
+
+				lifecycleKey, hasDefaultLifecycleKey, hashErr := rcd.runSpec.GetLifecycleKey()
+				if hashErr != nil {
+					log.Error(hashErr, "Could not calculate lifecycle key")
 					return change | additionalReconciliationNeeded
-				} else {
-					log.Error(envErr, "Could not compute effective environment for the Container")
-					_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-					return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
 				}
-			}
 
-			invocErr := r.computeEffectiveInvocationArgs(ctx, container, rcd, log)
-			if invocErr != nil {
-				if templating.IsTransientTemplateError(invocErr) {
-					log.Info("Could not compute effective invocation arguments for the Container, retrying startup...", "Cause", invocErr.Error())
-					return change | additionalReconciliationNeeded
-				} else {
-					log.Error(invocErr, "Could not compute effective invocation arguments for the Container")
-					_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-					return r.setContainerState(container, apiv1.ContainerStateFailedToStart)
+				if container.Status.LifecycleKey == "" {
+					container.Status.LifecycleKey = lifecycleKey
+					change |= statusChanged
 				}
-			}
 
-			lifecycleKey, hasDefaultLifecycleKey, hashErr := rcd.runSpec.GetLifecycleKey()
-			if hashErr != nil {
-				log.Error(hashErr, "Could not calculate lifecycle key")
-				return change | additionalReconciliationNeeded
-			}
-
-			if container.Status.LifecycleKey == "" {
-				container.Status.LifecycleKey = lifecycleKey
-				change |= statusChanged
-			}
-
-			_, dcpManaged := inspected.Labels[dcpBuildLabel]
-			oldLifecycleKey, found := inspected.Labels[lifecycleKeyLabel]
-			if dcpManaged && ((found && oldLifecycleKey != lifecycleKey) || (!found && lifecycleKey != "")) {
-				// We need to recreate this DCP managed container because the lifecycle key has changed
-				if hasDefaultLifecycleKey {
-					mounts, ports, env, other := calculatePersistentContainerChanges(rcd, inspected)
-					log.Info("Found existing Container, but calculated lifecycle key doesn't match", "OldLifecycleKey", oldLifecycleKey, "NewLifecycleKey", lifecycleKey, "MountChanges", mounts, "PortChanges", ports, "EnvChanges", env, "OtherChanges", other)
+				_, dcpManaged := inspected.Labels[dcpBuildLabel]
+				oldLifecycleKey, found := inspected.Labels[lifecycleKeyLabel]
+				if dcpManaged && ((found && oldLifecycleKey != lifecycleKey) || (!found && lifecycleKey != "")) {
+					// We need to recreate this DCP managed container because the lifecycle key has changed
+					if hasDefaultLifecycleKey {
+						mounts, ports, env, other := calculatePersistentContainerChanges(rcd, inspected)
+						log.Info("Found existing Container, but calculated lifecycle key doesn't match", "OldLifecycleKey", oldLifecycleKey, "NewLifecycleKey", lifecycleKey, "MountChanges", mounts, "PortChanges", ports, "EnvChanges", env, "OtherChanges", other)
+					} else {
+						log.Info("Found existing Container, but custom lifecycle key doesn't match", "OldLifecycleKey", oldLifecycleKey, "NewLifecycleKey", lifecycleKey)
+					}
+				} else if dcpManaged && inspected.Status != containers.ContainerStatusRunning {
+					log.V(1).Info("Found existing Container that is not running", "ContainerStatus", inspected.Status)
 				} else {
-					log.Info("Found existing Container, but custom lifecycle key doesn't match", "OldLifecycleKey", oldLifecycleKey, "NewLifecycleKey", lifecycleKey)
+					return change | r.adoptExistingContainer(ctx, container, rcd, inspected, log)
 				}
-			} else if dcpManaged && inspected.Status != containers.ContainerStatusRunning {
-				log.V(1).Info("Found existing Container that is not running", "ContainerStatus", inspected.Status)
 			} else {
-				log.Info("Found existing Container")
-
-				rcd.updateFromInspectedContainer(inspected)
-
-				rcd.ensureStartupLogFiles(container, log)
-				rcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
-				rcd.containerState = apiv1.ContainerStateRunning
-
-				r.runningContainers.Store(container.NamespacedName(), rcd.containerID, rcd)
-				r.EnsureContainerWatchForResource(container.UID, log)
-
-				change |= rcd.applyTo(container, log)
-
-				_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-				return change | r.setContainerState(container, apiv1.ContainerStateRunning)
+				return change | r.adoptExistingContainer(ctx, container, rcd, inspected, log)
 			}
 
-			if container.ShouldStart() {
+			if container.ShouldStart() && shouldCreateIfMissing(effectiveMode) {
 				log.V(1).Info("Removing existing container")
 				if removeErr := r.removeExistingContainer(ctx, containerID(inspected.Id), inspected, log); removeErr != nil {
 					log.Error(removeErr, "Could not remove existing container")
@@ -465,6 +465,11 @@ func handleNewContainer(
 				}
 			}
 		}
+	}
+
+	if !shouldCreateIfMissing(effectiveMode) {
+		_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+		return change
 	}
 
 	if !container.ShouldStart() {
@@ -486,6 +491,30 @@ func handleNewContainer(
 		// Initiate startup sequence.
 		return change | r.setContainerState(container, apiv1.ContainerStateStarting)
 	}
+}
+
+func (r *ContainerReconciler) adoptExistingContainer(
+	ctx context.Context,
+	container *apiv1.Container,
+	rcd *runningContainerData,
+	inspected *containers.InspectedContainer,
+	log logr.Logger,
+) objectChange {
+	log.Info("Found existing Container")
+
+	rcd.updateFromInspectedContainer(inspected)
+
+	rcd.ensureStartupLogFiles(container, log)
+	rcd.startAttemptFinishedAt = metav1.NewMicroTime(inspected.StartedAt)
+	rcd.containerState = apiv1.ContainerStateRunning
+
+	r.runningContainers.Store(container.NamespacedName(), rcd.containerID, rcd)
+	r.EnsureContainerWatchForResource(container.UID, log)
+
+	change := rcd.applyTo(container, log)
+
+	_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
+	return change | r.setContainerState(container, apiv1.ContainerStateRunning)
 }
 
 func ensureContainerBuildingState(
@@ -1391,7 +1420,7 @@ func (r *ContainerReconciler) addContainerCreationLabels(container *apiv1.Contai
 		},
 		{
 			Key:   PersistentLabel,
-			Value: fmt.Sprintf("%t", rcd.runSpec.Persistent),
+			Value: fmt.Sprintf("%t", rcd.runSpec.EffectiveMode() == apiv1.ContainerModePersistent),
 		},
 	}...)
 
@@ -1519,7 +1548,7 @@ func (r *ContainerReconciler) acquirePersistentContainerResourceLease(
 	container *apiv1.Container,
 	log logr.Logger,
 ) error {
-	if !container.Spec.Persistent {
+	if container.Spec.EffectiveMode() != apiv1.ContainerModePersistent {
 		return nil
 	}
 	if r.config.StateStore == nil {
@@ -1544,7 +1573,7 @@ func (r *ContainerReconciler) acquirePersistentContainerResourceLease(
 }
 
 func (r *ContainerReconciler) verifyPersistentContainerResourceLeaseHeld(ctx context.Context, container *apiv1.Container, log logr.Logger) error {
-	if !container.Spec.Persistent {
+	if container.Spec.EffectiveMode() != apiv1.ContainerModePersistent {
 		return nil
 	}
 	if r.config.StateStore == nil {
@@ -1566,7 +1595,7 @@ func (r *ContainerReconciler) releasePersistentContainerResourceLease(
 	log logr.Logger,
 	suppressNotHeldLog bool,
 ) error {
-	if !container.Spec.Persistent {
+	if container.Spec.EffectiveMode() != apiv1.ContainerModePersistent {
 		return nil
 	}
 	if r.config.StateStore == nil {
@@ -1821,8 +1850,8 @@ func (r *ContainerReconciler) deleteContainer(ctx context.Context, container *ap
 	defer rcd.deleteStartupLogFiles(log)
 	defer rcd.closeTerminalResources(r.config.ProcessExecutor, log)
 
-	if container.Spec.Persistent {
-		log.V(1).Info("Container is not using Managed mode, leaving underlying resources")
+	if !shouldDeleteContainer(container.Spec.EffectiveMode()) {
+		log.V(1).Info("Container is being deleted, leaving underlying resources")
 		return
 	}
 
@@ -2045,7 +2074,7 @@ func (r *ContainerReconciler) handleInitialNetworkConnections(
 }
 
 func (r *ContainerReconciler) runPersistentContainerLifecycleMonitor(rcd *runningContainerData, log logr.Logger) {
-	if rcd == nil || rcd.runSpec == nil || !rcd.runSpec.Persistent {
+	if rcd == nil || rcd.runSpec == nil || rcd.runSpec.EffectiveMode() != apiv1.ContainerModePersistent {
 		return
 	}
 
@@ -2111,7 +2140,7 @@ func (r *ContainerReconciler) removeContainerNetworkConnections(
 	container *apiv1.Container,
 	log logr.Logger,
 ) {
-	if container.Spec.Persistent {
+	if !shouldDeleteContainer(container.Spec.EffectiveMode()) {
 		return
 	}
 
@@ -2444,7 +2473,7 @@ func (r *ContainerReconciler) setContainerState(container *apiv1.Container, stat
 		change = statusChanged
 	}
 
-	if container.Spec.Persistent && persistentContainerLeaseReleaseState(state) {
+	if container.Spec.EffectiveMode() == apiv1.ContainerModePersistent && persistentContainerLeaseReleaseState(state) {
 		// Intentionally ignore errors: this is a defensive, idempotent release attempt for stable states.
 		_ = r.releasePersistentContainerResourceLease(context.Background(), container, r.Log, true)
 	}
@@ -2462,6 +2491,37 @@ func persistentContainerLeaseReleaseState(state apiv1.ContainerState) bool {
 		apiv1.ContainerStatePaused,
 		apiv1.ContainerStateExited,
 		apiv1.ContainerStateUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldReuseExisting(mode apiv1.ContainerMode) bool {
+	switch mode {
+	case apiv1.ContainerModePersistent,
+		apiv1.ContainerModeExisting,
+		apiv1.ContainerModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldCreateIfMissing(mode apiv1.ContainerMode) bool {
+	switch mode {
+	case apiv1.ContainerModeSession,
+		apiv1.ContainerModePersistent:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldDeleteContainer(mode apiv1.ContainerMode) bool {
+	switch mode {
+	case apiv1.ContainerModeSession,
+		apiv1.ContainerModeCleanup:
 		return true
 	default:
 		return false

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -83,6 +83,7 @@ var (
 		apiv1.ContainerStateRuntimeUnhealthy: handleNewContainer,
 		apiv1.ContainerStateBuilding:         ensureContainerBuildingState,
 		apiv1.ContainerStateStarting:         ensureContainerStartingState,
+		apiv1.ContainerStateNotFound:         handleNewContainer,
 		apiv1.ContainerStateFailedToStart:    ensureContainerFailedToStartState,
 		apiv1.ContainerStateRunning:          ensureContainerRunningState,
 		apiv1.ContainerStatePaused:           ensureContainerRunningState,
@@ -469,7 +470,7 @@ func handleNewContainer(
 
 	if !shouldCreateIfMissing(effectiveMode) {
 		_ = r.releasePersistentContainerResourceLease(ctx, container, log, false)
-		return change
+		return change | r.setContainerState(container, apiv1.ContainerStateNotFound)
 	}
 
 	if !container.ShouldStart() {
@@ -2533,7 +2534,7 @@ func updateContainerHealthStatus(ctr *apiv1.Container, state apiv1.ContainerStat
 
 	switch state {
 
-	case apiv1.ContainerStateEmpty, apiv1.ContainerStatePending, apiv1.ContainerStateBuilding, apiv1.ContainerStateStarting, apiv1.ContainerStatePaused, apiv1.ContainerStateUnknown, apiv1.ContainerStateStopping:
+	case apiv1.ContainerStateEmpty, apiv1.ContainerStatePending, apiv1.ContainerStateBuilding, apiv1.ContainerStateStarting, apiv1.ContainerStateNotFound, apiv1.ContainerStatePaused, apiv1.ContainerStateUnknown, apiv1.ContainerStateStopping:
 		newHealthStatus = apiv1.HealthStatusCaution
 
 	case apiv1.ContainerStateRunning:

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -224,8 +224,8 @@ func (r *ExecutableReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *ExecutableReconciler) handleDeletionRequest(ctx context.Context, exe *apiv1.Executable, log logr.Logger) objectChange {
 	_, runInfo := r.runs.BorrowByNamespacedName(exe.NamespacedName())
 
-	if exe.Spec.Persistent {
-		log.V(1).Info("Persistent Executable is being deleted; leaving underlying process running")
+	if !shouldStopProcessOnDelete(exe.Spec.EffectiveMode()) {
+		log.V(1).Info("Executable is being deleted, leaving underlying process running")
 		var deletionChange objectChange
 		leaseChange := r.withPersistentExecutableLease(ctx, exe, log, func(context.Context, *statestore.ResourceLease) objectChange {
 			r.releasePersistentExecutableResources(ctx, exe, runInfo, log)
@@ -241,6 +241,16 @@ func (r *ExecutableReconciler) handleDeletionRequest(ctx context.Context, exe *a
 	switch {
 	case runInfo == nil:
 		log.V(1).Info("Executable is being deleted (deleting finalizer only)...")
+		if exe.Spec.EffectiveMode() == apiv1.ExecutableModeCleanup {
+			var deletionChange objectChange
+			leaseChange := r.withPersistentExecutableLease(ctx, exe, log, func(ctx context.Context, _ *statestore.ResourceLease) objectChange {
+				cleanupChange := r.stopPersistentExecutableRecordForDeletion(ctx, exe, log)
+				r.runs.DeleteByNamespacedName(exe.NamespacedName())
+				deletionChange = deleteFinalizer(exe, executableFinalizer, log)
+				return cleanupChange | deletionChange
+			})
+			return leaseChange | deletionChange
+		}
 		change = deleteFinalizer(exe, executableFinalizer, log)
 
 	case runInfo.ExeState == apiv1.ExecutableStateStopping || runInfo.ExeState == apiv1.ExecutableStateStarting:
@@ -300,7 +310,11 @@ func handleNewExecutable(
 	runInfo *ExecutableRunInfo,
 	log logr.Logger,
 ) objectChange {
-	if exe.Spec.Persistent {
+	effectiveMode := exe.Spec.EffectiveMode()
+	reuseExisting := shouldReuseExistingProcess(effectiveMode)
+	createIfMissing := shouldCreateProcessIfMissing(effectiveMode)
+
+	if reuseExisting {
 		leaseErr := r.acquirePersistentExecutableResourceLease(ctx, exe, log)
 		if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
 			return additionalReconciliationNeeded
@@ -312,12 +326,17 @@ func handleNewExecutable(
 	}
 
 	if exe.Status.State == apiv1.ExecutableStateEmpty && runInfo == nil {
-		if exe.Spec.Persistent && (exe.Spec.Stop || !exe.ShouldStart()) {
+		if reuseExisting && (exe.Spec.Stop || !exe.ShouldStart() || !createIfMissing) {
 			adopted, adoptionChange := r.tryAdoptExistingPersistentExecutable(ctx, exe, log)
 			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
 			if adopted || adoptionChange != noChange {
 				return adoptionChange
 			}
+		}
+
+		if !createIfMissing {
+			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
+			return noChange
 		}
 
 		if !exe.ShouldStart() {
@@ -334,7 +353,7 @@ func handleNewExecutable(
 	}
 
 	change := r.startExecutable(ctx, exe, runInfo, log)
-	if exe.Spec.Persistent {
+	if reuseExisting {
 		_, updatedRunInfo := r.runs.BorrowByNamespacedName(exe.NamespacedName())
 		if !persistentExecutableStartupInProgress(updatedRunInfo) {
 			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
@@ -359,14 +378,20 @@ func ensureExecutableRunningState(
 		return change
 	}
 
-	if exe.Spec.Persistent && runInfo.Pid != apiv1.UnknownPID && !runInfo.ProcessIdentityTime.IsZero() {
+	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && runInfo.Pid != apiv1.UnknownPID && !runInfo.ProcessIdentityTime.IsZero() {
 		pid, pidErr := process.Int64_ToPidT(*runInfo.Pid)
 		if pidErr != nil {
 			log.Error(pidErr, "Persistent Executable run has invalid PID")
 			runInfo.ExeState = apiv1.ExecutableStateUnknown
 			return change | r.setExecutableState(exe, apiv1.ExecutableStateUnknown)
 		}
-		if _, findErr := process.FindProcess(pid, runInfo.ProcessIdentityTime); findErr != nil {
+		persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+		if persistentRunnerErr != nil {
+			log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
+			runInfo.ExeState = apiv1.ExecutableStateUnknown
+			return change | r.setExecutableState(exe, apiv1.ExecutableStateUnknown)
+		}
+		if findErr := persistentRunner.FindProcess(pid, runInfo.ProcessIdentityTime); findErr != nil {
 			log.Info("Persistent Executable process is no longer running", "PID", pid, "Error", findErr.Error())
 			r.deletePersistentProcessRecord(ctx, exe.NamespacedName(), log)
 			runInfo.ExeState = apiv1.ExecutableStateFinished
@@ -481,7 +506,7 @@ func (r *ExecutableReconciler) startExecutable(
 
 	environmentChanged := noChange
 
-	if exe.Spec.Persistent && len(ri.startResults) == 0 {
+	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && len(ri.startResults) == 0 {
 		computed, startupDataChanged := r.computeExecutableEnvironment(ctx, exe, log, ri)
 		environmentChanged |= startupDataChanged
 		if !computed {
@@ -514,7 +539,7 @@ func (r *ExecutableReconciler) startExecutable(
 
 	// Helper function to update Executable status when the start attempt was successful.
 	handleSuccessfulStart := func(res *ExecutableStartResult) objectChange {
-		if exe.Spec.Persistent {
+		if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
 			persistErr := r.upsertPersistentProcessRecord(ctx, exe, res)
 			if persistErr != nil {
 				log.Error(persistErr, "Could not persist Executable process record")
@@ -723,7 +748,7 @@ func (r *ExecutableReconciler) processRunChangeNotification(
 	r.runs.QueueDeferredOp(name, func(_ types.NamespacedName, _ RunID, exe *apiv1.Executable) {
 		// The run may have been deleted by the time we get here, so we do not care if Update() returns false.
 		_ = runMap.Update(name, runID, runInfo)
-		if runIsTerminal && exe != nil && exe.Spec.Persistent {
+		if runIsTerminal && exe != nil && shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
 			r.deletePersistentProcessRecordWithLease(context.Background(), name, log)
 		}
 	})
@@ -1373,7 +1398,7 @@ func (r *ExecutableReconciler) setExecutableState(exe *apiv1.Executable, state a
 		}
 	}
 
-	if exe.Spec.Persistent && persistentExecutableLeaseReleaseState(state) {
+	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && persistentExecutableLeaseReleaseState(state) {
 		// Intentionally ignore errors: this is a defensive, idempotent release attempt for stable states.
 		_ = r.releasePersistentExecutableResourceLease(context.Background(), exe, r.Log, true)
 	}

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -224,60 +224,47 @@ func (r *ExecutableReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 func (r *ExecutableReconciler) handleDeletionRequest(ctx context.Context, exe *apiv1.Executable, log logr.Logger) objectChange {
 	_, runInfo := r.runs.BorrowByNamespacedName(exe.NamespacedName())
+	effectiveMode := exe.Spec.EffectiveMode()
 
-	if !shouldStopProcessOnDelete(exe.Spec.EffectiveMode()) {
-		log.V(1).Info("Executable is being deleted, leaving underlying process running")
-		var deletionChange objectChange
-		leaseChange := r.withPersistentExecutableLease(ctx, exe, log, func(context.Context, *statestore.ResourceLease) objectChange {
-			r.releasePersistentExecutableResources(ctx, exe, runInfo, log)
-			r.runs.DeleteByNamespacedName(exe.NamespacedName())
-			deletionChange = deleteFinalizer(exe, executableFinalizer, log)
-			return deletionChange
-		})
-		return leaseChange | deletionChange
+	if !effectiveMode.ShouldStopProcessOnDelete() {
+		// Don't bother cleaning up the persistent resource record as it's either still running or a future run will detect it's stale and clean it up
+		if runInfo != nil {
+			runner, runnerErr := r.getExecutableRunner(exe, runInfo.startupStage)
+			if runnerErr != nil {
+				log.Error(runnerErr, "Could not release persistent Executable runner tracking", "RunID", runInfo.RunID)
+			} else if releaseErr := runner.ReleaseRun(ctx, runInfo.RunID, log); releaseErr != nil {
+				log.Error(releaseErr, "Could not release persistent Executable runner tracking", "RunID", runInfo.RunID)
+			}
+		}
+
+		return deleteFinalizer(exe, executableFinalizer, log)
 	}
-
-	var change objectChange
 
 	switch {
 	case runInfo == nil:
 		log.V(1).Info("Executable is being deleted (deleting finalizer only)...")
-		if exe.Spec.EffectiveMode() == apiv1.ExecutableModeCleanup {
-			var deletionChange objectChange
-			leaseChange := r.withPersistentExecutableLease(ctx, exe, log, func(ctx context.Context, _ *statestore.ResourceLease) objectChange {
-				cleanupSucceeded, cleanupChange := r.stopPersistentExecutableRecordForDeletion(ctx, exe, log)
-				if !cleanupSucceeded {
-					return cleanupChange | additionalReconciliationNeeded
-				}
-				r.runs.DeleteByNamespacedName(exe.NamespacedName())
-				deletionChange = deleteFinalizer(exe, executableFinalizer, log)
-				return cleanupChange | deletionChange
-			})
-			return leaseChange | deletionChange
-		}
-		change = deleteFinalizer(exe, executableFinalizer, log)
+		return deleteFinalizer(exe, executableFinalizer, log)
 
 	case runInfo.ExeState == apiv1.ExecutableStateStopping || runInfo.ExeState == apiv1.ExecutableStateStarting:
 		log.V(1).Info("Executable is being deleted, waiting for it to exit transient state...",
 			"CurrentState", runInfo.ExeState)
-		change = r.manageExecutable(ctx, exe, log)
+		return r.manageExecutable(ctx, exe, log)
 
 	case runInfo.ExeState == apiv1.ExecutableStateRunning:
 		log.V(1).Info("Executable is being deleted, but it needs to be stopped first...")
 		runInfo.ExeState = apiv1.ExecutableStateStopping
 		stoppingInitializer := getStateInitializer(executableStateInitializers, apiv1.ExecutableStateStopping, log)
-		change = stoppingInitializer(ctx, r, exe, apiv1.ExecutableStateStopping, runInfo, log)
+		change := stoppingInitializer(ctx, r, exe, apiv1.ExecutableStateStopping, runInfo, log)
 		r.runs.Update(exe.NamespacedName(), runInfo.RunID, runInfo)
+		return change
 
 	default:
-		log.V(1).Info("Executable is being deleted (in initial or final state; releasing resources and deleting finalizer)...",
+		log.V(1).Info("Executable is being deleted (in final state; releasing resources and deleting finalizer)...",
 			"CurrentState", runInfo.ExeState)
 		r.releaseExecutableResources(ctx, exe, log)
-		change = deleteFinalizer(exe, executableFinalizer, log)
 		r.runs.DeleteByNamespacedName(exe.NamespacedName())
+		return deleteFinalizer(exe, executableFinalizer, log)
 	}
-
-	return change
 }
 
 func (r *ExecutableReconciler) manageExecutable(ctx context.Context, exe *apiv1.Executable, log logr.Logger) objectChange {
@@ -315,11 +302,26 @@ func handleNewExecutable(
 	log logr.Logger,
 ) objectChange {
 	effectiveMode := exe.Spec.EffectiveMode()
-	reuseExisting := shouldReuseExistingProcess(effectiveMode)
-	createIfMissing := shouldCreateProcessIfMissing(effectiveMode)
+	reuseExisting := effectiveMode.ShouldReuseExisting()
+	createIfMissing := effectiveMode.ShouldCreateIfMissing()
+
+	if runInfo == nil {
+		runInfo = NewRunInfo(exe)
+		runInfo.ExeState = apiv1.ExecutableStateStarting
+		runInfo.RunID = getStartingRunID(exe.NamespacedName())
+	}
+
+	var persistentLease *statestore.ResourceLease
+	defer func() {
+		if persistentLease != nil {
+			_ = persistentLease.Release(ctx)
+		}
+	}()
 
 	if reuseExisting {
-		leaseErr := r.acquirePersistentExecutableResourceLease(ctx, exe, log)
+		var leaseErr error
+		var record *statestore.PersistentProcessRecord
+		persistentLease, record, leaseErr = r.acquirePersistentExecutableResourceLeaseAndRecord(ctx, exe, log)
 		if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
 			return additionalReconciliationNeeded
 		}
@@ -327,42 +329,117 @@ func handleNewExecutable(
 			log.Error(leaseErr, "Could not acquire persistent Executable resource lease")
 			return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 		}
-	}
 
-	if (exe.Status.State == apiv1.ExecutableStateEmpty || exe.Status.State == apiv1.ExecutableStateNotFound) && runInfo == nil {
-		if reuseExisting && (exe.Spec.Stop || !exe.ShouldStart() || !createIfMissing) {
-			adopted, adoptionChange := r.tryAdoptExistingPersistentExecutable(ctx, exe, log)
-			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
-			if adopted || adoptionChange != noChange {
-				return adoptionChange
+		if record != nil {
+			persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+			if persistentRunnerErr != nil {
+				log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
+				return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+			}
+
+			findErr := persistentRunner.CheckProcessRunning(record.PID, record.IdentityTime)
+			if exe.Spec.Stop {
+				stopChange := noChange
+				if findErr == nil {
+					stopErr := persistentRunner.StopPersistentProcess(ctx, exe, record, log)
+					if stopErr != nil {
+						log.Error(stopErr, "Could not stop persistent Executable process", "PID", record.PID)
+						return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+					}
+				} else {
+					log.Info("Persistent Executable process record is no longer running",
+						"PID", record.PID,
+						"Error", findErr.Error())
+				}
+
+				if exe.Status.ExecutionID != "" {
+					exe.Status.ExecutionID = ""
+					stopChange |= statusChanged
+				}
+				if exe.Status.PID != apiv1.UnknownPID {
+					exe.Status.PID = apiv1.UnknownPID
+					stopChange |= statusChanged
+				}
+				stopChange |= r.setExecutableState(exe, apiv1.ExecutableStateFinished)
+
+				if deleteErr := record.Delete(ctx); deleteErr != nil {
+					log.Error(deleteErr, "Could not delete persistent Executable process record", "ResourceKey", record.ResourceKey)
+				}
+				return stopChange
+			}
+
+			if findErr != nil {
+				log.Info("Persistent Executable process record is stale; process is no longer running",
+					"PID", record.PID,
+					"Error", findErr.Error())
+				if deleteErr := record.Delete(ctx); deleteErr != nil {
+					log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", record.ResourceKey)
+					return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+				}
+			} else {
+				computed, environmentChange := r.computeExecutableEnvironment(ctx, exe, log, runInfo)
+				if !computed {
+					return environmentChange
+				}
+
+				lifecycleKey, hasDefaultLifecycleKey, lifecycleKeyErr := exe.GetLifecycleKey()
+				if lifecycleKeyErr != nil {
+					log.Error(lifecycleKeyErr, "Could not calculate Executable lifecycle key")
+					return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+				}
+
+				if record.LifecycleKey != lifecycleKey {
+					if hasDefaultLifecycleKey {
+						args, env, other := calculatePersistentExecutableChanges(exe, record.LifecycleMetadata)
+						log.Info("Found existing persistent Executable process record, but calculated lifecycle key does not match",
+							"OldLifecycleKey", record.LifecycleKey,
+							"NewLifecycleKey", lifecycleKey,
+							"ArgChanges", args,
+							"EnvChanges", env,
+							"OtherChanges", other)
+					} else {
+						log.Info("Found existing persistent Executable process record, but custom lifecycle key does not match",
+							"OldLifecycleKey", record.LifecycleKey,
+							"NewLifecycleKey", lifecycleKey)
+					}
+					stopErr := persistentRunner.StopPersistentProcess(ctx, exe, record, log)
+					if stopErr != nil {
+						log.Error(stopErr, "Could not stop persistent Executable process with stale lifecycle key", "PID", record.PID)
+						return environmentChange | r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+					}
+					if deleteErr := record.Delete(ctx); deleteErr != nil {
+						log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", record.ResourceKey)
+						return environmentChange | r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+					}
+					if environmentChange != noChange {
+						return environmentChange
+					}
+				} else {
+					adopted, adoptionChange := r.adoptPersistentExecutableRecord(ctx, exe, runInfo, record, persistentRunner, log)
+					if adopted || adoptionChange != noChange {
+						return environmentChange | adoptionChange
+					}
+				}
 			}
 		}
+	}
 
-		if !createIfMissing {
-			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
-			return r.setExecutableState(exe, apiv1.ExecutableStateNotFound)
-		}
+	if !createIfMissing {
+		return r.setExecutableState(exe, apiv1.ExecutableStateNotFound) | additionalReconciliationNeeded
+	}
 
-		if !exe.ShouldStart() {
-			// We should wait to create an executable until the user clears Start = false
-			log.V(1).Info("Waiting for the executable to be started")
-			return noChange
-		}
+	if exe.Spec.Stop && runInfo.startupStage == StartupStageInitial && len(runInfo.startResults) == 0 {
+		log.V(1).Info("No persistent Executable process was found to stop")
+		return noChange
+	}
 
-		if exe.Spec.Stop {
-			log.Info("Executable.Stop property was set to true before Executable was started, marking Executable as 'failed to start'...")
-			r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-			return statusChanged
-		}
+	if !exe.ShouldStart() {
+		// We should wait to create an executable until the user clears Start = false
+		log.V(1).Info("Waiting for the executable to be started")
+		return noChange
 	}
 
 	change := r.startExecutable(ctx, exe, runInfo, log)
-	if reuseExisting {
-		_, updatedRunInfo := r.runs.BorrowByNamespacedName(exe.NamespacedName())
-		if !persistentExecutableStartupInProgress(updatedRunInfo) {
-			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
-		}
-	}
 	return change
 }
 
@@ -380,29 +457,6 @@ func ensureExecutableRunningState(
 		// Might happen if the Executable is being deleted and the run was already terminated
 		// (we are seeing stale Executable data due to Kubernetes container-runtime caching).
 		return change
-	}
-
-	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && runInfo.Pid != apiv1.UnknownPID && !runInfo.ProcessIdentityTime.IsZero() {
-		pid, pidErr := process.Int64_ToPidT(*runInfo.Pid)
-		if pidErr != nil {
-			log.Error(pidErr, "Persistent Executable run has invalid PID")
-			runInfo.ExeState = apiv1.ExecutableStateUnknown
-			return change | r.setExecutableState(exe, apiv1.ExecutableStateUnknown)
-		}
-		persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
-		if persistentRunnerErr != nil {
-			log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
-			runInfo.ExeState = apiv1.ExecutableStateUnknown
-			return change | r.setExecutableState(exe, apiv1.ExecutableStateUnknown)
-		}
-		if findErr := persistentRunner.FindProcess(pid, runInfo.ProcessIdentityTime); findErr != nil {
-			log.Info("Persistent Executable process is no longer running", "PID", pid, "Error", findErr.Error())
-			r.deletePersistentProcessRecord(ctx, exe.NamespacedName(), log)
-			runInfo.ExeState = apiv1.ExecutableStateFinished
-			runInfo.FinishTimestamp = metav1.NowMicro()
-			r.disableEndpointsAndHealthProbes(ctx, exe, runInfo, log)
-			return change | runInfo.ApplyTo(exe, log) | r.setExecutableState(exe, apiv1.ExecutableStateFinished)
-		}
 	}
 
 	if exe.Spec.Stop {
@@ -433,11 +487,27 @@ func ensureExecutableStoppingState(
 
 	if !runInfo.stopAttemptInitiated {
 		log.V(1).Info("Attempting to stop the Executable...", "RunID", runInfo.RunID)
+		var persistentLease *statestore.ResourceLease
+		if exe.Spec.EffectiveMode().ShouldReuseExisting() {
+			var leaseErr error
+			persistentLease, _, leaseErr = r.acquirePersistentExecutableResourceLeaseAndRecord(ctx, exe, log)
+			if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
+				return change | additionalReconciliationNeeded
+			}
+			if leaseErr != nil {
+				log.Error(leaseErr, "Could not acquire persistent Executable resource lease before stopping")
+				return change | additionalReconciliationNeeded
+			}
+		}
+
 		runInfo.stopAttemptInitiated = true
 		runInfo.ExeState = apiv1.ExecutableStateStopping
 		runInfoCopy := runInfo.Clone()
-		err := r.stopQueue.Enqueue(r.stopExecutableFunc(exe, runInfoCopy, log))
+		err := r.stopQueue.Enqueue(r.stopExecutableFunc(exe, runInfoCopy, persistentLease, log))
 		if err != nil {
+			if persistentLease != nil {
+				_ = persistentLease.Release(ctx)
+			}
 			log.Error(err, "Could not enqueue Executable stop operation")
 			change |= ensureExecutableFinalState(ctx, r, exe, apiv1.ExecutableStateUnknown, runInfo, log)
 			return change
@@ -478,20 +548,17 @@ func (r *ExecutableReconciler) startExecutable(
 	log logr.Logger,
 ) objectChange {
 	if leaseErr := r.verifyPersistentExecutableResourceLeaseHeld(ctx, exe, log); leaseErr != nil {
-		if ri != nil {
-			ri.ExeState = apiv1.ExecutableStateFailedToStart
-			r.runs.Update(exe.NamespacedName(), ri.RunID, ri.Clone())
-		}
+		ri.ExeState = apiv1.ExecutableStateFailedToStart
+		r.runs.Update(exe.NamespacedName(), ri.RunID, ri.Clone())
 		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
-	if ri == nil {
+	if ri.startupStage == StartupStageInitial && len(ri.startResults) == 0 {
 		log.V(1).Info("Starting Executable...")
-		ri = NewRunInfo(exe)
-		ri.ExeState = apiv1.ExecutableStateStarting
-		ri.RunID = getStartingRunID(exe.NamespacedName())
 		r.runs.Store(exe.NamespacedName(), ri.RunID, ri.Clone())
 	}
+
+	environmentChanged := noChange
 
 	if ri.startupStage == StartupStageInitial {
 		if exe.Spec.PemCertificates != nil {
@@ -508,19 +575,12 @@ func (r *ExecutableReconciler) startExecutable(
 		r.runs.Update(exe.NamespacedName(), ri.RunID, ri.Clone())
 	}
 
-	environmentChanged := noChange
-
-	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && len(ri.startResults) == 0 {
+	if len(ri.startResults) == 0 {
 		computed, startupDataChanged := r.computeExecutableEnvironment(ctx, exe, log, ri)
 		environmentChanged |= startupDataChanged
 		if !computed {
 			// Environment is not ready, or an error occurred; report it and let the next reconciliation try again.
 			return environmentChanged
-		}
-
-		adopted, adoptionChange := r.tryAdoptPersistentExecutable(ctx, exe, ri, log)
-		if adopted || adoptionChange != noChange {
-			return adoptionChange | environmentChanged
 		}
 	}
 
@@ -543,7 +603,7 @@ func (r *ExecutableReconciler) startExecutable(
 
 	// Helper function to update Executable status when the start attempt was successful.
 	handleSuccessfulStart := func(res *ExecutableStartResult) objectChange {
-		if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
+		if exe.Spec.EffectiveMode().ShouldReuseExisting() {
 			persistErr := r.upsertPersistentProcessRecord(ctx, exe, res)
 			if persistErr != nil {
 				log.Error(persistErr, "Could not persist Executable process record")
@@ -752,8 +812,23 @@ func (r *ExecutableReconciler) processRunChangeNotification(
 	r.runs.QueueDeferredOp(name, func(_ types.NamespacedName, _ RunID, exe *apiv1.Executable) {
 		// The run may have been deleted by the time we get here, so we do not care if Update() returns false.
 		_ = runMap.Update(name, runID, runInfo)
-		if runIsTerminal && exe != nil && shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
-			r.deletePersistentProcessRecordWithLease(context.Background(), name, log)
+		if runIsTerminal && exe != nil && exe.Spec.EffectiveMode().ShouldReuseExisting() {
+			ctx := context.Background()
+			persistentLease, record, leaseErr := r.acquirePersistentExecutableResourceLeaseAndRecord(ctx, exe, log)
+			if leaseErr != nil {
+				if !errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
+					log.Error(leaseErr, "Could not acquire persistent Executable resource lease", "ResourceKey", exe.GetLeaseKey())
+				}
+			} else {
+				defer func() {
+					_ = persistentLease.Release(ctx)
+				}()
+				if record != nil {
+					if deleteErr := record.Delete(ctx); deleteErr != nil {
+						log.Error(deleteErr, "Could not delete persistent Executable process record", "Executable", exe.NamespacedName().String())
+					}
+				}
+			}
 		}
 	})
 
@@ -859,8 +934,16 @@ func (r *ExecutableReconciler) OnRunMessage(runID RunID, level RunMessageLevel, 
 // Stops the underlying Executable run, if any.
 // The Executable data update related to stopped run is handled by the caller.
 // The passed runInfo is a copy that the method can modify
-func (r *ExecutableReconciler) stopExecutableFunc(exe *apiv1.Executable, runInfo *ExecutableRunInfo, log logr.Logger) func(context.Context) {
+func (r *ExecutableReconciler) stopExecutableFunc(exe *apiv1.Executable, runInfo *ExecutableRunInfo, persistentLease *statestore.ResourceLease, log logr.Logger) func(context.Context) {
 	return func(stopCtx context.Context) {
+		if persistentLease != nil {
+			defer func() {
+				if releaseErr := persistentLease.Release(context.WithoutCancel(stopCtx)); releaseErr != nil {
+					log.Error(releaseErr, "Could not release persistent Executable resource lease after stopping", "RunID", runInfo.RunID)
+				}
+			}()
+		}
+
 		runner, runnerNotFoundErr := r.getExecutableRunner(exe, runInfo.startupStage)
 		if runnerNotFoundErr != nil {
 			// Should never happen
@@ -1402,7 +1485,7 @@ func (r *ExecutableReconciler) setExecutableState(exe *apiv1.Executable, state a
 		}
 	}
 
-	if shouldReuseExistingProcess(exe.Spec.EffectiveMode()) && persistentExecutableLeaseReleaseState(state) {
+	if exe.Spec.EffectiveMode().ShouldReuseExisting() && persistentExecutableLeaseReleaseState(state) {
 		// Intentionally ignore errors: this is a defensive, idempotent release attempt for stable states.
 		_ = r.releasePersistentExecutableResourceLease(context.Background(), exe, r.Log, true)
 	}

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -436,7 +436,7 @@ func handleNewExecutable(
 
 	if exe.Spec.Stop && runInfo.startupStage == StartupStageInitial && len(runInfo.startResults) == 0 {
 		log.V(1).Info("No Executable process was found to stop")
-		return noChange
+		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
 	if !exe.ShouldStart() {

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -237,11 +237,17 @@ func (r *ExecutableReconciler) handleDeletionRequest(ctx context.Context, exe *a
 			}
 		}
 
+		r.releaseExecutableControllerResources(ctx, exe, log)
 		return deleteFinalizer(exe, executableFinalizer, log)
 	}
 
 	switch {
 	case runInfo == nil:
+		if effectiveMode == apiv1.ExecutableModeCleanup && exe.Status.State != apiv1.ExecutableStateNotFound {
+			log.V(1).Info("Executable is being deleted, resolving cleanup target before deleting finalizer")
+			return handleNewExecutable(ctx, r, exe, apiv1.ExecutableStateEmpty, nil, log) | additionalReconciliationNeeded
+		}
+
 		log.V(1).Info("Executable is being deleted (deleting finalizer only)...")
 		return deleteFinalizer(exe, executableFinalizer, log)
 
@@ -314,7 +320,7 @@ func handleNewExecutable(
 	var persistentLease *statestore.ResourceLease
 	defer func() {
 		if persistentLease != nil {
-			_ = persistentLease.Release(ctx)
+			_ = persistentLease.Release(context.WithoutCancel(ctx))
 		}
 	}()
 
@@ -429,7 +435,7 @@ func handleNewExecutable(
 	}
 
 	if exe.Spec.Stop && runInfo.startupStage == StartupStageInitial && len(runInfo.startResults) == 0 {
-		log.V(1).Info("No persistent Executable process was found to stop")
+		log.V(1).Info("No Executable process was found to stop")
 		return noChange
 	}
 
@@ -1005,9 +1011,13 @@ func allRunnersAttempted(currentStage ExecutableStartuptStage, exe *apiv1.Execut
 }
 
 func (r *ExecutableReconciler) releaseExecutableResources(ctx context.Context, exe *apiv1.Executable, log logr.Logger) {
-	r.disableEndpointsAndHealthProbes(ctx, exe, nil, log)
+	r.releaseExecutableControllerResources(ctx, exe, log)
 	r.deleteOutputFiles(exe, log)
 	r.deleteCertificateFiles(exe, log)
+}
+
+func (r *ExecutableReconciler) releaseExecutableControllerResources(ctx context.Context, exe *apiv1.Executable, log logr.Logger) {
+	r.disableEndpointsAndHealthProbes(ctx, exe, nil, log)
 	logger.ReleaseResourceLog(exe.GetResourceId())
 }
 

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -55,6 +55,7 @@ var executableStateInitializers = map[apiv1.ExecutableState]executableStateIniti
 	apiv1.ExecutableStateEmpty:         handleNewExecutable,
 	apiv1.ExecutableStateStarting:      handleNewExecutable,
 	apiv1.ExecutableStateRunning:       ensureExecutableRunningState,
+	apiv1.ExecutableStateNotFound:      handleNewExecutable,
 	apiv1.ExecutableStateStopping:      ensureExecutableStoppingState,
 	apiv1.ExecutableStateTerminated:    ensureExecutableFinalState,
 	apiv1.ExecutableStateFailedToStart: ensureExecutableFinalState,
@@ -244,7 +245,10 @@ func (r *ExecutableReconciler) handleDeletionRequest(ctx context.Context, exe *a
 		if exe.Spec.EffectiveMode() == apiv1.ExecutableModeCleanup {
 			var deletionChange objectChange
 			leaseChange := r.withPersistentExecutableLease(ctx, exe, log, func(ctx context.Context, _ *statestore.ResourceLease) objectChange {
-				cleanupChange := r.stopPersistentExecutableRecordForDeletion(ctx, exe, log)
+				cleanupSucceeded, cleanupChange := r.stopPersistentExecutableRecordForDeletion(ctx, exe, log)
+				if !cleanupSucceeded {
+					return cleanupChange | additionalReconciliationNeeded
+				}
 				r.runs.DeleteByNamespacedName(exe.NamespacedName())
 				deletionChange = deleteFinalizer(exe, executableFinalizer, log)
 				return cleanupChange | deletionChange
@@ -325,7 +329,7 @@ func handleNewExecutable(
 		}
 	}
 
-	if exe.Status.State == apiv1.ExecutableStateEmpty && runInfo == nil {
+	if (exe.Status.State == apiv1.ExecutableStateEmpty || exe.Status.State == apiv1.ExecutableStateNotFound) && runInfo == nil {
 		if reuseExisting && (exe.Spec.Stop || !exe.ShouldStart() || !createIfMissing) {
 			adopted, adoptionChange := r.tryAdoptExistingPersistentExecutable(ctx, exe, log)
 			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
@@ -336,7 +340,7 @@ func handleNewExecutable(
 
 		if !createIfMissing {
 			_ = r.releasePersistentExecutableResourceLease(ctx, exe, log, false)
-			return noChange
+			return r.setExecutableState(exe, apiv1.ExecutableStateNotFound)
 		}
 
 		if !exe.ShouldStart() {
@@ -1425,7 +1429,7 @@ func updateExecutableHealthStatus(exe *apiv1.Executable, state apiv1.ExecutableS
 	var newHealthStatus apiv1.HealthStatus
 
 	switch state {
-	case apiv1.ExecutableStateEmpty, apiv1.ExecutableStateStarting, apiv1.ExecutableStateStopping, apiv1.ExecutableStateTerminated, apiv1.ExecutableStateUnknown:
+	case apiv1.ExecutableStateEmpty, apiv1.ExecutableStateStarting, apiv1.ExecutableStateNotFound, apiv1.ExecutableStateStopping, apiv1.ExecutableStateTerminated, apiv1.ExecutableStateUnknown:
 		newHealthStatus = apiv1.HealthStatusCaution
 
 	case apiv1.ExecutableStateRunning:

--- a/controllers/executable_persistence.go
+++ b/controllers/executable_persistence.go
@@ -390,24 +390,23 @@ func (r *ExecutableReconciler) stopPersistentExecutableRecordWithoutLifecycle(ct
 	return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
 }
 
-func (r *ExecutableReconciler) stopPersistentExecutableRecordForDeletion(ctx context.Context, exe *apiv1.Executable, log logr.Logger) objectChange {
+func (r *ExecutableReconciler) stopPersistentExecutableRecordForDeletion(ctx context.Context, exe *apiv1.Executable, log logr.Logger) (bool, objectChange) {
 	stateStore, stateStoreErr := r.getStateStore()
 	if stateStoreErr != nil {
 		log.Error(stateStoreErr, "Could not open state store to delete persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
 	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
 	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
-		return noChange
+		return true, noChange
 	}
 	if recordErr != nil {
 		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
-	_, change := r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
-	return change
+	return r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
 }
 
 func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {

--- a/controllers/executable_persistence.go
+++ b/controllers/executable_persistence.go
@@ -17,90 +17,51 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
 	"github.com/microsoft/dcp/internal/statestore"
-	"github.com/microsoft/dcp/pkg/logger"
 	"github.com/microsoft/dcp/pkg/maps"
 	"github.com/microsoft/dcp/pkg/pointers"
 	"github.com/microsoft/dcp/pkg/process"
 )
 
-func (r *ExecutableReconciler) withPersistentExecutableLease(ctx context.Context, exe *apiv1.Executable, log logr.Logger, f func(context.Context, *statestore.ResourceLease) objectChange) objectChange {
-	if f == nil {
-		log.Error(fmt.Errorf("persistent Executable lease callback cannot be nil"), "Could not acquire persistent Executable resource lease")
-		return r.setExecutableState(exe, apiv1.ExecutableStateUnknown)
-	}
-
+func (r *ExecutableReconciler) acquirePersistentExecutableResourceLeaseAndRecord(ctx context.Context, exe *apiv1.Executable, log logr.Logger) (*statestore.ResourceLease, *statestore.PersistentProcessRecord, error) {
 	stateStore, stateStoreErr := r.getStateStore()
 	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Persistent Executable cannot be reconciled without a state store")
-		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+		return nil, nil, stateStoreErr
 	}
-	leaseOwner, leaseOwnerErr := r.getResourceLeaseOwner()
-	if leaseOwnerErr != nil {
-		log.Error(leaseOwnerErr, "Could not determine persistent Executable resource lease owner")
-		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	var change objectChange
-	leaseErr := stateStore.WithResourceLease(ctx, exe, leaseOwner, resourceLeaseRevalidationInterval, func(ctx context.Context, lease *statestore.ResourceLease) error {
-		log.V(1).Info("Acquired resource lease", "ResourceKey", lease.ResourceKey)
-		change = f(ctx, lease)
-		return nil
-	})
-	if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
-		logResourceLeaseHeld(log, leaseErr, exe.GetLeaseKey(), "Persistent Executable is being updated by another DCP instance, retrying")
-		return additionalReconciliationNeeded
-	}
-	if leaseErr != nil {
-		log.Error(leaseErr, "Could not acquire persistent Executable resource lease", "ResourceKey", exe.GetLeaseKey())
-		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	return change
-}
-
-func (r *ExecutableReconciler) acquirePersistentExecutableResourceLease(ctx context.Context, exe *apiv1.Executable, log logr.Logger) error {
-	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
-		return nil
-	}
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		return stateStoreErr
-	}
-	leaseOwner, leaseOwnerErr := r.getResourceLeaseOwner()
-	if leaseOwnerErr != nil {
-		return leaseOwnerErr
-	}
-
-	lease, leaseErr := stateStore.AcquireResourceLease(ctx, exe, leaseOwner, resourceLeaseRevalidationInterval)
+	lease, leaseErr := stateStore.AcquireResourceLease(ctx, exe, r.config.ResourceLeaseOwner, resourceLeaseRevalidationInterval)
 	if errors.Is(leaseErr, statestore.ErrResourceLeaseHeld) {
 		logResourceLeaseHeld(log, leaseErr, exe.GetLeaseKey(), "Persistent Executable is being updated by another DCP instance, retrying")
 	}
 	if leaseErr != nil {
-		return leaseErr
+		return nil, nil, leaseErr
 	}
 
 	log.V(1).Info("Acquired resource lease", "ResourceKey", lease.ResourceKey)
-	return nil
+	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
+	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
+		return lease, nil, nil
+	}
+	if recordErr != nil {
+		if releaseErr := lease.Release(ctx); releaseErr != nil {
+			log.Error(releaseErr, "Could not release persistent Executable resource lease after failing to read process record")
+		}
+		return nil, nil, recordErr
+	}
+
+	return lease, record, nil
 }
 
 func (r *ExecutableReconciler) verifyPersistentExecutableResourceLeaseHeld(ctx context.Context, exe *apiv1.Executable, log logr.Logger) error {
-	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
+	if !exe.Spec.EffectiveMode().ShouldReuseExisting() {
 		return nil
 	}
 	stateStore, stateStoreErr := r.getStateStore()
 	if stateStoreErr != nil {
 		return stateStoreErr
 	}
-	leaseOwner, leaseOwnerErr := r.getResourceLeaseOwner()
-	if leaseOwnerErr != nil {
-		return leaseOwnerErr
-	}
-
-	leaseErr := stateStore.VerifyResourceLeaseHeld(ctx, exe, leaseOwner)
+	leaseErr := stateStore.VerifyResourceLeaseHeld(ctx, exe, r.config.ResourceLeaseOwner)
 	if leaseErr != nil {
 		log.Error(leaseErr, "Cannot continue persistent Executable startup because this DCP instance does not hold the resource lease")
 		return leaseErr
@@ -115,19 +76,14 @@ func (r *ExecutableReconciler) releasePersistentExecutableResourceLease(
 	log logr.Logger,
 	suppressNotHeldLog bool,
 ) error {
-	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
+	if !exe.Spec.EffectiveMode().ShouldReuseExisting() {
 		return nil
 	}
 	stateStore, stateStoreErr := r.getStateStore()
 	if stateStoreErr != nil {
 		return stateStoreErr
 	}
-	leaseOwner, leaseOwnerErr := r.getResourceLeaseOwner()
-	if leaseOwnerErr != nil {
-		return leaseOwnerErr
-	}
-
-	releaseErr := stateStore.ReleaseResourceLease(ctx, exe, leaseOwner)
+	releaseErr := stateStore.ReleaseResourceLease(ctx, exe, r.config.ResourceLeaseOwner)
 	if releaseErr != nil {
 		if errors.Is(releaseErr, statestore.ErrResourceLeaseNotHeld) {
 			logResourceLeaseNotHeld(log, suppressNotHeldLog, exe.GetLeaseKey(), "Persistent Executable resource lease was not held")
@@ -140,295 +96,28 @@ func (r *ExecutableReconciler) releasePersistentExecutableResourceLease(
 	return nil
 }
 
-func persistentExecutableStartupInProgress(runInfo *ExecutableRunInfo) bool {
-	return runInfo != nil && runInfo.ExeState == apiv1.ExecutableStateStarting
-}
-
-func shouldReuseExistingProcess(mode apiv1.ExecutableMode) bool {
-	switch mode {
-	case apiv1.ExecutableModePersistent,
-		apiv1.ExecutableModeCleanup:
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldCreateProcessIfMissing(mode apiv1.ExecutableMode) bool {
-	switch mode {
-	case apiv1.ExecutableModeSession,
-		apiv1.ExecutableModePersistent:
-		return true
-	default:
-		return false
-	}
-}
-
-func shouldStopProcessOnDelete(mode apiv1.ExecutableMode) bool {
-	switch mode {
-	case apiv1.ExecutableModeSession,
-		apiv1.ExecutableModeCleanup:
-		return true
-	default:
-		return false
-	}
-}
-
-func (r *ExecutableReconciler) tryAdoptExistingPersistentExecutable(ctx context.Context, exe *apiv1.Executable, log logr.Logger) (bool, objectChange) {
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Persistent Executable cannot be reconciled without a state store")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
-	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
-		return false, noChange
-	}
-	if recordErr != nil {
-		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	if exe.Spec.Stop {
-		return r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
-	}
-
-	ri := NewRunInfo(exe)
-	computed, environmentChange := r.computeExecutableEnvironment(ctx, exe, log, ri)
-	if !computed {
-		return false, environmentChange
-	}
-
-	adopted, adoptionChange := r.tryAdoptPersistentExecutableRecord(ctx, exe, ri, record, log)
-	return adopted, environmentChange | adoptionChange
-}
-
-func (r *ExecutableReconciler) tryAdoptPersistentExecutable(ctx context.Context, exe *apiv1.Executable, runInfo *ExecutableRunInfo, log logr.Logger) (bool, objectChange) {
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Persistent Executable cannot be reconciled without a state store")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	resourceKey := exe.GetLeaseKey()
-	record, recordErr := stateStore.GetPersistentProcess(ctx, resourceKey)
-	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
-		return false, noChange
-	}
-	if recordErr != nil {
-		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", resourceKey)
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	return r.tryAdoptPersistentExecutableRecord(ctx, exe, runInfo, record, log)
-}
-
-func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, runInfo *ExecutableRunInfo, record *statestore.PersistentProcessRecord, log logr.Logger) (bool, objectChange) {
-	resourceKey := exe.GetLeaseKey()
-	lifecycleInfo, lifecycleKeyErr := persistentExecutableLifecycleInfo(exe)
-	if lifecycleKeyErr != nil {
-		log.Error(lifecycleKeyErr, "Could not calculate Executable lifecycle key")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
-	if persistentRunnerErr != nil {
-		log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	if record.LifecycleKey != lifecycleInfo.Key {
-		if lifecycleInfo.HasDefaultKey {
-			args, env, other := calculatePersistentExecutableChanges(record.LifecycleMetadata, lifecycleInfo.Metadata)
-			log.Info("Found existing persistent Executable process record, but calculated lifecycle key does not match",
-				"OldLifecycleKey", record.LifecycleKey,
-				"NewLifecycleKey", lifecycleInfo.Key,
-				"ArgChanges", args,
-				"EnvChanges", env,
-				"OtherChanges", other)
-		} else {
-			log.Info("Found existing persistent Executable process record, but custom lifecycle key does not match",
-				"OldLifecycleKey", record.LifecycleKey,
-				"NewLifecycleKey", lifecycleInfo.Key)
-		}
-		if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr == nil {
-			if !shouldCreateProcessIfMissing(exe.Spec.EffectiveMode()) && !exe.Spec.Stop {
-				log.Info("Found existing Executable process record, but lifecycle key does not match and mode does not allow replacing it",
-					"PID", record.PID,
-					"OldLifecycleKey", record.LifecycleKey,
-					"NewLifecycleKey", lifecycleInfo.Key)
-				return false, noChange
-			}
-			stopErr := r.stopPersistentExecutableRecord(ctx, exe, record, log)
-			if stopErr != nil {
-				log.Error(stopErr, "Could not stop persistent Executable process with stale lifecycle key", "PID", record.PID)
-				return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-			}
-		} else {
-			log.Info("Persistent Executable process record with stale lifecycle key is no longer running",
-				"PID", record.PID,
-				"Error", findErr.Error())
-		}
-		stateStore, stateStoreErr := r.getStateStore()
-		if stateStoreErr != nil {
-			log.Error(stateStoreErr, "Could not open state store to delete stale persistent Executable process record", "ResourceKey", resourceKey)
-			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		}
-		if deleteErr := stateStore.DeletePersistentProcess(ctx, resourceKey); deleteErr != nil {
-			log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", resourceKey)
-			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		}
-		if exe.Spec.Stop {
-			return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
-		}
-		return false, noChange
-	}
-
-	if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr != nil {
-		log.Info("Persistent Executable process record is stale; process is no longer running",
-			"PID", record.PID,
-			"Error", findErr.Error())
-		stateStore, stateStoreErr := r.getStateStore()
-		if stateStoreErr != nil {
-			log.Error(stateStoreErr, "Could not open state store to delete stale persistent Executable process record", "ResourceKey", resourceKey)
-			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		}
-		if deleteErr := stateStore.DeletePersistentProcess(ctx, resourceKey); deleteErr != nil {
-			log.Error(deleteErr, "Could not delete stale persistent Executable process record", "ResourceKey", resourceKey)
-			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		}
-		if exe.Spec.Stop {
-			return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
-		}
-		return false, noChange
-	}
+func (r *ExecutableReconciler) adoptPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, runInfo *ExecutableRunInfo, record *statestore.PersistentProcessRecord, persistentRunner PersistentExecutableRunner, log logr.Logger) (bool, objectChange) {
 	displayStartTime := process.StartTimeForProcess(record.PID)
 
 	runID := RunID(record.RunID)
-	adoptionErr := persistentRunner.AdoptRun(ctx, ExecutableRunAdoptionInfo{
-		RunID:               runID,
-		Pid:                 record.PID,
-		ProcessIdentityTime: record.IdentityTime,
-		StdOutFile:          record.StdOutFile,
-		StdErrFile:          record.StdErrFile,
-		CommandInfo:         exe.Spec.ExecutablePath,
-	}, r, log)
+	adoptionErr := persistentRunner.AdoptRun(ctx, exe, record, r, log)
 	if adoptionErr != nil {
 		log.Error(adoptionErr, "Could not adopt persistent Executable process")
 		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
-	ri := runInfo
-	if ri == nil {
-		ri = NewRunInfo(exe)
-	}
-	startingRunID := ri.RunID
-	ri.ExeState = apiv1.ExecutableStateRunning
-	ri.RunID = runID
-	pointers.SetValue(&ri.Pid, int64(record.PID))
-	ri.ProcessIdentityTime = record.IdentityTime
-	ri.StartupTimestamp = metav1.NewMicroTime(displayStartTime)
-	ri.StdOutFile = record.StdOutFile
-	ri.StdErrFile = record.StdErrFile
-	ri.startupStage = StartupStageDefaultRunner
-	if startingRunID == UnknownRunID {
-		r.runs.Store(exe.NamespacedName(), ri.RunID, ri.Clone())
-	} else {
-		r.runs.UpdateChangingStateKey(exe.NamespacedName(), startingRunID, ri.RunID, ri.Clone())
-	}
+	runInfo.ExeState = apiv1.ExecutableStateRunning
+	runInfo.RunID = runID
+	pointers.SetValue(&runInfo.Pid, int64(record.PID))
+	runInfo.ProcessIdentityTime = record.IdentityTime
+	runInfo.StartupTimestamp = metav1.NewMicroTime(displayStartTime)
+	runInfo.StdOutFile = record.StdOutFile
+	runInfo.StdErrFile = record.StdErrFile
+	runInfo.startupStage = StartupStageDefaultRunner
+	r.runs.Store(exe.NamespacedName(), runInfo.RunID, runInfo.Clone())
 
 	log.Info("Adopted persistent Executable process", "PID", record.PID, "RunID", runID)
-	return true, ri.ApplyTo(exe, log) | r.setExecutableState(exe, apiv1.ExecutableStateRunning)
-}
-
-func (r *ExecutableReconciler) finishPersistentExecutableStopWithoutStart(exe *apiv1.Executable, record *statestore.PersistentProcessRecord) objectChange {
-	change := noChange
-	if exe.Status.StdOutFile != record.StdOutFile {
-		exe.Status.StdOutFile = record.StdOutFile
-		change |= statusChanged
-	}
-	if exe.Status.StdErrFile != record.StdErrFile {
-		exe.Status.StdErrFile = record.StdErrFile
-		change |= statusChanged
-	}
-	exe.Status.ExecutionID = ""
-	exe.Status.PID = apiv1.UnknownPID
-	return change | r.setExecutableState(exe, apiv1.ExecutableStateFinished)
-}
-
-func (r *ExecutableReconciler) stopPersistentExecutableRecordWithoutLifecycle(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) (bool, objectChange) {
-	resourceKey := exe.GetLeaseKey()
-	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
-	if persistentRunnerErr != nil {
-		log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime)
-	if findErr == nil {
-		stopErr := r.stopPersistentExecutableRecord(ctx, exe, record, log)
-		if stopErr != nil {
-			log.Error(stopErr, "Could not stop persistent Executable process", "PID", record.PID)
-			return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-		}
-	} else {
-		log.Info("Persistent Executable process record is no longer running",
-			"PID", record.PID,
-			"Error", findErr.Error())
-	}
-
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Could not open state store to delete persistent Executable process record", "ResourceKey", resourceKey)
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-	if deleteErr := stateStore.DeletePersistentProcess(ctx, resourceKey); deleteErr != nil {
-		log.Error(deleteErr, "Could not delete persistent Executable process record", "ResourceKey", resourceKey)
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-	return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
-}
-
-func (r *ExecutableReconciler) stopPersistentExecutableRecordForDeletion(ctx context.Context, exe *apiv1.Executable, log logr.Logger) (bool, objectChange) {
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Could not open state store to delete persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
-	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
-		return true, noChange
-	}
-	if recordErr != nil {
-		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-
-	return r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
-}
-
-func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {
-	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
-	if persistentRunnerErr != nil {
-		return persistentRunnerErr
-	}
-
-	runID := RunID(record.RunID)
-	adoptionErr := persistentRunner.AdoptRun(ctx, ExecutableRunAdoptionInfo{
-		RunID:               runID,
-		Pid:                 record.PID,
-		ProcessIdentityTime: record.IdentityTime,
-		StdOutFile:          record.StdOutFile,
-		StdErrFile:          record.StdErrFile,
-		CommandInfo:         exe.Spec.ExecutablePath,
-	}, nil, log)
-	if adoptionErr != nil {
-		return fmt.Errorf("could not adopt persistent Executable process before stopping it: %w", adoptionErr)
-	}
-
-	return persistentRunner.StopRun(ctx, runID, log)
+	return true, runInfo.ApplyTo(exe, log) | r.setExecutableState(exe, apiv1.ExecutableStateRunning)
 }
 
 func (r *ExecutableReconciler) upsertPersistentProcessRecord(ctx context.Context, exe *apiv1.Executable, res *ExecutableStartResult) error {
@@ -445,73 +134,55 @@ func (r *ExecutableReconciler) upsertPersistentProcessRecord(ctx context.Context
 		return fmt.Errorf("cannot persist Executable process record with invalid PID %d: %w", *res.Pid, pidErr)
 	}
 
-	lifecycleInfo, lifecycleKeyErr := persistentExecutableLifecycleInfo(exe)
+	record := statestore.PersistentProcessRecord{
+		ResourceKey:  exe.GetLeaseKey(),
+		PID:          pid,
+		IdentityTime: res.ProcessIdentityTime,
+		RunID:        string(res.RunID),
+		StdOutFile:   res.StdOutFile,
+		StdErrFile:   res.StdErrFile,
+	}
+	lifecycleKey, hasDefaultLifecycleKey, lifecycleKeyErr := exe.GetLifecycleKey()
 	if lifecycleKeyErr != nil {
-		return fmt.Errorf("could not calculate Executable lifecycle key: %w", lifecycleKeyErr)
+		return fmt.Errorf("cannot calculate Executable lifecycle key: %w", lifecycleKeyErr)
+	}
+	record.LifecycleKey = lifecycleKey
+	if hasDefaultLifecycleKey {
+		lifecycleMetadata, lifecycleMetadataErr := persistentExecutableLifecycleMetadataFor(exe)
+		if lifecycleMetadataErr != nil {
+			return fmt.Errorf("cannot calculate Executable lifecycle metadata: %w", lifecycleMetadataErr)
+		}
+		record.LifecycleMetadata = lifecycleMetadata
 	}
 
-	return stateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
-		ResourceKey:       exe.GetLeaseKey(),
-		LifecycleKey:      lifecycleInfo.Key,
-		PID:               pid,
-		IdentityTime:      res.ProcessIdentityTime,
-		RunID:             string(res.RunID),
-		StdOutFile:        res.StdOutFile,
-		StdErrFile:        res.StdErrFile,
-		LifecycleMetadata: lifecycleInfo.Metadata,
-	})
-}
-
-type persistentExecutableLifecycleData struct {
-	Key           string
-	HasDefaultKey bool
-	Metadata      string
+	return stateStore.UpsertPersistentProcess(ctx, record)
 }
 
 type persistentExecutableLifecycleMetadata struct {
-	ExecutablePath                 string                            `json:"executablePath"`
-	WorkingDirectory               string                            `json:"workingDirectory,omitempty"`
-	AmbientEnvironment             string                            `json:"ambientEnvironment,omitempty"`
-	EffectiveArgs                  []string                          `json:"effectiveArgs,omitempty"`
-	ExplicitEffectiveEnv           []persistentExecutableEnvMetadata `json:"explicitEffectiveEnv,omitempty"`
-	PEMCertificates                []string                          `json:"pemCertificates,omitempty"`
-	PEMCertificatesContinueOnError bool                              `json:"pemCertificatesContinueOnError,omitempty"`
+	ExecutablePath                 string            `json:"executablePath"`
+	WorkingDirectory               string            `json:"workingDirectory,omitempty"`
+	AmbientEnvironment             string            `json:"ambientEnvironment,omitempty"`
+	EffectiveArgs                  []string          `json:"effectiveArgs,omitempty"`
+	ExplicitEffectiveEnv           map[string]string `json:"explicitEffectiveEnv,omitempty"`
+	PEMCertificates                []string          `json:"pemCertificates,omitempty"`
+	PEMCertificatesContinueOnError bool              `json:"pemCertificatesContinueOnError,omitempty"`
 }
 
-type persistentExecutableEnvMetadata struct {
-	Name      string `json:"name"`
-	ValueHash string `json:"valueHash"`
-}
-
-func persistentExecutableLifecycleInfo(exe *apiv1.Executable) (persistentExecutableLifecycleData, error) {
-	lifecycleKey, hasDefaultLifecycleKey, lifecycleKeyErr := exe.GetLifecycleKey()
-	if lifecycleKeyErr != nil {
-		return persistentExecutableLifecycleData{}, lifecycleKeyErr
-	}
-	if !hasDefaultLifecycleKey {
-		return persistentExecutableLifecycleData{
-			Key:           lifecycleKey,
-			HasDefaultKey: false,
-		}, nil
-	}
-
+func persistentExecutableLifecycleMetadataFor(exe *apiv1.Executable) (string, error) {
 	lifecycleSpec, lifecycleSpecErr := exe.EffectiveLifecycleSpec()
 	if lifecycleSpecErr != nil {
-		return persistentExecutableLifecycleData{}, lifecycleSpecErr
+		return "", lifecycleSpecErr
 	}
-	lifecycleMetadata := persistentExecutableLifecycleMetadata{
+	metadata := persistentExecutableLifecycleMetadata{
 		ExecutablePath:     lifecycleSpec.ExecutablePath,
 		WorkingDirectory:   lifecycleSpec.WorkingDirectory,
 		AmbientEnvironment: string(lifecycleSpec.AmbientEnvironment.Behavior),
 		EffectiveArgs:      stdslices.Clone(lifecycleSpec.Args),
 	}
 
-	lifecycleMetadata.ExplicitEffectiveEnv = make([]persistentExecutableEnvMetadata, 0, len(lifecycleSpec.Env))
+	metadata.ExplicitEffectiveEnv = make(map[string]string, len(lifecycleSpec.Env))
 	for _, envVar := range lifecycleSpec.Env {
-		lifecycleMetadata.ExplicitEffectiveEnv = append(lifecycleMetadata.ExplicitEffectiveEnv, persistentExecutableEnvMetadata{
-			Name:      envVar.Name,
-			ValueHash: fmt.Sprintf("%x", sha256.Sum256([]byte(envVar.Value))),
-		})
+		metadata.ExplicitEffectiveEnv[envVar.Name] = fmt.Sprintf("%x", sha256.Sum256([]byte(envVar.Value)))
 	}
 
 	if lifecycleSpec.PemCertificates != nil {
@@ -519,35 +190,35 @@ func persistentExecutableLifecycleInfo(exe *apiv1.Executable) (persistentExecuta
 		stdslices.SortFunc(sortedPemCertificates, func(c1, c2 apiv1.PemCertificate) int {
 			return strings.Compare(c1.Thumbprint, c2.Thumbprint)
 		})
-
 		for i := range sortedPemCertificates {
-			lifecycleMetadata.PEMCertificates = append(lifecycleMetadata.PEMCertificates, sortedPemCertificates[i].Thumbprint)
+			metadata.PEMCertificates = append(metadata.PEMCertificates, sortedPemCertificates[i].Thumbprint)
 		}
-		lifecycleMetadata.PEMCertificatesContinueOnError = lifecycleSpec.PemCertificates.ContinueOnError
+		metadata.PEMCertificatesContinueOnError = lifecycleSpec.PemCertificates.ContinueOnError
 	}
 
-	metadataBytes, metadataErr := json.Marshal(lifecycleMetadata)
+	metadataBytes, metadataErr := json.Marshal(metadata)
 	if metadataErr != nil {
-		return persistentExecutableLifecycleData{}, metadataErr
+		return "", metadataErr
 	}
 
-	return persistentExecutableLifecycleData{
-		Key:           lifecycleKey,
-		HasDefaultKey: true,
-		Metadata:      string(metadataBytes),
-	}, nil
+	return string(metadataBytes), nil
 }
 
-func calculatePersistentExecutableChanges(oldMetadata, newMetadata string) (args []string, env []string, other []string) {
+func calculatePersistentExecutableChanges(exe *apiv1.Executable, oldMetadata string) (args []string, env []string, other []string) {
 	if oldMetadata == "" {
 		return nil, nil, []string{"Executable lifecycle metadata was not recorded for the existing process"}
+	}
+
+	newMetadata, newMetadataErr := persistentExecutableLifecycleMetadataFor(exe)
+	if newMetadataErr != nil {
+		return nil, nil, []string{"Executable lifecycle metadata could not be calculated"}
 	}
 
 	var oldLifecycleMetadata persistentExecutableLifecycleMetadata
 	var newLifecycleMetadata persistentExecutableLifecycleMetadata
 	oldMetadataErr := json.Unmarshal([]byte(oldMetadata), &oldLifecycleMetadata)
-	newMetadataErr := json.Unmarshal([]byte(newMetadata), &newLifecycleMetadata)
-	if oldMetadataErr != nil || newMetadataErr != nil {
+	newMetadataDecodeErr := json.Unmarshal([]byte(newMetadata), &newLifecycleMetadata)
+	if oldMetadataErr != nil || newMetadataDecodeErr != nil {
 		return nil, nil, []string{"Executable lifecycle metadata could not be decoded"}
 	}
 
@@ -574,24 +245,15 @@ func calculatePersistentExecutableChanges(oldMetadata, newMetadata string) (args
 	return args, env, other
 }
 
-func changedExecutableEnvNames(oldEnv, newEnv []persistentExecutableEnvMetadata) []string {
-	oldEnvByName := map[string]string{}
-	newEnvByName := map[string]string{}
-	for _, envVar := range oldEnv {
-		oldEnvByName[envVar.Name] = envVar.ValueHash
-	}
-	for _, envVar := range newEnv {
-		newEnvByName[envVar.Name] = envVar.ValueHash
-	}
-
+func changedExecutableEnvNames(oldEnv, newEnv map[string]string) []string {
 	changedEnv := map[string]bool{}
-	for name, oldValueHash := range oldEnvByName {
-		if newValueHash, found := newEnvByName[name]; !found || oldValueHash != newValueHash {
+	for name, oldValueHash := range oldEnv {
+		if newValueHash, found := newEnv[name]; !found || oldValueHash != newValueHash {
 			changedEnv[name] = true
 		}
 	}
-	for name := range newEnvByName {
-		if _, found := oldEnvByName[name]; !found {
+	for name := range newEnv {
+		if _, found := oldEnv[name]; !found {
 			changedEnv[name] = true
 		}
 	}
@@ -601,104 +263,11 @@ func changedExecutableEnvNames(oldEnv, newEnv []persistentExecutableEnvMetadata)
 	return changedNames
 }
 
-func (r *ExecutableReconciler) deletePersistentProcessRecord(ctx context.Context, name types.NamespacedName, log logr.Logger) {
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		return
-	}
-
-	deleteErr := stateStore.DeletePersistentProcess(ctx, name.String())
-	if deleteErr != nil {
-		log.Error(deleteErr, "Could not delete persistent Executable process record", "Executable", name.String())
-	}
-}
-
-func (r *ExecutableReconciler) deletePersistentProcessRecordWithLease(ctx context.Context, name types.NamespacedName, log logr.Logger) {
-	exe := &apiv1.Executable{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
-		Spec: apiv1.ExecutableSpec{
-			Persistent: true,
-		},
-	}
-	_ = r.withPersistentExecutableLease(ctx, exe, log, func(ctx context.Context, _ *statestore.ResourceLease) objectChange {
-		r.deletePersistentProcessRecord(ctx, name, log)
-		return noChange
-	})
-}
-
 func (r *ExecutableReconciler) getStateStore() (*statestore.Store, error) {
 	if r.config.StateStore == nil {
 		return nil, fmt.Errorf("state store is not configured")
 	}
 	return r.config.StateStore, nil
-}
-
-func (r *ExecutableReconciler) getResourceLeaseOwner() (process.ProcessTreeItem, error) {
-	if r.config.ResourceLeaseOwner.Pid > 0 && !r.config.ResourceLeaseOwner.IdentityTime.IsZero() {
-		return r.config.ResourceLeaseOwner, nil
-	}
-	return statestore.CurrentResourceLeaseOwner()
-}
-
-func (r *ExecutableReconciler) releasePersistentExecutableResources(ctx context.Context, exe *apiv1.Executable, runInfo *ExecutableRunInfo, log logr.Logger) {
-	r.disableEndpointsAndHealthProbes(ctx, exe, runInfo, log)
-	logger.ReleaseResourceLog(exe.GetResourceId())
-	if runInfo != nil && runInfo.RunID != UnknownRunID {
-		runner, runnerErr := r.getExecutableRunner(exe, runInfo.startupStage)
-		if runnerErr != nil {
-			log.Error(runnerErr, "Could not release persistent Executable runner tracking", "RunID", runInfo.RunID)
-		} else if releaseErr := runner.ReleaseRun(ctx, runInfo.RunID, log); releaseErr != nil {
-			log.Error(releaseErr, "Could not release persistent Executable runner tracking", "RunID", runInfo.RunID)
-		}
-	}
-	if r.persistentProcessRecordCanBeReused(ctx, exe, log) {
-		log.V(1).Info("Preserving persistent Executable process record for reuse", "ResourceKey", exe.GetLeaseKey())
-		return
-	}
-	r.deletePersistentProcessRecord(ctx, exe.NamespacedName(), log)
-}
-
-func (r *ExecutableReconciler) persistentProcessRecordCanBeReused(ctx context.Context, exe *apiv1.Executable, log logr.Logger) bool {
-	stateStore, stateStoreErr := r.getStateStore()
-	if stateStoreErr != nil {
-		log.Error(stateStoreErr, "Could not determine whether persistent Executable process record can be reused", "ResourceKey", exe.GetLeaseKey())
-		return false
-	}
-
-	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
-	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
-		return false
-	}
-	if recordErr != nil {
-		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
-		return false
-	}
-
-	lifecycleInfo, lifecycleKeyErr := persistentExecutableLifecycleInfo(exe)
-	if lifecycleKeyErr != nil {
-		log.Error(lifecycleKeyErr, "Could not calculate Executable lifecycle key")
-		return false
-	}
-	if record.LifecycleKey != lifecycleInfo.Key {
-		return false
-	}
-
-	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
-	if persistentRunnerErr != nil {
-		log.Error(persistentRunnerErr, "Could not determine whether persistent Executable process record can be reused", "ResourceKey", exe.GetLeaseKey())
-		return false
-	}
-	if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr != nil {
-		log.Info("Persistent Executable process record is not reusable because the process is no longer running",
-			"PID", record.PID,
-			"Error", findErr.Error())
-		return false
-	}
-
-	return true
 }
 
 func (r *ExecutableReconciler) getPersistentExecutableRunner(exe *apiv1.Executable) (PersistentExecutableRunner, error) {

--- a/controllers/executable_persistence.go
+++ b/controllers/executable_persistence.go
@@ -63,7 +63,7 @@ func (r *ExecutableReconciler) withPersistentExecutableLease(ctx context.Context
 }
 
 func (r *ExecutableReconciler) acquirePersistentExecutableResourceLease(ctx context.Context, exe *apiv1.Executable, log logr.Logger) error {
-	if !exe.Spec.Persistent {
+	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
 		return nil
 	}
 	stateStore, stateStoreErr := r.getStateStore()
@@ -88,7 +88,7 @@ func (r *ExecutableReconciler) acquirePersistentExecutableResourceLease(ctx cont
 }
 
 func (r *ExecutableReconciler) verifyPersistentExecutableResourceLeaseHeld(ctx context.Context, exe *apiv1.Executable, log logr.Logger) error {
-	if !exe.Spec.Persistent {
+	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
 		return nil
 	}
 	stateStore, stateStoreErr := r.getStateStore()
@@ -115,7 +115,7 @@ func (r *ExecutableReconciler) releasePersistentExecutableResourceLease(
 	log logr.Logger,
 	suppressNotHeldLog bool,
 ) error {
-	if !exe.Spec.Persistent {
+	if !shouldReuseExistingProcess(exe.Spec.EffectiveMode()) {
 		return nil
 	}
 	stateStore, stateStoreErr := r.getStateStore()
@@ -142,6 +142,36 @@ func (r *ExecutableReconciler) releasePersistentExecutableResourceLease(
 
 func persistentExecutableStartupInProgress(runInfo *ExecutableRunInfo) bool {
 	return runInfo != nil && runInfo.ExeState == apiv1.ExecutableStateStarting
+}
+
+func shouldReuseExistingProcess(mode apiv1.ExecutableMode) bool {
+	switch mode {
+	case apiv1.ExecutableModePersistent,
+		apiv1.ExecutableModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldCreateProcessIfMissing(mode apiv1.ExecutableMode) bool {
+	switch mode {
+	case apiv1.ExecutableModeSession,
+		apiv1.ExecutableModePersistent:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldStopProcessOnDelete(mode apiv1.ExecutableMode) bool {
+	switch mode {
+	case apiv1.ExecutableModeSession,
+		apiv1.ExecutableModeCleanup:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *ExecutableReconciler) tryAdoptExistingPersistentExecutable(ctx context.Context, exe *apiv1.Executable, log logr.Logger) (bool, objectChange) {
@@ -202,6 +232,12 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
 
+	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+	if persistentRunnerErr != nil {
+		log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+	}
+
 	if record.LifecycleKey != lifecycleInfo.Key {
 		if lifecycleInfo.HasDefaultKey {
 			args, env, other := calculatePersistentExecutableChanges(record.LifecycleMetadata, lifecycleInfo.Metadata)
@@ -216,7 +252,14 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 				"OldLifecycleKey", record.LifecycleKey,
 				"NewLifecycleKey", lifecycleInfo.Key)
 		}
-		if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr == nil {
+		if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr == nil {
+			if !shouldCreateProcessIfMissing(exe.Spec.EffectiveMode()) && !exe.Spec.Stop {
+				log.Info("Found existing Executable process record, but lifecycle key does not match and mode does not allow replacing it",
+					"PID", record.PID,
+					"OldLifecycleKey", record.LifecycleKey,
+					"NewLifecycleKey", lifecycleInfo.Key)
+				return false, noChange
+			}
 			stopErr := r.stopPersistentExecutableRecord(ctx, exe, record, log)
 			if stopErr != nil {
 				log.Error(stopErr, "Could not stop persistent Executable process with stale lifecycle key", "PID", record.PID)
@@ -242,7 +285,7 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 		return false, noChange
 	}
 
-	if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr != nil {
+	if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr != nil {
 		log.Info("Persistent Executable process record is stale; process is no longer running",
 			"PID", record.PID,
 			"Error", findErr.Error())
@@ -261,17 +304,6 @@ func (r *ExecutableReconciler) tryAdoptPersistentExecutableRecord(ctx context.Co
 		return false, noChange
 	}
 	displayStartTime := process.StartTimeForProcess(record.PID)
-
-	runner, runnerErr := r.getExecutableRunner(exe, StartupStageDefaultRunner)
-	if runnerErr != nil {
-		log.Error(runnerErr, "The persistent Executable runner is not available")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
-	persistentRunner, ok := runner.(PersistentExecutableRunner)
-	if !ok {
-		log.Error(fmt.Errorf("runner does not support persistent run adoption"), "The persistent Executable cannot be adopted")
-		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
-	}
 
 	runID := RunID(record.RunID)
 	adoptionErr := persistentRunner.AdoptRun(ctx, ExecutableRunAdoptionInfo{
@@ -327,7 +359,14 @@ func (r *ExecutableReconciler) finishPersistentExecutableStopWithoutStart(exe *a
 
 func (r *ExecutableReconciler) stopPersistentExecutableRecordWithoutLifecycle(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) (bool, objectChange) {
 	resourceKey := exe.GetLeaseKey()
-	if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr == nil {
+	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+	if persistentRunnerErr != nil {
+		log.Error(persistentRunnerErr, "The persistent Executable runner is not available")
+		return false, r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+	}
+
+	findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime)
+	if findErr == nil {
 		stopErr := r.stopPersistentExecutableRecord(ctx, exe, record, log)
 		if stopErr != nil {
 			log.Error(stopErr, "Could not stop persistent Executable process", "PID", record.PID)
@@ -351,14 +390,30 @@ func (r *ExecutableReconciler) stopPersistentExecutableRecordWithoutLifecycle(ct
 	return true, r.finishPersistentExecutableStopWithoutStart(exe, record)
 }
 
-func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {
-	runner, runnerErr := r.getExecutableRunner(exe, StartupStageDefaultRunner)
-	if runnerErr != nil {
-		return fmt.Errorf("persistent Executable runner is not available: %w", runnerErr)
+func (r *ExecutableReconciler) stopPersistentExecutableRecordForDeletion(ctx context.Context, exe *apiv1.Executable, log logr.Logger) objectChange {
+	stateStore, stateStoreErr := r.getStateStore()
+	if stateStoreErr != nil {
+		log.Error(stateStoreErr, "Could not open state store to delete persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
+		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 	}
-	persistentRunner, ok := runner.(PersistentExecutableRunner)
-	if !ok {
-		return fmt.Errorf("runner does not support persistent run adoption")
+
+	record, recordErr := stateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
+	if errors.Is(recordErr, statestore.ErrPersistentProcessNotFound) {
+		return noChange
+	}
+	if recordErr != nil {
+		log.Error(recordErr, "Could not read persistent Executable process record", "ResourceKey", exe.GetLeaseKey())
+		return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
+	}
+
+	_, change := r.stopPersistentExecutableRecordWithoutLifecycle(ctx, exe, record, log)
+	return change
+}
+
+func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {
+	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+	if persistentRunnerErr != nil {
+		return persistentRunnerErr
 	}
 
 	runID := RunID(record.RunID)
@@ -374,7 +429,7 @@ func (r *ExecutableReconciler) stopPersistentExecutableRecord(ctx context.Contex
 		return fmt.Errorf("could not adopt persistent Executable process before stopping it: %w", adoptionErr)
 	}
 
-	return runner.StopRun(ctx, runID, log)
+	return persistentRunner.StopRun(ctx, runID, log)
 }
 
 func (r *ExecutableReconciler) upsertPersistentProcessRecord(ctx context.Context, exe *apiv1.Executable, res *ExecutableStartResult) error {
@@ -632,7 +687,12 @@ func (r *ExecutableReconciler) persistentProcessRecordCanBeReused(ctx context.Co
 		return false
 	}
 
-	if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr != nil {
+	persistentRunner, persistentRunnerErr := r.getPersistentExecutableRunner(exe)
+	if persistentRunnerErr != nil {
+		log.Error(persistentRunnerErr, "Could not determine whether persistent Executable process record can be reused", "ResourceKey", exe.GetLeaseKey())
+		return false
+	}
+	if findErr := persistentRunner.FindProcess(record.PID, record.IdentityTime); findErr != nil {
 		log.Info("Persistent Executable process record is not reusable because the process is no longer running",
 			"PID", record.PID,
 			"Error", findErr.Error())
@@ -640,4 +700,17 @@ func (r *ExecutableReconciler) persistentProcessRecordCanBeReused(ctx context.Co
 	}
 
 	return true
+}
+
+func (r *ExecutableReconciler) getPersistentExecutableRunner(exe *apiv1.Executable) (PersistentExecutableRunner, error) {
+	runner, runnerErr := r.getExecutableRunner(exe, StartupStageDefaultRunner)
+	if runnerErr != nil {
+		return nil, fmt.Errorf("persistent Executable runner is not available: %w", runnerErr)
+	}
+	persistentRunner, ok := runner.(PersistentExecutableRunner)
+	if !ok {
+		return nil, fmt.Errorf("runner does not support persistent Executable process operations")
+	}
+
+	return persistentRunner, nil
 }

--- a/controllers/executable_runner.go
+++ b/controllers/executable_runner.go
@@ -67,6 +67,9 @@ type PersistentExecutableRunner interface {
 		runChangeHandler RunChangeHandler,
 		log logr.Logger,
 	) error
+
+	// Finds the process associated with a persistent run.
+	FindProcess(pid process.Pid_t, processStartTime time.Time) error
 }
 
 type RunMessageLevel string

--- a/controllers/executable_runner.go
+++ b/controllers/executable_runner.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
+	"github.com/microsoft/dcp/internal/statestore"
 
 	"github.com/microsoft/dcp/pkg/process"
 )
@@ -48,28 +49,23 @@ type ExecutableRunner interface {
 	ReleaseRun(ctx context.Context, runID RunID, log logr.Logger) error
 }
 
-type ExecutableRunAdoptionInfo struct {
-	RunID               RunID
-	Pid                 process.Pid_t
-	ProcessIdentityTime time.Time
-	StdOutFile          string
-	StdErrFile          string
-	CommandInfo         string
-}
-
 type PersistentExecutableRunner interface {
 	ExecutableRunner
 
-	// Adopts a persistent run that was started by a previous DCP controller instance.
+	// Adopts a persistent process record for controller-side tracking.
 	AdoptRun(
 		ctx context.Context,
-		run ExecutableRunAdoptionInfo,
+		exe *apiv1.Executable,
+		record *statestore.PersistentProcessRecord,
 		runChangeHandler RunChangeHandler,
 		log logr.Logger,
 	) error
 
-	// Finds the process associated with a persistent run.
-	FindProcess(pid process.Pid_t, processStartTime time.Time) error
+	// Stops the process referenced by a persistent process record without adopting it.
+	StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error
+
+	// Checks that the process associated with a persistent run is running.
+	CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error
 }
 
 type RunMessageLevel string

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -306,14 +306,13 @@ func (r *NetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *NetworkReconciler) deleteNetwork(ctx context.Context, network *apiv1.ContainerNetwork, log logr.Logger) error {
-	if network.Spec.Persistent {
+	if !shouldDeleteNetwork(network.Spec.EffectiveMode()) {
 		return nil
 	}
 
-	_, networkState := r.existingNetworks.BorrowByNamespacedName(network.NamespacedName())
-	if networkState != nil && networkState.state == apiv1.ContainerNetworkStateRunning {
+	if network.Status.ID != "" {
 		inspectedNetwork, err := r.orchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
-			Networks: []string{networkState.id},
+			Networks: []string{network.Status.ID},
 		})
 
 		if errors.Is(err, containers.ErrNotFound) {
@@ -326,7 +325,7 @@ func (r *NetworkReconciler) deleteNetwork(ctx context.Context, network *apiv1.Co
 
 		for _, container := range inspectedNetwork[0].Containers {
 			disconnectErr := r.orchestrator.DisconnectNetwork(ctx, containers.DisconnectNetworkOptions{
-				Network:   networkState.id,
+				Network:   network.Status.ID,
 				Container: container.Id,
 			})
 
@@ -340,7 +339,7 @@ func (r *NetworkReconciler) deleteNetwork(ctx context.Context, network *apiv1.Co
 			return err
 		}
 
-		err = removeNetwork(ctx, r.orchestrator, networkState.id, log)
+		err = removeNetwork(ctx, r.orchestrator, network.Status.ID, log)
 		if err != nil {
 			return err
 		}
@@ -380,7 +379,7 @@ func (r *NetworkReconciler) ensureNetwork(ctx context.Context, network *apiv1.Co
 	r.ensureNetworkWatch(network, log)
 
 	networkName := strings.TrimSpace(network.Spec.NetworkName)
-	if network.Spec.Persistent {
+	if network.Spec.EffectiveMode() == apiv1.ContainerNetworkModePersistent {
 		var change objectChange
 		if r.config.StateStore == nil {
 			stateStoreErr := fmt.Errorf("state store is not configured")
@@ -430,14 +429,15 @@ func (r *NetworkReconciler) failNetworkToStart(network *apiv1.ContainerNetwork, 
 }
 
 func (r *NetworkReconciler) ensureNetworkWithName(ctx context.Context, network *apiv1.ContainerNetwork, networkName string, log logr.Logger) objectChange {
-	if network.Spec.Persistent {
+	effectiveMode := network.Spec.EffectiveMode()
+	if shouldReuseExistingNetwork(effectiveMode) {
 		isNetworkSafeToReuse := r.harvester.IsDone() || r.harvester.TryProtectNetwork(ctx, networkName)
 		existing, err := inspectNetworkIfExists(ctx, r.orchestrator, networkName)
 		if err == nil {
 			if !isNetworkSafeToReuse {
 				// If the harvester is not done, we need to wait for it to complete before we can safely re-use an
 				// existing network.
-				log.V(1).Info("Waiting for the resource harvester to finish before re-using persistent network")
+				log.V(1).Info("Waiting for the resource harvester to finish before re-using existing network")
 				return additionalReconciliationNeeded
 			}
 
@@ -451,6 +451,19 @@ func (r *NetworkReconciler) ensureNetworkWithName(ctx context.Context, network *
 			network.Status.Subnets = existing.Subnets
 			network.Status.Gateways = existing.Gateways
 			return statusChanged
+		}
+		if !errors.Is(err, containers.ErrNotFound) {
+			log.Error(err, "Could not inspect existing network")
+			return additionalReconciliationNeeded
+		}
+		if !shouldCreateMissingNetwork(effectiveMode) {
+			if network.Status.ID != "" {
+				network.Status.ID = ""
+			}
+			if network.Status.NetworkName != networkName {
+				network.Status.NetworkName = networkName
+			}
+			return statusChanged | r.setNetworkState(network, apiv1.ContainerNetworkStateNotFound, "")
 		}
 	}
 
@@ -469,7 +482,7 @@ func (r *NetworkReconciler) ensureNetworkWithName(ctx context.Context, network *
 		Name: networkName,
 		IPv6: network.Spec.IPv6,
 		Labels: map[string]string{
-			PersistentLabel: fmt.Sprintf("%t", network.Spec.Persistent),
+			PersistentLabel: fmt.Sprintf("%t", effectiveMode == apiv1.ContainerNetworkModePersistent),
 		},
 	}
 
@@ -482,7 +495,7 @@ func (r *NetworkReconciler) ensureNetworkWithName(ctx context.Context, network *
 	}
 
 	cnet, err := createNetwork(ctx, r.orchestrator, createOptions)
-	if network.Spec.Persistent && errors.Is(err, containers.ErrAlreadyExists) {
+	if effectiveMode == apiv1.ContainerNetworkModePersistent && errors.Is(err, containers.ErrAlreadyExists) {
 		log.V(1).Info("Persistent network already exists, but initial inspection failed, retrying...")
 		return additionalReconciliationNeeded
 	} else if errors.Is(err, containers.ErrCouldNotAllocate) {
@@ -529,7 +542,7 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 	if networkState.connections == nil {
 		networkState.connections = make(map[string]*connectionState)
 
-		if !network.Spec.Persistent {
+		if !shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
 			// If this is not a persistent network, we assume these were all connected by us
 			for _, containerID := range network.Status.ContainerIDs {
 				networkState.connections[containerID] = &connectionState{}
@@ -551,7 +564,7 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 		}
 
 		_, knownConnection := networkState.connections[containerID]
-		if !knownConnection && network.Spec.Persistent {
+		if !knownConnection && shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
 			// If this is a persistent network, we shouldn't disconnect any containers that we didn't explicitly connect
 			continue
 		}
@@ -712,7 +725,7 @@ func (r *NetworkReconciler) setNetworkState(network *apiv1.ContainerNetwork, sta
 		change = statusChanged
 	}
 
-	if network.Spec.Persistent && persistentNetworkLeaseReleaseState(state) {
+	if network.Spec.EffectiveMode() == apiv1.ContainerNetworkModePersistent && persistentNetworkLeaseReleaseState(state) {
 		// Intentionally ignore errors: this is a defensive, idempotent release attempt for stable states.
 		_ = r.releasePersistentNetworkResourceLease(context.Background(), network, r.Log, true)
 	}
@@ -732,13 +745,48 @@ func persistentNetworkLeaseReleaseState(state apiv1.ContainerNetworkState) bool 
 	}
 }
 
+func shouldReuseExistingNetwork(mode apiv1.ContainerNetworkMode) bool {
+	switch mode {
+	case apiv1.ContainerNetworkModePersistent,
+		apiv1.ContainerNetworkModeExisting,
+		apiv1.ContainerNetworkModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldCreateMissingNetwork(mode apiv1.ContainerNetworkMode) bool {
+	switch mode {
+	case apiv1.ContainerNetworkModeSession,
+		apiv1.ContainerNetworkModePersistent:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldDeleteNetwork(mode apiv1.ContainerNetworkMode) bool {
+	switch mode {
+	case apiv1.ContainerNetworkModeSession,
+		apiv1.ContainerNetworkModeCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldKeepUnmanagedConnections(mode apiv1.ContainerNetworkMode) bool {
+	return mode != apiv1.ContainerNetworkModeSession
+}
+
 func (r *NetworkReconciler) releasePersistentNetworkResourceLease(
 	ctx context.Context,
 	network *apiv1.ContainerNetwork,
 	log logr.Logger,
 	suppressNotHeldLog bool,
 ) error {
-	if !network.Spec.Persistent || r.config.StateStore == nil ||
+	if network.Spec.EffectiveMode() != apiv1.ContainerNetworkModePersistent || r.config.StateStore == nil ||
 		r.config.ResourceLeaseOwner.Pid <= 0 || r.config.ResourceLeaseOwner.IdentityTime.IsZero() {
 		return nil
 	}

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -557,7 +557,7 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 		networkState.connections = make(map[string]*connectionState)
 
 		if !shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
-			// If this is not a persistent network, we assume these were all connected by us
+			// Session networks are fully managed by this resource, so assume these were all connected by us.
 			for _, containerID := range network.Status.ContainerIDs {
 				networkState.connections[containerID] = &connectionState{}
 			}
@@ -579,7 +579,7 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 
 		_, knownConnection := networkState.connections[containerID]
 		if !knownConnection && shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
-			// If this is a persistent network, we shouldn't disconnect any containers that we didn't explicitly connect
+			// Reused networks may have unmanaged connections, so only disconnect containers explicitly connected by us.
 			continue
 		}
 

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -277,15 +277,26 @@ func (r *NetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if network.DeletionTimestamp != nil && !network.DeletionTimestamp.IsZero() {
 		log.Info("ContainerNetwork object is being deleted")
 
-		err = r.deleteNetwork(ctx, &network, log)
-		if err != nil {
-			// deleteNetwork() logged the error already
-			change = additionalReconciliationNeeded
+		_, networkState := r.existingNetworks.BorrowByNamespacedName(network.NamespacedName())
+		if network.Spec.EffectiveMode() == apiv1.ContainerNetworkModeCleanup &&
+			networkState == nil &&
+			network.Status.State != apiv1.ContainerNetworkStateNotFound {
+			log.V(1).Info("ContainerNetwork is being deleted, resolving cleanup target before deleting finalizer")
+			change = r.manageNetwork(ctx, &network, log) | additionalReconciliationNeeded
 		} else {
-			// We've successfully deleted the network, so stop tracking it
-			r.existingNetworks.DeleteByNamespacedName(network.NamespacedName())
-			change = deleteFinalizer(&network, networkFinalizer, log)
-			r.releaseNetworkWatch(&network, log)
+			if networkState != nil && network.Status.ID == "" {
+				network.Status.ID = networkState.id
+			}
+			err = r.deleteNetwork(ctx, &network, log)
+			if err != nil {
+				// deleteNetwork() logged the error already
+				change = additionalReconciliationNeeded
+			} else {
+				// We've successfully deleted the network, so stop tracking it
+				r.existingNetworks.DeleteByNamespacedName(network.NamespacedName())
+				change = deleteFinalizer(&network, networkFinalizer, log)
+				r.releaseNetworkWatch(&network, log)
+			}
 		}
 	} else {
 		change = ensureFinalizer(&network, networkFinalizer, log)

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -457,13 +457,16 @@ func (r *NetworkReconciler) ensureNetworkWithName(ctx context.Context, network *
 			return additionalReconciliationNeeded
 		}
 		if !shouldCreateMissingNetwork(effectiveMode) {
+			change := noChange
 			if network.Status.ID != "" {
 				network.Status.ID = ""
+				change |= statusChanged
 			}
 			if network.Status.NetworkName != networkName {
 				network.Status.NetworkName = networkName
+				change |= statusChanged
 			}
-			return statusChanged | r.setNetworkState(network, apiv1.ContainerNetworkStateNotFound, "")
+			return change | r.setNetworkState(network, apiv1.ContainerNetworkStateNotFound, "")
 		}
 	}
 

--- a/internal/contextdata/contextdata.go
+++ b/internal/contextdata/contextdata.go
@@ -66,6 +66,10 @@ func (*dummyProcessExecutor) StopProcess(_ process.Pid_t, _ time.Time, _ ...proc
 	return fmt.Errorf("there is no process executor configured, no processes can be stopped")
 }
 
+func (*dummyProcessExecutor) FindProcess(_ process.Pid_t, _ time.Time) error {
+	return fmt.Errorf("there is no process executor configured, no processes can be found")
+}
+
 func (*dummyProcessExecutor) StartAndForget(_ *exec.Cmd, _ process.ProcessCreationFlag) (process.Pid_t, time.Time, error) {
 	return process.UnknownPID, time.Time{}, fmt.Errorf("there is no process executor configured, no processes can be started")
 }

--- a/internal/contextdata/contextdata.go
+++ b/internal/contextdata/contextdata.go
@@ -66,8 +66,8 @@ func (*dummyProcessExecutor) StopProcess(_ process.Pid_t, _ time.Time, _ ...proc
 	return fmt.Errorf("there is no process executor configured, no processes can be stopped")
 }
 
-func (*dummyProcessExecutor) FindProcess(_ process.Pid_t, _ time.Time) error {
-	return fmt.Errorf("there is no process executor configured, no processes can be found")
+func (*dummyProcessExecutor) CheckProcessRunning(_ process.Pid_t, _ time.Time) error {
+	return fmt.Errorf("there is no process executor configured, no processes can be checked")
 }
 
 func (*dummyProcessExecutor) StartAndForget(_ *exec.Cmd, _ process.ProcessCreationFlag) (process.Pid_t, time.Time, error) {

--- a/internal/dcpctrl/commands/persistent_process_cleanup.go
+++ b/internal/dcpctrl/commands/persistent_process_cleanup.go
@@ -108,7 +108,7 @@ func cleanupInvalidPersistentExecutableRecord(
 			"PID", currentRecord.PID,
 			"Error", findErr.Error())
 
-		if deleteErr := stateStore.DeletePersistentProcess(ctx, currentRecord.ResourceKey); deleteErr != nil {
+		if deleteErr := currentRecord.Delete(ctx); deleteErr != nil {
 			return fmt.Errorf("could not delete invalid persistent Executable process record '%s': %w", currentRecord.ResourceKey, deleteErr)
 		}
 		return removePersistentExecutableRecordLogs(ctx, *currentRecord, log)

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/microsoft/dcp/controllers"
 	"github.com/microsoft/dcp/internal/dcpproc"
 	"github.com/microsoft/dcp/internal/logs"
+	"github.com/microsoft/dcp/internal/statestore"
 	"github.com/microsoft/dcp/internal/termpty"
 	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/osutil"
@@ -223,15 +224,7 @@ func (r *ProcessExecutableRunner) startProcessRun(
 		return result
 	}
 
-	if !executableIsPersistent(exe) {
-		// Use original log here, the watcher is a different process.
-		dcpproc.RunProcessWatcher(r.pe, pid, processIdentityTime, startLog)
-	} else if monitor, found, monitorErr := dcpproc.MonitorTargetFromFields(exe.Spec.MonitorPID, exe.Spec.MonitorTimestamp); monitorErr != nil {
-		startLog.Error(monitorErr, "Could not start persistent Executable lifecycle monitor")
-	} else if found {
-		// Use original log here, the watcher is a different process.
-		dcpproc.RunProcessWatcherForMonitor(r.pe, monitor, pid, processIdentityTime, startLog)
-	}
+	r.runExecutableLifecycleMonitor(exe, pid, processIdentityTime, startLog)
 
 	r.runningProcesses.Store(pidToRunID(pid), &processRunState{
 		pid:              pid,
@@ -336,6 +329,8 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 	}
 
 	runID := pidToRunID(ptp.PID)
+	r.runExecutableLifecycleMonitor(exe, ptp.PID, ptp.IdentityTime, startLog)
+
 	r.runningProcesses.Store(runID, &processRunState{
 		pid:              ptp.PID,
 		identityTime:     ptp.IdentityTime,
@@ -422,23 +417,34 @@ func (r *ProcessExecutableRunner) watchTerminalRunExit(
 
 func (r *ProcessExecutableRunner) AdoptRun(
 	_ context.Context,
-	run controllers.ExecutableRunAdoptionInfo,
+	exe *apiv1.Executable,
+	record *statestore.PersistentProcessRecord,
 	runChangeHandler controllers.RunChangeHandler,
 	log logr.Logger,
 ) error {
-	if run.RunID == controllers.UnknownRunID {
-		return fmt.Errorf("cannot adopt a process run without a run ID")
+	if exe == nil {
+		return fmt.Errorf("cannot adopt a process run without an Executable")
 	}
-	if run.Pid == process.UnknownPID {
-		return fmt.Errorf("cannot adopt process run %s without a valid PID", run.RunID)
-	}
-	if run.ProcessIdentityTime.IsZero() {
-		return fmt.Errorf("cannot adopt process run %s without process identity time", run.RunID)
+	if record == nil {
+		return fmt.Errorf("cannot adopt a process run without a persistent process record")
 	}
 
-	if findErr := r.pe.FindProcess(run.Pid, run.ProcessIdentityTime); findErr != nil {
-		return fmt.Errorf("cannot adopt process run %s: %w", run.RunID, findErr)
+	runID := controllers.RunID(record.RunID)
+	if runID == controllers.UnknownRunID {
+		return fmt.Errorf("cannot adopt a process run without a run ID")
 	}
+	if record.PID == process.UnknownPID {
+		return fmt.Errorf("cannot adopt process run %s without a valid PID", runID)
+	}
+	if record.IdentityTime.IsZero() {
+		return fmt.Errorf("cannot adopt process run %s without process identity time", runID)
+	}
+
+	if findErr := r.pe.CheckProcessRunning(record.PID, record.IdentityTime); findErr != nil {
+		return fmt.Errorf("cannot adopt process run %s: %w", runID, findErr)
+	}
+	r.runExecutableLifecycleMonitor(exe, record.PID, record.IdentityTime, log)
+
 	stopWatching := make(chan struct{})
 	var stopWatchingOnce sync.Once
 	cancelWatch := func() {
@@ -447,18 +453,76 @@ func (r *ProcessExecutableRunner) AdoptRun(
 		})
 	}
 
-	r.runningProcesses.Store(run.RunID, &processRunState{
-		pid:              run.Pid,
-		identityTime:     run.ProcessIdentityTime,
-		cmdInfo:          run.CommandInfo,
+	r.runningProcesses.Store(runID, &processRunState{
+		pid:              record.PID,
+		identityTime:     record.IdentityTime,
+		cmdInfo:          exe.Spec.ExecutablePath,
 		adopted:          true,
 		cancelWatch:      cancelWatch,
 		runChangeHandler: runChangeHandler,
 	})
 
-	go r.watchAdoptedProcess(run.RunID, run.Pid, run.ProcessIdentityTime, stopWatching, log)
+	go r.watchAdoptedProcess(runID, record.PID, record.IdentityTime, stopWatching, log)
 
 	return nil
+}
+
+func (r *ProcessExecutableRunner) runExecutableLifecycleMonitor(
+	exe *apiv1.Executable,
+	pid process.Pid_t,
+	identityTime time.Time,
+	log logr.Logger,
+) {
+	effectiveMode := exe.Spec.EffectiveMode()
+	switch {
+	case effectiveMode.ShouldStopProcessOnDelete():
+		// Use original log here, the watcher is a different process.
+		dcpproc.RunProcessWatcher(r.pe, pid, identityTime, log)
+		return
+
+	case effectiveMode == apiv1.ExecutableModePersistent:
+		monitor, found, monitorErr := dcpproc.MonitorTargetFromFields(exe.Spec.MonitorPID, exe.Spec.MonitorTimestamp)
+		if monitorErr != nil {
+			log.Error(monitorErr, "Could not start persistent Executable lifecycle monitor")
+			return
+		}
+		if !found {
+			return
+		}
+
+		// Use original log here, the watcher is a different process.
+		dcpproc.RunProcessWatcherForMonitor(r.pe, monitor, pid, identityTime, log)
+
+	default:
+		return
+	}
+}
+
+func (r *ProcessExecutableRunner) StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {
+	if exe == nil {
+		return fmt.Errorf("cannot stop a persistent process run without an Executable")
+	}
+	if record == nil {
+		return fmt.Errorf("cannot stop a persistent process run without a persistent process record")
+	}
+
+	runID := controllers.RunID(record.RunID)
+	if runID == controllers.UnknownRunID {
+		return fmt.Errorf("cannot stop a persistent process run without a run ID")
+	}
+	if record.PID == process.UnknownPID {
+		return fmt.Errorf("cannot stop persistent process run %s without a valid PID", runID)
+	}
+	if record.IdentityTime.IsZero() {
+		return fmt.Errorf("cannot stop persistent process run %s without process identity time", runID)
+	}
+
+	return r.stopProcessRunState(ctx, runID, &processRunState{
+		pid:          record.PID,
+		identityTime: record.IdentityTime,
+		cmdInfo:      exe.Spec.ExecutablePath,
+		adopted:      true,
+	}, log)
 }
 
 func (r *ProcessExecutableRunner) watchAdoptedProcess(
@@ -477,7 +541,7 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 			return
 
 		case <-timer.C:
-			if findErr := r.pe.FindProcess(pid, identityTime); findErr != nil {
+			if findErr := r.pe.CheckProcessRunning(pid, identityTime); findErr != nil {
 				runState, found := r.runningProcesses.Load(runID)
 				if !found {
 					return
@@ -503,8 +567,8 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 	}
 }
 
-func (r *ProcessExecutableRunner) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
-	return r.pe.FindProcess(pid, processStartTime)
+func (r *ProcessExecutableRunner) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
+	return r.pe.CheckProcessRunning(pid, processStartTime)
 }
 
 func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers.RunID, log logr.Logger) error {
@@ -513,6 +577,11 @@ func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers
 		log.V(1).Info("Stop of a process run requested, but the run was already stopped", "RunID", runID)
 		return nil
 	}
+
+	return r.stopProcessRunState(ctx, runID, runState, log)
+}
+
+func (r *ProcessExecutableRunner) stopProcessRunState(ctx context.Context, runID controllers.RunID, runState *processRunState, log logr.Logger) error {
 	if runState.cancelWatch != nil {
 		runState.cancelWatch()
 	}
@@ -547,10 +616,8 @@ func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers
 		stopErr = fmt.Errorf("timed out waiting for process associated with run %s to stop", runID)
 	}
 
-	if found {
-		stopErr = errors.Join(stopErr, closeProcessRunResources(runState))
-		waitForConnManagerShutdown(ctx, runState, stopLog)
-	}
+	stopErr = errors.Join(stopErr, closeProcessRunResources(runState))
+	waitForConnManagerShutdown(ctx, runState, stopLog)
 
 	if stopErr != nil {
 		stopLog.Error(stopErr, "Failed to stop run")

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -149,7 +149,7 @@ func (r *ProcessExecutableRunner) makeProcessCommand(
 
 	var creationFlags process.ProcessCreationFlag = process.CreationFlagEnsureKillOnDispose
 	processCtx := ctx
-	if exe.Spec.Persistent {
+	if executableIsPersistent(exe) {
 		creationFlags = process.CreationFlagsNone
 		processCtx = context.WithoutCancel(ctx)
 	}
@@ -223,7 +223,7 @@ func (r *ProcessExecutableRunner) startProcessRun(
 		return result
 	}
 
-	if !exe.Spec.Persistent {
+	if !executableIsPersistent(exe) {
 		// Use original log here, the watcher is a different process.
 		dcpproc.RunProcessWatcher(r.pe, pid, processIdentityTime, startLog)
 	} else if monitor, found, monitorErr := dcpproc.MonitorTargetFromFields(exe.Spec.MonitorPID, exe.Spec.MonitorTimestamp); monitorErr != nil {
@@ -436,7 +436,7 @@ func (r *ProcessExecutableRunner) AdoptRun(
 		return fmt.Errorf("cannot adopt process run %s without process identity time", run.RunID)
 	}
 
-	if _, findErr := process.FindProcess(run.Pid, run.ProcessIdentityTime); findErr != nil {
+	if findErr := r.pe.FindProcess(run.Pid, run.ProcessIdentityTime); findErr != nil {
 		return fmt.Errorf("cannot adopt process run %s: %w", run.RunID, findErr)
 	}
 	stopWatching := make(chan struct{})
@@ -477,7 +477,7 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 			return
 
 		case <-timer.C:
-			if _, findErr := process.FindProcess(pid, identityTime); findErr != nil {
+			if findErr := r.pe.FindProcess(pid, identityTime); findErr != nil {
 				runState, found := r.runningProcesses.Load(runID)
 				if !found {
 					return
@@ -501,6 +501,10 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 			timer.Reset(2 * time.Second)
 		}
 	}
+}
+
+func (r *ProcessExecutableRunner) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
+	return r.pe.FindProcess(pid, processStartTime)
 }
 
 func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers.RunID, log logr.Logger) error {
@@ -622,7 +626,7 @@ func openExecutableOutputFile(exe *apiv1.Executable, stream string) (*os.File, e
 	// Persistent output files are keyed by resource UID to keep paths unique across persistent Executable instances.
 	// Kubernetes UIDs are effectively unique, so collisions between different Executable objects are not expected.
 	fileName := fmt.Sprintf("%s_%s", exe.UID, stream)
-	if !exe.Spec.Persistent {
+	if !executableIsPersistent(exe) {
 		return usvc_io.OpenTempFile(fileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, osutil.PermissionOnlyOwnerReadWrite)
 	}
 
@@ -638,10 +642,14 @@ func openExecutableOutputFile(exe *apiv1.Executable, stream string) (*os.File, e
 }
 
 func executableOutputWriter(exe *apiv1.Executable, file *os.File) usvc_io.WriteSyncerCloser {
-	if exe.Spec.Persistent {
+	if executableIsPersistent(exe) {
 		return file
 	}
 	return usvc_io.NewTimestampWriter(file)
+}
+
+func executableIsPersistent(exe *apiv1.Executable) bool {
+	return exe.Spec.EffectiveMode() == apiv1.ExecutableModePersistent
 }
 
 func makeCommand(exe *apiv1.Executable) *exec.Cmd {

--- a/internal/exerunners/process_executable_runner_test.go
+++ b/internal/exerunners/process_executable_runner_test.go
@@ -25,6 +25,7 @@ import (
 	apiv1 "github.com/microsoft/dcp/api/v1"
 	"github.com/microsoft/dcp/controllers"
 	"github.com/microsoft/dcp/internal/dcppaths"
+	"github.com/microsoft/dcp/internal/statestore"
 	"github.com/microsoft/dcp/internal/testutil"
 	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/osutil"
@@ -245,6 +246,91 @@ func TestAdoptedProcessStopUsesAdoptedPID(t *testing.T) {
 	require.Equal(t, int32(testutil.KilledProcessExitCode), execution.ExitCode)
 }
 
+func TestAdoptedProcessStartsLifecycleMonitor(t *testing.T) {
+	t.Parallel()
+
+	dcppaths.EnableTestPathProbing()
+
+	monitorPID := int64(12345)
+	monitorTimestamp := metav1.NewMicroTime(time.Now().Add(-time.Minute))
+	testCases := []struct {
+		name             string
+		spec             apiv1.ExecutableSpec
+		expectedMonitor  int
+		expectedMonitorP *int64
+	}{
+		{
+			name: "cleanup executable starts DCP cleanup monitor",
+			spec: apiv1.ExecutableSpec{
+				ExecutablePath: "/test/app",
+				Mode:           apiv1.ExecutableModeCleanup,
+			},
+			expectedMonitor: 1,
+		},
+		{
+			name: "persistent executable without monitor skips monitor",
+			spec: apiv1.ExecutableSpec{
+				ExecutablePath: "/test/app",
+				Persistent:     true,
+			},
+		},
+		{
+			name: "persistent executable with monitor starts scoped monitor",
+			spec: apiv1.ExecutableSpec{
+				ExecutablePath:   "/test/app",
+				Persistent:       true,
+				MonitorPID:       &monitorPID,
+				MonitorTimestamp: monitorTimestamp,
+			},
+			expectedMonitor:  1,
+			expectedMonitorP: &monitorPID,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			processExecutor := testutil.NewTestProcessExecutor(ctx)
+			runner := NewProcessExecutableRunner(processExecutor)
+			pid, identityTime, _, startErr := processExecutor.StartProcess(ctx, exec.Command("/test/app"), nil, process.CreationFlagsNone, nil)
+			require.NoError(t, startErr)
+			runID := pidToRunID(pid)
+			t.Cleanup(func() {
+				_ = runner.ReleaseRun(context.Background(), runID, logr.Discard())
+				_ = processExecutor.StopProcess(pid, identityTime)
+			})
+
+			exe := &apiv1.Executable{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api",
+					Namespace: "default",
+					UID:       types.UID(fmt.Sprintf("api-uid-%d", time.Now().UnixNano())),
+				},
+				Spec: testCase.spec,
+			}
+			record := &statestore.PersistentProcessRecord{
+				RunID:        string(runID),
+				PID:          pid,
+				IdentityTime: identityTime,
+			}
+
+			adoptErr := runner.AdoptRun(ctx, exe, record, newRecordingRunChangeHandler(), logr.Discard())
+			require.NoError(t, adoptErr)
+
+			monitorProcesses := processExecutor.FindAll([]string{"dcp", "monitor-process"}, "", nil)
+			require.Len(t, monitorProcesses, testCase.expectedMonitor)
+			if testCase.expectedMonitorP != nil {
+				require.Contains(t, monitorProcesses[0].Cmd.Args, "--monitor")
+				require.Contains(t, monitorProcesses[0].Cmd.Args, strconv.FormatInt(*testCase.expectedMonitorP, 10))
+				require.Contains(t, monitorProcesses[0].Cmd.Args, "--monitor-identity-time")
+				require.Contains(t, monitorProcesses[0].Cmd.Args, testCase.spec.MonitorTimestamp.Time.Format(osutil.RFC3339MiliTimestampFormat))
+			}
+		})
+	}
+}
+
 func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 	t.Parallel()
 
@@ -258,13 +344,18 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 	runner := NewProcessExecutableRunner(processExecutor)
 	runID := pidToRunID(pid)
 	changeHandler := newRecordingRunChangeHandler()
+	exe := &apiv1.Executable{
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "./delay",
+		},
+	}
+	record := &statestore.PersistentProcessRecord{
+		RunID:        string(runID),
+		PID:          pid,
+		IdentityTime: identityTime,
+	}
 
-	adoptErr := runner.AdoptRun(ctx, controllers.ExecutableRunAdoptionInfo{
-		RunID:               runID,
-		Pid:                 pid,
-		ProcessIdentityTime: identityTime,
-		CommandInfo:         "./delay --delay=1s",
-	}, changeHandler, logr.Discard())
+	adoptErr := runner.AdoptRun(ctx, exe, record, changeHandler, logr.Discard())
 	require.NoError(t, adoptErr)
 
 	processExecutor.SimulateProcessExit(t, pid, 0)

--- a/internal/exerunners/process_executable_runner_test.go
+++ b/internal/exerunners/process_executable_runner_test.go
@@ -248,24 +248,14 @@ func TestAdoptedProcessStopUsesAdoptedPID(t *testing.T) {
 func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 	t.Parallel()
 
-	delayToolDir, delayToolDirErr := testutil.GetTestToolDir("delay")
-	require.NoError(t, delayToolDirErr)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "./delay", "--delay=1s")
-	cmd.Dir = delayToolDir
-	require.NoError(t, cmd.Start())
-	go func() {
-		_ = cmd.Wait()
-	}()
-
-	pid := process.Uint32_ToPidT(uint32(cmd.Process.Pid))
-	identityTime := process.ProcessIdentityTime(pid)
-	require.False(t, identityTime.IsZero())
-
-	runner := NewProcessExecutableRunner(testutil.NewTestProcessExecutor(ctx))
+	processExecutor := testutil.NewTestProcessExecutor(ctx)
+	cmd := exec.Command("./delay", "--delay=1s")
+	pid, identityTime, _, startProcessErr := processExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	require.NoError(t, startProcessErr)
+	runner := NewProcessExecutableRunner(processExecutor)
 	runID := pidToRunID(pid)
 	changeHandler := newRecordingRunChangeHandler()
 
@@ -276,6 +266,8 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 		CommandInfo:         "./delay --delay=1s",
 	}, changeHandler, logr.Discard())
 	require.NoError(t, adoptErr)
+
+	processExecutor.SimulateProcessExit(t, pid, 0)
 
 	select {
 	case completedRun := <-changeHandler.completedRuns:

--- a/internal/statestore/leases.go
+++ b/internal/statestore/leases.go
@@ -25,6 +25,7 @@ type ResourceLease struct {
 	ResourceKey  string
 	OwnerProcess process.ProcessTreeItem
 	UpdatedAt    time.Time
+	store        *Store
 }
 
 type ResourceLeaseHeldError struct {
@@ -47,6 +48,17 @@ func HeldResourceLease(err error) (*ResourceLease, bool) {
 
 	lease := heldErr.Lease
 	return &lease, true
+}
+
+func (l *ResourceLease) Release(ctx context.Context) error {
+	if l == nil {
+		return fmt.Errorf("%w: resource lease cannot be nil", ErrInvalidArgument)
+	}
+	if l.store == nil {
+		return fmt.Errorf("%w: resource lease store cannot be nil", ErrInvalidArgument)
+	}
+
+	return l.store.releaseResourceLease(ctx, l.ResourceKey, l.OwnerProcess)
 }
 
 type LeasableResource interface {
@@ -113,6 +125,7 @@ func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResou
 		sameOwner := existingLease.OwnerProcess.Pid == normalizedOwner.Pid &&
 			existingLease.OwnerProcess.IdentityTime.Equal(normalizedOwner.IdentityTime)
 		if !sameOwner && now.Sub(existingLease.UpdatedAt) < revalidationInterval {
+			existingLease.store = s
 			return &ResourceLeaseHeldError{Lease: *existingLease}
 		}
 		if !sameOwner && resourceLeaseOwnerIsActive(existingLease.OwnerProcess) {
@@ -120,6 +133,7 @@ func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResou
 			if updateErr != nil {
 				return updateErr
 			}
+			existingLease.store = s
 			return &ResourceLeaseHeldError{Lease: *existingLease}
 		}
 
@@ -133,6 +147,7 @@ func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResou
 	if txErr != nil {
 		return nil, txErr
 	}
+	lease.store = s
 
 	return lease, nil
 }
@@ -141,6 +156,14 @@ func (s *Store) ReleaseResourceLease(ctx context.Context, resource LeasableResou
 	resourceKey, resourceKeyErr := resourceLeaseKey(resource)
 	if resourceKeyErr != nil {
 		return resourceKeyErr
+	}
+	return s.releaseResourceLease(ctx, resourceKey, ownerProcess)
+}
+
+func (s *Store) releaseResourceLease(ctx context.Context, resourceKey string, ownerProcess process.ProcessTreeItem) error {
+	resourceKey = strings.TrimSpace(resourceKey)
+	if resourceKey == "" {
+		return fmt.Errorf("%w: resource lease key cannot be empty", ErrInvalidArgument)
 	}
 	normalizedOwner, ownerErr := normalizeResourceLeaseOwner(ownerProcess)
 	if ownerErr != nil {
@@ -226,7 +249,7 @@ func (s *Store) WithResourceLease(ctx context.Context, resource LeasableResource
 	}
 
 	callbackErr := f(ctx, lease)
-	releaseErr := s.ReleaseResourceLease(context.Background(), resource, ownerProcess)
+	releaseErr := lease.Release(context.Background())
 	return errors.Join(callbackErr, releaseErr)
 }
 

--- a/internal/statestore/processes.go
+++ b/internal/statestore/processes.go
@@ -28,6 +28,18 @@ type PersistentProcessRecord struct {
 	StdErrFile        string
 	LifecycleMetadata string
 	UpdatedAt         time.Time
+	store             *Store
+}
+
+func (r *PersistentProcessRecord) Delete(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("%w: persistent process record cannot be nil", ErrInvalidArgument)
+	}
+	if r.store == nil {
+		return fmt.Errorf("%w: persistent process record store cannot be nil", ErrInvalidArgument)
+	}
+
+	return r.store.DeletePersistentProcess(ctx, r.ResourceKey)
 }
 
 func (s *Store) UpsertPersistentProcess(ctx context.Context, record PersistentProcessRecord) error {
@@ -109,6 +121,7 @@ func (s *Store) GetPersistentProcess(ctx context.Context, resourceKey string) (*
 	if scanErr != nil {
 		return nil, fmt.Errorf("could not get persistent process record '%s': %w", resourceKey, scanErr)
 	}
+	record.store = s
 
 	return record, nil
 }
@@ -140,6 +153,7 @@ func (s *Store) ListPersistentProcesses(ctx context.Context) ([]PersistentProces
 		if scanErr != nil {
 			return nil, fmt.Errorf("could not read persistent process record: %w", scanErr)
 		}
+		record.store = s
 		records = append(records, *record)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -578,7 +578,7 @@ func TestPersistentProcessRecordRoundTrip(t *testing.T) {
 	require.Equal(t, record.LifecycleMetadata, actual.LifecycleMetadata)
 	require.False(t, actual.UpdatedAt.IsZero())
 
-	require.NoError(t, store.DeletePersistentProcess(ctx, record.ResourceKey))
+	require.NoError(t, actual.Delete(ctx))
 
 	_, getErr = store.GetPersistentProcess(ctx, record.ResourceKey)
 	require.True(t, errors.Is(getErr, ErrPersistentProcessNotFound), "expected ErrPersistentProcessNotFound, got %v", getErr)

--- a/internal/testutil/ctrlutil/test_process_executable_runner.go
+++ b/internal/testutil/ctrlutil/test_process_executable_runner.go
@@ -156,5 +156,14 @@ func (r *TestProcessExecutableRunner) AdoptRun(
 	return persistentRunner.AdoptRun(ctx, run, runChangeHandler, log)
 }
 
+func (r *TestProcessExecutableRunner) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
+	persistentRunner, ok := r.inner.(controllers.PersistentExecutableRunner)
+	if !ok {
+		return fmt.Errorf("inner test process runner does not support persistent process lookup")
+	}
+
+	return persistentRunner.FindProcess(pid, processStartTime)
+}
+
 var _ controllers.ExecutableRunner = (*TestProcessExecutableRunner)(nil)
 var _ controllers.PersistentExecutableRunner = (*TestProcessExecutableRunner)(nil)

--- a/internal/testutil/ctrlutil/test_process_executable_runner.go
+++ b/internal/testutil/ctrlutil/test_process_executable_runner.go
@@ -17,6 +17,7 @@ import (
 	apiv1 "github.com/microsoft/dcp/api/v1"
 	"github.com/microsoft/dcp/controllers"
 	"github.com/microsoft/dcp/internal/exerunners"
+	"github.com/microsoft/dcp/internal/statestore"
 	"github.com/microsoft/dcp/internal/termpty"
 	"github.com/microsoft/dcp/internal/testutil"
 	"github.com/microsoft/dcp/pkg/process"
@@ -144,7 +145,8 @@ func (r *TestProcessExecutableRunner) ReleaseRun(ctx context.Context, runID cont
 
 func (r *TestProcessExecutableRunner) AdoptRun(
 	ctx context.Context,
-	run controllers.ExecutableRunAdoptionInfo,
+	exe *apiv1.Executable,
+	record *statestore.PersistentProcessRecord,
 	runChangeHandler controllers.RunChangeHandler,
 	log logr.Logger,
 ) error {
@@ -153,16 +155,25 @@ func (r *TestProcessExecutableRunner) AdoptRun(
 		return fmt.Errorf("inner test process runner does not support persistent run adoption")
 	}
 
-	return persistentRunner.AdoptRun(ctx, run, runChangeHandler, log)
+	return persistentRunner.AdoptRun(ctx, exe, record, runChangeHandler, log)
 }
 
-func (r *TestProcessExecutableRunner) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
+func (r *TestProcessExecutableRunner) StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error {
 	persistentRunner, ok := r.inner.(controllers.PersistentExecutableRunner)
 	if !ok {
-		return fmt.Errorf("inner test process runner does not support persistent process lookup")
+		return fmt.Errorf("inner test process runner does not support persistent process stop")
 	}
 
-	return persistentRunner.FindProcess(pid, processStartTime)
+	return persistentRunner.StopPersistentProcess(ctx, exe, record, log)
+}
+
+func (r *TestProcessExecutableRunner) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
+	persistentRunner, ok := r.inner.(controllers.PersistentExecutableRunner)
+	if !ok {
+		return fmt.Errorf("inner test process runner does not support persistent process liveness checks")
+	}
+
+	return persistentRunner.CheckProcessRunning(pid, processStartTime)
 }
 
 var _ controllers.ExecutableRunner = (*TestProcessExecutableRunner)(nil)

--- a/internal/testutil/test_process_executor.go
+++ b/internal/testutil/test_process_executor.go
@@ -213,6 +213,30 @@ func (e *TestProcessExecutor) StopProcess(pid process.Pid_t, processStartTime ti
 	return e.stopProcessImpl(pid, processStartTime, KilledProcessExitCode)
 }
 
+func (e *TestProcessExecutor) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
+	e.m.RLock()
+	defer e.m.RUnlock()
+
+	i := e.findByPid(pid)
+	if i == NotFound {
+		return fmt.Errorf("no process with PID %d found", pid)
+	}
+
+	execution := e.Executions[i]
+	if !processStartTime.IsZero() && !osutil.Within(processStartTime, execution.StartedAt, process.ProcessIdentityTimeMaximumDifference) {
+		return fmt.Errorf("process start time mismatch for PID %d: expected %s, actual %s",
+			pid,
+			processStartTime.Format(osutil.RFC3339MiliTimestampFormat),
+			execution.StartedAt.Format(osutil.RFC3339MiliTimestampFormat),
+		)
+	}
+	if execution.Finished() {
+		return fmt.Errorf("process with PID %d is not running", pid)
+	}
+
+	return nil
+}
+
 // Called by tests to simulate a process exit with specific exit code.
 func (e *TestProcessExecutor) SimulateProcessExit(t *testing.T, pid process.Pid_t, exitCode int32) {
 	err := e.stopProcessImpl(pid, time.Time{}, exitCode)

--- a/internal/testutil/test_process_executor.go
+++ b/internal/testutil/test_process_executor.go
@@ -213,7 +213,7 @@ func (e *TestProcessExecutor) StopProcess(pid process.Pid_t, processStartTime ti
 	return e.stopProcessImpl(pid, processStartTime, KilledProcessExitCode)
 }
 
-func (e *TestProcessExecutor) FindProcess(pid process.Pid_t, processStartTime time.Time) error {
+func (e *TestProcessExecutor) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
 	e.m.RLock()
 	defer e.m.RUnlock()
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1040,8 +1040,15 @@ func schema_microsoft_dcp_api_v1_ContainerNetworkSpec(ref common.ReferenceCallba
 					},
 					"ipv6": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Shouild IPv6 be enabled for the network?",
+							Description: "Should IPv6 be enabled for the network?",
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Controls how the network is created, reused, and cleaned up. Ignored when persistent is true.",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
@@ -1740,6 +1747,13 @@ func schema_microsoft_dcp_api_v1_ContainerSpec(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Controls how the container is created, reused, and cleaned up. Ignored when persistent is true.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"persistent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Should this container be created and persisted between DCP runs?",
@@ -1749,7 +1763,7 @@ func schema_microsoft_dcp_api_v1_ContainerSpec(ref common.ReferenceCallback) com
 					},
 					"monitorPid": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Optional parent process PID used to scope persistent Container cleanup to a process lifecycle. When set, MonitorTimestamp must also be set and Persistent must be true.",
+							Description: "Optional parent process PID used to scope persistent Container cleanup to a process lifecycle. When set, MonitorTimestamp must also be set and the effective mode must be persistent.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -2944,6 +2958,13 @@ func schema_microsoft_dcp_api_v1_ExecutableSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Controls how the Executable process is created, reused, and cleaned up. Ignored when persistent is true.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"persistent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Should this Executable be created and persisted between DCP runs?",
@@ -2960,7 +2981,7 @@ func schema_microsoft_dcp_api_v1_ExecutableSpec(ref common.ReferenceCallback) co
 					},
 					"monitorPid": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Optional parent process PID used to scope persistent Executable cleanup to a process lifecycle. When set, MonitorTimestamp must also be set and Persistent must be true.",
+							Description: "Optional parent process PID used to scope persistent Executable cleanup to a process lifecycle. When set, MonitorTimestamp must also be set and the effective mode must be persistent.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/pkg/process/os_executor.go
+++ b/pkg/process/os_executor.go
@@ -490,7 +490,7 @@ func (e *OSExecutor) Dispose() {
 	e.log.V(1).Info("Process executor disposed")
 }
 
-func (e *OSExecutor) FindProcess(pid Pid_t, processStartTime time.Time) error {
+func (e *OSExecutor) CheckProcessRunning(pid Pid_t, processStartTime time.Time) error {
 	proc, err := FindProcess(pid, processStartTime)
 	if err != nil {
 		return err

--- a/pkg/process/os_executor.go
+++ b/pkg/process/os_executor.go
@@ -490,6 +490,11 @@ func (e *OSExecutor) Dispose() {
 	e.log.V(1).Info("Process executor disposed")
 }
 
+func (e *OSExecutor) FindProcess(pid Pid_t, processStartTime time.Time) error {
+	_, err := FindProcess(pid, processStartTime)
+	return err
+}
+
 type processStoppingOpts uint16
 
 const (

--- a/pkg/process/os_executor.go
+++ b/pkg/process/os_executor.go
@@ -491,8 +491,14 @@ func (e *OSExecutor) Dispose() {
 }
 
 func (e *OSExecutor) FindProcess(pid Pid_t, processStartTime time.Time) error {
-	_, err := FindProcess(pid, processStartTime)
-	return err
+	proc, err := FindProcess(pid, processStartTime)
+	if err != nil {
+		return err
+	}
+	if releaseErr := proc.Release(); releaseErr != nil {
+		e.log.Error(releaseErr, "Failed to release process handle", "PID", pid)
+	}
+	return nil
 }
 
 type processStoppingOpts uint16

--- a/pkg/process/process_types.go
+++ b/pkg/process/process_types.go
@@ -108,9 +108,9 @@ type Executor interface {
 	// (to protect against stopping a wrong process, if the PID was reused).
 	StopProcess(pid Pid_t, processStartTime time.Time, options ...ProcessStopOption) error
 
-	// Finds the process with a given PID.
+	// Checks that the process with a given PID is running.
 	// The processStartTime, if provided (time.IsZero() returns false), is used to further validate the process.
-	FindProcess(pid Pid_t, processStartTime time.Time) error
+	CheckProcessRunning(pid Pid_t, processStartTime time.Time) error
 
 	// Starts a process that does not need to be tracked (the caller is not interested in its exit code),
 	// minimizing resource usage. An error is returned if the process could not be started.

--- a/pkg/process/process_types.go
+++ b/pkg/process/process_types.go
@@ -108,6 +108,10 @@ type Executor interface {
 	// (to protect against stopping a wrong process, if the PID was reused).
 	StopProcess(pid Pid_t, processStartTime time.Time, options ...ProcessStopOption) error
 
+	// Finds the process with a given PID.
+	// The processStartTime, if provided (time.IsZero() returns false), is used to further validate the process.
+	FindProcess(pid Pid_t, processStartTime time.Time) error
+
 	// Starts a process that does not need to be tracked (the caller is not interested in its exit code),
 	// minimizing resource usage. An error is returned if the process could not be started.
 	StartAndForget(cmd *exec.Cmd, creationFlags ProcessCreationFlag) (pid Pid_t, startTime time.Time, err error)

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -1718,7 +1718,6 @@ func TestContainerExistingModeDoesNotCreateMissingContainer(t *testing.T) {
 	defer cancel()
 
 	const testName = "container-existing-mode-missing"
-	const imageName = testName + "-image"
 
 	ctr := apiv1.Container{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1726,7 +1725,6 @@ func TestContainerExistingModeDoesNotCreateMissingContainer(t *testing.T) {
 			Namespace: metav1.NamespaceNone,
 		},
 		Spec: apiv1.ContainerSpec{
-			Image:         imageName,
 			ContainerName: testName,
 			Mode:          apiv1.ContainerModeExisting,
 		},
@@ -1737,7 +1735,40 @@ func TestContainerExistingModeDoesNotCreateMissingContainer(t *testing.T) {
 	require.NoError(t, err, "could not create a Container")
 
 	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(currentCtr *apiv1.Container) (bool, error) {
-		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateEmpty, nil
+		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateNotFound, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{testName},
+	})
+	require.ErrorIs(t, err, containers.ErrNotFound, "expected no container resource to be created")
+	require.Len(t, inspected, 0, "expected no container resource to be created")
+}
+
+func TestContainerCleanupModeDoesNotCreateMissingContainer(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-cleanup-mode-missing"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeCleanup,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(currentCtr *apiv1.Container) (bool, error) {
+		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateNotFound, nil
 	})
 
 	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -1987,6 +1987,79 @@ func TestContainerCleanupModeRemovesExistingContainerOnDelete(t *testing.T) {
 	require.NoError(t, err, "container was not removed")
 }
 
+func TestContainerCleanupModeDeletedBeforeAdoptionRemovesExistingContainer(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+
+	const testName = "container-cleanup-mode-delete-before-adopt"
+	const imageName = testName + "-image"
+
+	serverInfo, _, startupErr := StartTestEnvironment(ctx, ContainerController, t.Name(), NoSeparateWorkingDir)
+	require.NoError(t, startupErr, "failed to start the API server")
+	defer func() {
+		cancel()
+		select {
+		case <-serverInfo.ApiServerDisposalComplete.Wait():
+		case <-time.After(5 * time.Second):
+		}
+	}()
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeCleanup,
+		},
+	}
+
+	id, err := serverInfo.ContainerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: ctr.Spec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = serverInfo.ContainerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	tco, isTCO := serverInfo.ContainerOrchestrator.(*ctrl_testutil.TestContainerOrchestrator)
+	require.True(t, isTCO, "Container orchestrator should be a TestContainerOrchestrator")
+	tco.SetRuntimeHealth(false)
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = serverInfo.Client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	waitObjectAssumesStateEx(t, ctx, serverInfo.Client, ctrl_client.ObjectKeyFromObject(&ctr), func(currentCtr *apiv1.Container) (bool, error) {
+		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateRuntimeUnhealthy, nil
+	})
+
+	t.Logf("Deleting Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflictEx(ctx, serverInfo.Client, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		return serverInfo.Client.Delete(ctx, currentCtr)
+	})
+	require.NoError(t, err, "container object could not be deleted")
+
+	tco.SetRuntimeHealth(true)
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, serverInfo.Client, &ctr)
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		inspected, inspectErr := serverInfo.ContainerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+			Containers: []string{id},
+		})
+		if !errors.Is(inspectErr, containers.ErrNotFound) || len(inspected) != 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "container was not removed")
+}
+
 func TestContainerPersistentFieldOverridesCleanupMode(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math/big"
@@ -30,6 +31,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/require"
@@ -1666,6 +1668,287 @@ func TestPersistentContainerDeletion(t *testing.T) {
 	require.NoError(t, err, "expected to find a container")
 	require.Len(t, inspected, 1, "expected to find a single container")
 	require.Equal(t, inspected[0].Status, containers.ContainerStatusRunning, "expected the container to be running")
+}
+
+func TestContainerModePersistentDeletion(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-mode-persistent-deletion"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModePersistent,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+
+	t.Logf("Deleting Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflict(ctx, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		return client.Delete(ctx, currentCtr)
+	})
+	require.NoError(t, err, "container object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &ctr)
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{updatedCtr.Status.ContainerID},
+	})
+	require.NoError(t, err, "expected to find a container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, inspected[0].Status, containers.ContainerStatusRunning, "expected the container to be running")
+}
+
+func TestContainerExistingModeDoesNotCreateMissingContainer(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-existing-mode-missing"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeExisting,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(currentCtr *apiv1.Container) (bool, error) {
+		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateEmpty, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{testName},
+	})
+	require.ErrorIs(t, err, containers.ErrNotFound, "expected no container resource to be created")
+	require.Len(t, inspected, 0, "expected no container resource to be created")
+}
+
+func TestContainerExistingModeKeepsExistingContainerOnDelete(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-existing-mode-keeps-existing"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeExisting,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: ctr.Spec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+	require.Equal(t, id, updatedCtr.Status.ContainerID, "container ID did not match expected value")
+
+	t.Logf("Deleting Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflict(ctx, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		return client.Delete(ctx, currentCtr)
+	})
+	require.NoError(t, err, "container object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &ctr)
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "expected to find a container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusRunning, inspected[0].Status, "expected the container to be running")
+}
+
+func TestContainerExistingModeIgnoresLifecycleMismatch(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-existing-mode-ignores-lifecycle"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeExisting,
+		},
+	}
+
+	seedSpec := ctr.Spec
+	seedSpec.Labels = []apiv1.ContainerLabel{
+		{
+			Key:   "com.microsoft.developer.usvc-dev",
+			Value: "true",
+		},
+		{
+			Key:   "com.microsoft.developer.usvc-dev.lifecycle-key",
+			Value: "stale-lifecycle-key",
+		},
+	}
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: seedSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+	require.Equal(t, id, updatedCtr.Status.ContainerID, "existing mode should adopt the existing container despite stale lifecycle labels")
+}
+
+func TestContainerCleanupModeRemovesExistingContainerOnDelete(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-cleanup-mode-removes-existing"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeCleanup,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: ctr.Spec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err = client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+	require.Equal(t, id, updatedCtr.Status.ContainerID, "container ID did not match expected value")
+
+	t.Logf("Deleting Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflict(ctx, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		return client.Delete(ctx, currentCtr)
+	})
+	require.NoError(t, err, "container object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &ctr)
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(_ context.Context) (bool, error) {
+		inspected, inspectErr := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+			Containers: []string{id},
+		})
+		if !errors.Is(inspectErr, containers.ErrNotFound) || len(inspected) != 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "container was not removed")
+}
+
+func TestContainerPersistentFieldOverridesCleanupMode(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-persistent-overrides-cleanup"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			Image:         imageName,
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeCleanup,
+			Persistent:    true,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+
+	t.Logf("Deleting Container object '%s'...", ctr.ObjectMeta.Name)
+	err = retryOnConflict(ctx, ctr.NamespacedName(), func(ctx context.Context, currentCtr *apiv1.Container) error {
+		return client.Delete(ctx, currentCtr)
+	})
+	require.NoError(t, err, "container object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &ctr)
+
+	inspected, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
+		Containers: []string{updatedCtr.Status.ContainerID},
+	})
+	require.NoError(t, err, "expected to find a container")
+	require.Len(t, inspected, 1, "expected to find a single container")
+	require.Equal(t, containers.ContainerStatusRunning, inspected[0].Status, "expected the container to be running")
 }
 
 func TestPersistentContainerAlreadyExists(t *testing.T) {

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -1896,7 +1896,7 @@ func TestContainerCleanupModeRemovesExistingContainerOnDelete(t *testing.T) {
 	require.NoError(t, err, "container object could not be deleted")
 
 	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &ctr)
-	err = wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(_ context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
 		inspected, inspectErr := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{
 			Containers: []string{id},
 		})

--- a/test/integration/container_controller_test.go
+++ b/test/integration/container_controller_test.go
@@ -280,7 +280,11 @@ func TestContainerInstanceStarts(t *testing.T) {
 	err := client.Create(ctx, &ctr)
 	require.NoError(t, err, "Could not create a Container object")
 
-	_, _ = ensureContainerRunning(t, ctx, &ctr)
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+	monitorProcesses := testProcessExecutor.FindAll([]string{"dcp", "monitor-container"}, "", func(pe *internal_testutil.ProcessExecution) bool {
+		return slices.Contains(pe.Cmd.Args, updatedCtr.Status.ContainerID)
+	})
+	require.Len(t, monitorProcesses, 1)
 }
 
 // Ensure a container instance is started after container runtime goes from unhealthy to healthy
@@ -1743,6 +1747,50 @@ func TestContainerExistingModeDoesNotCreateMissingContainer(t *testing.T) {
 	})
 	require.ErrorIs(t, err, containers.ErrNotFound, "expected no container resource to be created")
 	require.Len(t, inspected, 0, "expected no container resource to be created")
+}
+
+func TestContainerExistingModeAdoptsContainerCreatedAfterNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "container-existing-mode-late-container"
+	const imageName = testName + "-image"
+
+	ctr := apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerSpec{
+			ContainerName: testName,
+			Mode:          apiv1.ContainerModeExisting,
+		},
+	}
+
+	t.Logf("Creating Container '%s'", ctr.ObjectMeta.Name)
+	err := client.Create(ctx, &ctr)
+	require.NoError(t, err, "could not create a Container")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&ctr), func(currentCtr *apiv1.Container) (bool, error) {
+		return len(currentCtr.Finalizers) > 0 && currentCtr.Status.State == apiv1.ContainerStateNotFound, nil
+	})
+
+	seedSpec := ctr.Spec
+	seedSpec.Image = imageName
+	id, err := containerOrchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name:          testName,
+		ContainerSpec: seedSpec,
+	})
+	require.NoError(t, err, "could not create container resource")
+
+	_, err = containerOrchestrator.StartContainers(ctx, containers.StartContainersOptions{
+		Containers: []string{id},
+	})
+	require.NoError(t, err, "could not start container resource")
+
+	updatedCtr, _ := ensureContainerRunning(t, ctx, &ctr)
+	require.Equal(t, id, updatedCtr.Status.ContainerID, "container ID did not match expected value")
 }
 
 func TestContainerCleanupModeDoesNotCreateMissingContainer(t *testing.T) {

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -435,6 +435,71 @@ func TestExecutableCleanupModeStopsExistingProcessOnDelete(t *testing.T) {
 	require.NoError(t, err, "process was not stopped")
 }
 
+func TestExecutableCleanupModeDeletedBeforeAdoptionStopsExistingProcess(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-cleanup-mode-delete-before-adopt"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModeCleanup,
+		},
+	}
+
+	cmd := exec.Command(exe.Spec.ExecutablePath)
+	pid, identityTime, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	require.NoError(t, startProcessErr, "could not seed process execution")
+	t.Cleanup(func() {
+		_ = testProcessExecutor.StopProcess(pid, identityTime)
+	})
+
+	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
+	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
+
+	upsertErr := testStateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      lifecycleKey,
+		PID:               pid,
+		IdentityTime:      identityTime,
+		RunID:             strconv.Itoa(int(pid)),
+		StdOutFile:        fmt.Sprintf("%s.out", exe.Name),
+		StdErrFile:        fmt.Sprintf("%s.err", exe.Name),
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, upsertErr, "could not seed persistent process record")
+
+	leaseOwner := process.ProcessTreeItem{Pid: process.Pid_t(1), IdentityTime: time.Now()}
+	lease, leaseErr := testStateStore.AcquireResourceLease(ctx, &exe, leaseOwner, time.Minute)
+	require.NoError(t, leaseErr, "could not acquire persistent process lease")
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return len(currentExe.Finalizers) > 0 && currentExe.Status.State == apiv1.ExecutableStateEmpty, nil
+	})
+
+	t.Logf("Deleting Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, retryOnConflict(ctx, exe.NamespacedName(), func(ctx context.Context, currentExe *apiv1.Executable) error {
+		return client.Delete(ctx, currentExe)
+	}), "Executable object could not be deleted")
+
+	require.NoError(t, lease.Release(context.WithoutCancel(ctx)), "could not release persistent process lease")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &exe)
+	err := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		processExecution, found := testProcessExecutor.FindByPid(pid)
+		return found && processExecution.Finished(), nil
+	})
+	require.NoError(t, err, "process was not stopped")
+}
+
 func TestExecutablePersistentFieldOverridesCleanupMode(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -499,6 +499,58 @@ func TestExecutableCleanupModeReportsNotFoundWhenProcessRecordMissing(t *testing
 	require.Empty(t, startedProcesses, "cleanup mode should not start a missing process")
 }
 
+func TestExecutableCleanupModeAdoptsProcessRecordCreatedAfterNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-cleanup-mode-late-record"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModeCleanup,
+		},
+	}
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return len(currentExe.Finalizers) > 0 && currentExe.Status.State == apiv1.ExecutableStateNotFound, nil
+	})
+
+	cmd := exec.Command(exe.Spec.ExecutablePath)
+	pid, identityTime, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	require.NoError(t, startProcessErr, "could not seed process execution")
+	t.Cleanup(func() {
+		_ = testProcessExecutor.StopProcess(pid, identityTime)
+	})
+
+	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
+	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
+
+	upsertErr := testStateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      lifecycleKey,
+		PID:               pid,
+		IdentityTime:      identityTime,
+		RunID:             strconv.Itoa(int(pid)),
+		StdOutFile:        fmt.Sprintf("%s.out", exe.Name),
+		StdErrFile:        fmt.Sprintf("%s.err", exe.Name),
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, upsertErr, "could not seed persistent process record")
+
+	updatedExe := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateRunning, nil
+	})
+	require.Equal(t, strconv.Itoa(int(pid)), updatedExe.Status.ExecutionID, "Executable should adopt the late persistent process record")
+}
+
 // Ensure exit code of processes/run sessions are captured correctly
 func TestExecutableExitCodeCaptured(t *testing.T) {
 	type testcase struct {

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -471,6 +471,34 @@ func TestExecutablePersistentFieldOverridesCleanupMode(t *testing.T) {
 	require.True(t, pe.Running(), "persistent=true should override cleanup mode and leave the process running")
 }
 
+func TestExecutableCleanupModeReportsNotFoundWhenProcessRecordMissing(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-cleanup-mode-missing"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModeCleanup,
+		},
+	}
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return len(currentExe.Finalizers) > 0 && currentExe.Status.State == apiv1.ExecutableStateNotFound, nil
+	})
+
+	startedProcesses := testProcessExecutor.FindAll([]string{exe.Spec.ExecutablePath}, "", nil)
+	require.Empty(t, startedProcesses, "cleanup mode should not start a missing process")
+}
+
 // Ensure exit code of processes/run sessions are captured correctly
 func TestExecutableExitCodeCaptured(t *testing.T) {
 	type testcase struct {

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"os/exec"
 	"reflect"
 	"regexp"
 	std_slices "slices"
@@ -329,6 +330,145 @@ func TestStalePersistentExecutableStopWithUnresolvedTemplate(t *testing.T) {
 
 	_, err = testStateStore.GetPersistentProcess(ctx, exe.GetLeaseKey())
 	require.ErrorIs(t, err, statestore.ErrPersistentProcessNotFound, "stale persistent process record should be deleted")
+}
+
+func TestExecutableModePersistentDeletion(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-mode-persistent-deletion"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModePersistent,
+		},
+	}
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	pid, processErr := ensureProcessRunning(ctx, exe.Spec.ExecutablePath)
+	require.NoError(t, processErr, "Executable process could not be started")
+
+	t.Logf("Deleting Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, retryOnConflict(ctx, exe.NamespacedName(), func(ctx context.Context, currentExe *apiv1.Executable) error {
+		return client.Delete(ctx, currentExe)
+	}), "Executable object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &exe)
+
+	pe, found := testProcessExecutor.FindByPid(pid)
+	require.True(t, found, "expected process to still be tracked")
+	require.True(t, pe.Running(), "persistent mode should leave the process running")
+}
+
+func TestExecutableCleanupModeStopsExistingProcessOnDelete(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-cleanup-mode-stops-existing"
+	serverInfo, teInfo, startupErr := StartTestEnvironment(
+		ctx,
+		ExecutableController,
+		testName,
+		t.TempDir(),
+	)
+	require.NoError(t, startupErr, "could not start test environment")
+
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModeCleanup,
+		},
+	}
+
+	cmd := exec.Command(exe.Spec.ExecutablePath)
+	pid, identityTime, _, startProcessErr := teInfo.TestProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	require.NoError(t, startProcessErr, "could not seed process execution")
+	t.Cleanup(func() {
+		_ = teInfo.TestProcessExecutor.StopProcess(pid, identityTime)
+	})
+
+	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
+	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
+
+	upsertErr := teInfo.StateStore.UpsertPersistentProcess(ctx, statestore.PersistentProcessRecord{
+		ResourceKey:       exe.GetLeaseKey(),
+		LifecycleKey:      lifecycleKey,
+		PID:               pid,
+		IdentityTime:      identityTime,
+		RunID:             strconv.Itoa(int(pid)),
+		StdOutFile:        fmt.Sprintf("%s.out", exe.Name),
+		StdErrFile:        fmt.Sprintf("%s.err", exe.Name),
+		LifecycleMetadata: "{}",
+	})
+	require.NoError(t, upsertErr, "could not seed persistent process record")
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, serverInfo.Client.Create(ctx, &exe), "Could not create Executable")
+
+	updatedExe := waitObjectAssumesStateEx(t, ctx, serverInfo.Client, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.State == apiv1.ExecutableStateRunning, nil
+	})
+	require.Equal(t, strconv.Itoa(int(pid)), updatedExe.Status.ExecutionID, "Executable should adopt the seeded process")
+
+	t.Logf("Deleting Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, retryOnConflictEx(ctx, serverInfo.Client, exe.NamespacedName(), func(ctx context.Context, currentExe *apiv1.Executable) error {
+		return serverInfo.Client.Delete(ctx, currentExe)
+	}), "Executable object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, serverInfo.Client, &exe)
+	err := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		processExecution, found := teInfo.TestProcessExecutor.FindByPid(pid)
+		return found && processExecution.Finished(), nil
+	})
+	require.NoError(t, err, "process was not stopped")
+}
+
+func TestExecutablePersistentFieldOverridesCleanupMode(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "executable-persistent-overrides-cleanup"
+	exe := apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ExecutableSpec{
+			ExecutablePath: "/path/to/" + testName,
+			Mode:           apiv1.ExecutableModeCleanup,
+			Persistent:     true,
+		},
+	}
+
+	t.Logf("Creating Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
+
+	pid, processErr := ensureProcessRunning(ctx, exe.Spec.ExecutablePath)
+	require.NoError(t, processErr, "Executable process could not be started")
+
+	t.Logf("Deleting Executable '%s'", exe.ObjectMeta.Name)
+	require.NoError(t, retryOnConflict(ctx, exe.NamespacedName(), func(ctx context.Context, currentExe *apiv1.Executable) error {
+		return client.Delete(ctx, currentExe)
+	}), "Executable object could not be deleted")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &exe)
+
+	pe, found := testProcessExecutor.FindByPid(pid)
+	require.True(t, found, "expected process to still be tracked")
+	require.True(t, pe.Running(), "persistent=true should override cleanup mode and leave the process running")
 }
 
 // Ensure exit code of processes/run sessions are captured correctly

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -183,10 +183,9 @@ func TestNoExistingPersistentExecutableStopWithoutStart(t *testing.T) {
 	t.Logf("Creating persistent Executable '%s' with Start=false and Stop=true", exe.ObjectMeta.Name)
 	require.NoError(t, client.Create(ctx, &exe), "Could not create Executable")
 
-	t.Logf("Waiting for Executable '%s' to be observed without failing to start", exe.ObjectMeta.Name)
+	t.Logf("Waiting for Executable '%s' to report a terminal state", exe.ObjectMeta.Name)
 	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&exe), func(currentExe *apiv1.Executable) (bool, error) {
-		require.NotEqual(t, apiv1.ExecutableStateFailedToStart, currentExe.Status.State, "Stop-only Executable should not fail startup when no persistent process exists")
-		return len(currentExe.Finalizers) > 0 && currentExe.Status.State == apiv1.ExecutableStateEmpty, nil
+		return currentExe.Status.State == apiv1.ExecutableStateFailedToStart && !currentExe.Status.FinishTimestamp.IsZero(), nil
 	})
 
 	startedProcesses := testProcessExecutor.FindAll([]string{exe.Spec.ExecutablePath}, "", nil)

--- a/test/integration/network_controller_test.go
+++ b/test/integration/network_controller_test.go
@@ -183,6 +183,253 @@ func TestNetworkRemovePersistentInstance(t *testing.T) {
 	require.Len(t, inspected, 1, "expected to find a single network")
 }
 
+func TestNetworkModePersistentInstance(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-mode-persistent-instance"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModePersistent,
+		},
+	}
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err := client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	updatedNet := ensureNetworkCreated(t, ctx, &net)
+
+	t.Logf("Deleting ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = retryOnConflict(ctx, net.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		return client.Delete(ctx, currentNet)
+	})
+	require.NoError(t, err, "could not delete a ContainerNetwork object")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
+
+	inspected, err := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
+		Networks: []string{updatedNet.Status.ID},
+	})
+	require.NoError(t, err, "could not inspect the network")
+	require.Len(t, inspected, 1, "expected to find a single network")
+}
+
+func TestNetworkExistingModeDoesNotCreateMissingNetwork(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-existing-mode-missing"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModeExisting,
+		},
+	}
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err := client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&net), func(currentNet *apiv1.ContainerNetwork) (bool, error) {
+		return currentNet.Status.State == apiv1.ContainerNetworkStateNotFound, nil
+	})
+
+	inspected, err := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
+		Networks: []string{testName},
+	})
+	require.ErrorIs(t, err, containers.ErrNotFound, "expected no network resource to be created")
+	require.Len(t, inspected, 0, "expected no network resource to be created")
+}
+
+func TestNetworkExistingModeKeepsExistingNetworkOnDelete(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-existing-mode-keeps-existing"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModeExisting,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateNetwork(ctx, containers.CreateNetworkOptions{
+		Name: testName,
+	})
+	require.NoError(t, err, "could not create a network")
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	updatedNetwork := ensureNetworkCreated(t, ctx, &net)
+	require.Equal(t, id, updatedNetwork.Status.ID, "network ID did not match expected value")
+
+	t.Logf("Deleting ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = retryOnConflict(ctx, net.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		return client.Delete(ctx, currentNet)
+	})
+	require.NoError(t, err, "could not delete a ContainerNetwork object")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
+
+	inspected, err := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
+		Networks: []string{id},
+	})
+	require.NoError(t, err, "could not inspect the network")
+	require.Len(t, inspected, 1, "expected to find a single network")
+}
+
+func TestNetworkCleanupModeDoesNotCreateMissingNetwork(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-cleanup-mode-missing"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModeCleanup,
+		},
+	}
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err := client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(&net), func(currentNet *apiv1.ContainerNetwork) (bool, error) {
+		return currentNet.Status.State == apiv1.ContainerNetworkStateNotFound, nil
+	})
+
+	t.Logf("Deleting ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = retryOnConflict(ctx, net.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		return client.Delete(ctx, currentNet)
+	})
+	require.NoError(t, err, "could not delete a ContainerNetwork object")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
+
+	inspected, err := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
+		Networks: []string{testName},
+	})
+	require.ErrorIs(t, err, containers.ErrNotFound, "expected no network resource to be created")
+	require.Len(t, inspected, 0, "expected no network resource to be created")
+}
+
+func TestNetworkCleanupModeRemovesExistingNetworkOnDelete(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-cleanup-mode-removes-existing"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModeCleanup,
+		},
+	}
+
+	id, err := containerOrchestrator.CreateNetwork(ctx, containers.CreateNetworkOptions{
+		Name: testName,
+	})
+	require.NoError(t, err, "could not create a network")
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	updatedNetwork := ensureNetworkCreated(t, ctx, &net)
+	require.Equal(t, id, updatedNetwork.Status.ID, "network ID did not match expected value")
+
+	t.Logf("Deleting ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = retryOnConflict(ctx, net.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		return client.Delete(ctx, currentNet)
+	})
+	require.NoError(t, err, "could not delete a ContainerNetwork object")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
+
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(_ context.Context) (bool, error) {
+		inspectedNetworks, networkInspectionErr := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{Networks: []string{id}})
+		if !errors.Is(networkInspectionErr, containers.ErrNotFound) || len(inspectedNetworks) != 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	require.NoError(t, err, "network was not removed")
+}
+
+func TestNetworkPersistentFieldOverridesCleanupMode(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-network-persistent-overrides-cleanup"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+		Spec: apiv1.ContainerNetworkSpec{
+			NetworkName: testName,
+			Mode:        apiv1.ContainerNetworkModeCleanup,
+			Persistent:  true,
+		},
+	}
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err := client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	updatedNet := ensureNetworkCreated(t, ctx, &net)
+
+	t.Logf("Deleting ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err = retryOnConflict(ctx, net.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		return client.Delete(ctx, currentNet)
+	})
+	require.NoError(t, err, "could not delete a ContainerNetwork object")
+
+	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
+
+	inspected, err := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{
+		Networks: []string{updatedNet.Status.ID},
+	})
+	require.NoError(t, err, "could not inspect the network")
+	require.Len(t, inspected, 1, "expected to find a single network")
+}
+
 func ensureNetworkCreated(t *testing.T, ctx context.Context, network *apiv1.ContainerNetwork) *apiv1.ContainerNetwork {
 	updatedNet := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(network), func(currentNet *apiv1.ContainerNetwork) (bool, error) {
 		if currentNet.Status.State == apiv1.ContainerNetworkStateFailedToStart {

--- a/test/integration/network_controller_test.go
+++ b/test/integration/network_controller_test.go
@@ -77,7 +77,7 @@ func TestNetworkRemoveInstance(t *testing.T) {
 	})
 	require.NoError(t, err, "could not delete a ContainerNetwork object")
 
-	err = wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(_ context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
 		inspectedNetworks, networkInspectionErr := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{Networks: []string{updatedNet.Status.ID}})
 		if !errors.Is(networkInspectionErr, containers.ErrNotFound) || len(inspectedNetworks) != 0 {
 			return false, nil
@@ -379,7 +379,7 @@ func TestNetworkCleanupModeRemovesExistingNetworkOnDelete(t *testing.T) {
 
 	ctrl_testutil.WaitObjectDeleted(t, ctx, client, &net)
 
-	err = wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(_ context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
 		inspectedNetworks, networkInspectionErr := containerOrchestrator.InspectNetworks(ctx, containers.InspectNetworksOptions{Networks: []string{id}})
 		if !errors.Is(networkInspectionErr, containers.ErrNotFound) || len(inspectedNetworks) != 0 {
 			return false, nil

--- a/test/integration/standard_test_env.go
+++ b/test/integration/standard_test_env.go
@@ -109,13 +109,9 @@ func StartTestEnvironment(
 		// This avoids a bunch of shutdown errors from the manager.
 		<-managerDone.Wait()
 
-		if pex != nil {
-			tpeCloseErr := pex.Close()
-			if tpeCloseErr != nil {
-				log.Error(tpeCloseErr, "Failed to close the test process executor")
-			}
-		} else {
-			pex.Dispose()
+		tpeCloseErr := pex.Close()
+		if tpeCloseErr != nil {
+			log.Error(tpeCloseErr, "Failed to close the test process executor")
 		}
 
 		stateStoreCleanup()

--- a/test/integration/standard_test_env.go
+++ b/test/integration/standard_test_env.go
@@ -109,9 +109,13 @@ func StartTestEnvironment(
 		// This avoids a bunch of shutdown errors from the manager.
 		<-managerDone.Wait()
 
-		tpeCloseErr := pex.Close()
-		if tpeCloseErr != nil {
-			log.Error(tpeCloseErr, "Failed to close the test process executor")
+		if pex != nil {
+			tpeCloseErr := pex.Close()
+			if tpeCloseErr != nil {
+				log.Error(tpeCloseErr, "Failed to close the test process executor")
+			}
+		} else {
+			pex.Dispose()
 		}
 
 		stateStoreCleanup()


### PR DESCRIPTION
Persistent resources currently rely on the legacy `persistent` boolean, which cannot express adoption-only or cleanup-on-delete scenarios clearly. This adds explicit lifecycle modes so Aspire can distinguish session-scoped resources, reusable persistent resources, existing-only resources, and cleanup resources while preserving `persistent=true` as the backward-compatible override.

## Summary

- Add `mode` fields for container networks, containers, and executables, with validation and generated OpenAPI updates.
- Preserve legacy `persistent=true` behavior by making it override `mode`.
- Implement mode-aware create, reuse, delete, and cleanup behavior in the network, container, and executable controllers.
- Keep executable modes limited to `session`, `persistent`, and `cleanup`; process reuse modes require `ExecutionType=Process` and no fallback runners.
- Route persistent executable liveness checks through the process executor/runner seam so tests can use the fake executor instead of real OS processes.
- Add integration coverage for mode behavior and persistence override cases.

## Validation

- `make test`
- `make lint`