### PR TITLE
Backport log stream release fix to release/0.25

### DIFF
--- a/internal/dcp/bootstrap/dcp_run.go
+++ b/internal/dcp/bootstrap/dcp_run.go
@@ -181,8 +181,14 @@ func DcpRun(
 			// If we are in server-only mode (no standard controllers) such as when running tests,
 			// there is no point trying to clean up all resources on shutdown because no actual resources are involved,
 			// it is all test mocks. Another case to avoid full cleanup is when shutdown request explicitly disables it.
+			// Hosted services still need to shut down before we return so child processes can release session files.
 			if serverOnly || !resourceCleanup.IsFull() {
-				return nil // No cleanup needed, just return
+				err = shutdownHost()
+				if err != nil {
+					log.Error(err, "Failed to shut down hosted services")
+					return err
+				}
+				return nil
 			}
 
 			err = appmgmt.CleanupAllResources(log)

--- a/internal/logs/containerlogs/container_logstreamer.go
+++ b/internal/logs/containerlogs/container_logstreamer.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	apiserver_resource "github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
@@ -31,7 +32,7 @@ import (
 )
 
 var (
-	lastLogStreamID logs.LogStreamID // Used to generate unique log stream IDs for each log stream
+	lastLogStreamID atomic.Uint64 // Used to generate unique log stream IDs for each log stream
 )
 
 type containerLogStreamer struct {
@@ -48,6 +49,12 @@ type containerLogStreamer struct {
 
 	log  logr.Logger
 	lock *sync.Mutex
+}
+
+type containerStreamsToStop struct {
+	streamKind    string
+	streams       []*usvc_io.FollowWriter
+	cancelStreams func([]*usvc_io.FollowWriter)
 }
 
 func NewLogStreamer(log logr.Logger) *containerLogStreamer {
@@ -235,13 +242,12 @@ func (c *containerLogStreamer) StreamLogs(
 	// to account for the fact that ContainerLogSource.CaptureContainerLogs() is an asynchronous operation.
 	// A few no-data stop retries will allow us to get log lines from a container that we just started capturing logs for, regardless of follow/non-follow mode.
 	const noDataStopRetries = 3
-	followWriter := usvc_io.NewFollowWriter(ctx, src, dest, usvc_io.WithNoDataStopRetries(noDataStopRetries))
+	followWriter := usvc_io.NewFollowWriter(ctx, src, dest, usvc_io.WithNoDataStopRetries(noDataStopRetries), usvc_io.WithCloseSourceOnCancel())
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	streamID := lastLogStreamID + 1
-	lastLogStreamID = streamID
+	streamID := logs.LogStreamID(lastLogStreamID.Add(1))
 
 	var streams logs.LogStreamMop
 	switch opts.Source {
@@ -262,7 +268,6 @@ func (c *containerLogStreamer) StreamLogs(
 
 	go func() {
 		defer cleanup()
-		defer src.Close()
 
 		streamLog.V(1).Info("Starting streaming logs to destination ...")
 		<-followWriter.Done()
@@ -296,62 +301,84 @@ func (c *containerLogStreamer) OnResourceUpdated(evt apiv1.ResourceWatcherEvent,
 		return
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	var streamsToStop []containerStreamsToStop
+	var containerLogsToRelease *logs.LogDescriptorSet
 
-	if c.containerLogSource == nil {
-		// We haven't completed initialization for any resources yet
-		return
-	}
+	c.lock.Lock()
 
 	switch evt.Type {
 
 	case watch.Added, watch.Modified:
 		// "watch.Added" does not necessarily mean that the resource was just created.
 		// It really means that the resource was added to the watch stream (has been observed for the first time).
-
 		if ctr.Status.State != apiv1.ContainerStateStarting && ctr.Status.State != apiv1.ContainerStateBuilding {
 			// If done starting the container, ensure startup logs stop streaming once they reach EOF
-			stopLogStreamsForContainer(c.startupLogStreams, ctr, "startup", log)
+			streamsToStop = append(streamsToStop, takeLogStreamsForContainer(c.startupLogStreams, ctr, "startup", logs.DelayStopFollowing))
 		}
 
 		if ctr.Done() {
 			// If the container is done, ensure standard and system logs stop streaming once they reach EOF
-			stopLogStreamsForContainer(c.stdioLogStreams, ctr, "stdio", log)
-			stopLogStreamsForContainer(c.systemLogStreams, ctr, "system", log)
+			streamsToStop = append(streamsToStop,
+				takeLogStreamsForContainer(c.stdioLogStreams, ctr, "stdio", logs.DelayStopFollowing),
+				takeLogStreamsForContainer(c.systemLogStreams, ctr, "system", logs.DelayStopFollowing),
+			)
 		}
 
 	case watch.Deleted:
 		// The resource was deleted, ensure any following log streams stop and cleanup their resources
-		stopLogStreamsForContainer(c.startupLogStreams, ctr, "startup", log)
-		stopLogStreamsForContainer(c.stdioLogStreams, ctr, "stdio", log)
-		stopLogStreamsForContainer(c.systemLogStreams, ctr, "system", log)
+		streamsToStop = append(streamsToStop,
+			takeLogStreamsForContainer(c.startupLogStreams, ctr, "startup", logs.DelayStopFollowing),
+			takeLogStreamsForContainer(c.stdioLogStreams, ctr, "stdio", logs.DelayStopFollowing),
+			takeLogStreamsForContainer(c.systemLogStreams, ctr, "system", logs.DelayStopFollowing),
+		)
 
 		if c.containerLogs != nil {
 			// Need to stop the log streamer and any log watchers for this container (if any) as it is being deleted.
 			// It is OK to call ReleaseForResource() if the resource is not in the set, it is a no-op in that case.
-			c.containerLogs.ReleaseForResource(ctr.UID)
+			containerLogsToRelease = c.containerLogs
 		}
+	}
+
+	c.lock.Unlock()
+
+	stopLogStreamsForContainer(ctr, log, streamsToStop)
+	if containerLogsToRelease != nil {
+		containerLogsToRelease.ReleaseForResource(ctr.UID)
 	}
 }
 
-func stopLogStreamsForContainer(
+func takeLogStreamsForContainer(
 	streams logs.LogStreamMop,
 	ctr *apiv1.Container,
 	streamKind string,
-	log logr.Logger,
-) {
+	cancelStreams func([]*usvc_io.FollowWriter),
+) containerStreamsToStop {
 	if ctrStreams, found := streams[ctr.UID]; found {
 		delete(streams, ctr.UID)
+		return containerStreamsToStop{
+			streamKind:    streamKind,
+			streams:       maps.Values(ctrStreams),
+			cancelStreams: cancelStreams,
+		}
+	}
+
+	return containerStreamsToStop{}
+}
+
+func stopLogStreamsForContainer(ctr *apiv1.Container, log logr.Logger, streamsToStop []containerStreamsToStop) {
+	for _, streamGroup := range streamsToStop {
+		if len(streamGroup.streams) == 0 {
+			continue
+		}
 
 		if log.V(1).Enabled() {
-			log.V(1).Info(fmt.Sprintf("Stopping %s follow logs for container", streamKind),
+			log.V(1).Info(fmt.Sprintf("Stopping %s follow logs for container", streamGroup.streamKind),
 				"Container", ctr.Status.ContainerID,
-				"StreamCount", len(ctrStreams),
+				"StreamCount", len(streamGroup.streams),
 			)
 		}
 
-		logs.DelayCancelFollowStreams(maps.Values(ctrStreams), (*usvc_io.FollowWriter).StopFollow)
+		streamGroup.cancelStreams(streamGroup.streams)
 	}
 }
 
@@ -374,24 +401,18 @@ func appropriatelyCancel(fw *usvc_io.FollowWriter, ctr *apiv1.Container, opts *a
 	if !follow {
 		fw.StopFollow() // Will stop writing after first EOF is reached
 	} else if ctr.Done() {
-		logs.DelayCancelFollowStreams([]*usvc_io.FollowWriter{fw}, (*usvc_io.FollowWriter).StopFollow)
+		logs.DelayStopFollowing([]*usvc_io.FollowWriter{fw})
 	}
 }
 
 func (c *containerLogStreamer) Dispose() error {
 	c.lock.Lock()
 
-	for _, w := range maps.FlattenValues(c.startupLogStreams) {
-		w.StopFollow()
-	}
+	streamsToCancel := maps.FlattenValues(c.startupLogStreams)
 	c.startupLogStreams = make(logs.LogStreamMop)
-	for _, w := range maps.FlattenValues(c.stdioLogStreams) {
-		w.StopFollow()
-	}
+	streamsToCancel = append(streamsToCancel, maps.FlattenValues(c.stdioLogStreams)...)
 	c.stdioLogStreams = make(logs.LogStreamMop)
-	for _, w := range maps.FlattenValues(c.systemLogStreams) {
-		w.StopFollow()
-	}
+	streamsToCancel = append(streamsToCancel, maps.FlattenValues(c.systemLogStreams)...)
 	c.systemLogStreams = make(logs.LogStreamMop)
 
 	lds := c.containerLogs
@@ -399,6 +420,7 @@ func (c *containerLogStreamer) Dispose() error {
 
 	c.lock.Unlock()
 
+	logs.CancelFollowStreams(streamsToCancel)
 	if lds != nil {
 		return lds.Dispose()
 	} else {

--- a/internal/logs/containerlogs/container_logstreamer_test.go
+++ b/internal/logs/containerlogs/container_logstreamer_test.go
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package containerlogs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	apiv1 "github.com/microsoft/dcp/api/v1"
+	"github.com/microsoft/dcp/internal/logs"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
+	"github.com/microsoft/dcp/pkg/testutil"
+)
+
+const containerLogStreamerTestTimeout = 20 * time.Second
+
+func TestOnResourceUpdatedDelaysDeletedContainerStreamStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, containerLogStreamerTestTimeout)
+	defer cancel()
+
+	log := testutil.NewLogForTesting("container-log-streamer-delete")
+	streamer := NewLogStreamer(log)
+	containerUID := types.UID("delete-container-stream-test")
+	followWriters := addEOFContainerFollowWriters(ctx, streamer, containerUID)
+	ctr := &apiv1.Container{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "delete-container-stream-test",
+			UID:  containerUID,
+		},
+		Status: apiv1.ContainerStatus{
+			State: apiv1.ContainerStateRunning,
+		},
+	}
+
+	streamer.OnResourceUpdated(apiv1.ResourceWatcherEvent{
+		Type:   watch.Deleted,
+		Object: ctr,
+	}, log)
+
+	for _, followWriter := range followWriters {
+		assertContainerStreamNotDoneImmediately(t, ctx, followWriter.Done())
+	}
+	for _, followWriter := range followWriters {
+		assertContainerStreamDone(t, ctx, followWriter.Done())
+	}
+}
+
+func TestDisposeCancelsContainerStreamsImmediately(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, containerLogStreamerTestTimeout)
+	defer cancel()
+
+	log := testutil.NewLogForTesting("container-log-streamer-dispose")
+	streamer := NewLogStreamer(log)
+	followWriters := addBlockingContainerFollowWriters(ctx, streamer, types.UID("dispose-container-stream-test"))
+
+	require.NoError(t, streamer.Dispose())
+	for _, followWriter := range followWriters {
+		assertContainerStreamDoneBeforeFollowDelay(t, ctx, followWriter.Done())
+	}
+}
+
+func addBlockingContainerFollowWriters(ctx context.Context, streamer *containerLogStreamer, containerUID types.UID) []*usvc_io.FollowWriter {
+	followWriters := []*usvc_io.FollowWriter{
+		newBlockingContainerFollowWriter(ctx),
+		newBlockingContainerFollowWriter(ctx),
+		newBlockingContainerFollowWriter(ctx),
+	}
+	streamer.startupLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		1: followWriters[0],
+	}
+	streamer.stdioLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		2: followWriters[1],
+	}
+	streamer.systemLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		3: followWriters[2],
+	}
+	return followWriters
+}
+
+func addEOFContainerFollowWriters(ctx context.Context, streamer *containerLogStreamer, containerUID types.UID) []*usvc_io.FollowWriter {
+	followWriters := []*usvc_io.FollowWriter{
+		newEOFContainerFollowWriter(ctx),
+		newEOFContainerFollowWriter(ctx),
+		newEOFContainerFollowWriter(ctx),
+	}
+	streamer.startupLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		1: followWriters[0],
+	}
+	streamer.stdioLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		2: followWriters[1],
+	}
+	streamer.systemLogStreams[containerUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		3: followWriters[2],
+	}
+	return followWriters
+}
+
+func newBlockingContainerFollowWriter(ctx context.Context) *usvc_io.FollowWriter {
+	reader, _ := usvc_io.NewBufferedPipe()
+	return usvc_io.NewFollowWriter(ctx, reader, testutil.NewBufferWriter(), usvc_io.WithCloseSourceOnCancel())
+}
+
+func newEOFContainerFollowWriter(ctx context.Context) *usvc_io.FollowWriter {
+	return usvc_io.NewFollowWriter(ctx, testutil.NewThreadSafeBuffer(), testutil.NewBufferWriter())
+}
+
+func assertContainerStreamDoneBeforeFollowDelay(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	timer := time.NewTimer(logs.FollowStreamCancellationDelay / 2)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("log stream was not canceled before follow cancellation delay")
+	case <-ctx.Done():
+		t.Fatal("test timed out before log stream was canceled")
+	}
+}
+
+func assertContainerStreamNotDoneImmediately(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		t.Fatal("log stream was canceled immediately")
+	case <-timer.C:
+	case <-ctx.Done():
+		t.Fatal("test timed out while checking that log stream was not canceled immediately")
+	}
+}
+
+func assertContainerStreamDone(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("test timed out before log stream was canceled")
+	}
+}

--- a/internal/logs/logdescriptor_test.go
+++ b/internal/logs/logdescriptor_test.go
@@ -77,7 +77,7 @@ func TestLogFollowingDelayWithinBounds(t *testing.T) {
 	stdOutFile, stdOutErr := io.OpenFile(stdOutPath, os.O_RDONLY, 0)
 	require.NoError(t, stdOutErr)
 
-	follow := io.NewFollowWriter(ctx, stdOutFile, buf)
+	follow := io.NewFollowWriter(ctx, stdOutFile, buf, io.WithCloseSourceOnCancel())
 
 	var logWriteTimes []time.Time
 	for i := 0; i < numWrites; i++ {

--- a/internal/logs/logutil.go
+++ b/internal/logs/logutil.go
@@ -63,3 +63,13 @@ func DelayCancelFollowStreams(streams []*usvc_io.FollowWriter, cancelStream func
 		}
 	}()
 }
+
+func DelayStopFollowing(streams []*usvc_io.FollowWriter) {
+	DelayCancelFollowStreams(streams, (*usvc_io.FollowWriter).StopFollow)
+}
+
+func CancelFollowStreams(streams []*usvc_io.FollowWriter) {
+	for _, stream := range streams {
+		stream.Cancel()
+	}
+}

--- a/internal/logs/stdiologs/stdio_log_streamer.go
+++ b/internal/logs/stdiologs/stdio_log_streamer.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	apiserver_resource "github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
@@ -26,7 +27,7 @@ import (
 )
 
 var (
-	lastLogStreamID logs.LogStreamID // Used to generate unique log stream IDs for each log stream
+	lastLogStreamID atomic.Uint64 // Used to generate unique log stream IDs for each log stream
 
 	stdIoStreamer = &stdIoLogStreamer{
 		lock:          &sync.Mutex{},
@@ -154,14 +155,13 @@ func (sls stdIoLogStreamer) StreamLogs(
 		return apiv1.ResourceStreamStatusDone, nil, nil
 	}
 
-	followWriter := usvc_io.NewFollowWriter(requestCtx, src, dest)
+	followWriter := usvc_io.NewFollowWriter(requestCtx, src, dest, usvc_io.WithCloseSourceOnCancel())
 	resourceID := resource.GetUID()
 
 	sls.lock.Lock()
 	defer sls.lock.Unlock()
 
-	streamID := lastLogStreamID + 1
-	lastLogStreamID = streamID
+	streamID := logs.LogStreamID(lastLogStreamID.Add(1))
 
 	followWriters, found := sls.activeStreams[resourceID]
 	if !found {
@@ -206,25 +206,9 @@ func (sls *stdIoLogStreamer) OnResourceUpdated(evt apiv1.ResourceWatcherEvent, l
 		return
 	}
 
-	sls.lock.Lock()
-	defer sls.lock.Unlock()
-
-	stopResourceStreams := func(logMessage string) {
-		resourceID := resource.GetUID()
-
-		if fwStreams, found := sls.activeStreams[resourceID]; found {
-			delete(sls.activeStreams, resourceID)
-
-			if log.V(1).Enabled() {
-				log.V(1).Info(logMessage, "Kind", evt.Object.GetObjectKind().GroupVersionKind().String(),
-					"Name", resource.NamespacedName().String(),
-					"StreamCount", len(fwStreams),
-				)
-			}
-
-			logs.DelayCancelFollowStreams(maps.Values(fwStreams), (*usvc_io.FollowWriter).StopFollow)
-		}
-	}
+	var streamsToStop []*usvc_io.FollowWriter
+	var stopStreams func([]*usvc_io.FollowWriter)
+	var logMessage string
 
 	switch evt.Type {
 
@@ -232,27 +216,49 @@ func (sls *stdIoLogStreamer) OnResourceUpdated(evt apiv1.ResourceWatcherEvent, l
 		// "watch.Added" does not necessarily mean that the resource was just created.
 		// It really means that the resource was added to the watch stream (has been observed for the first time).
 
-		if !resource.GetDeletionTimestamp().IsZero() {
-			stopResourceStreams("Stopping log streams for resource that is being deleted")
-		} else if resource.Done() {
+		if resource.GetDeletionTimestamp().IsZero() && resource.Done() {
 			// If the resource isn't running, ensure logs stop streaming once they reach EOF
-			stopResourceStreams("Stopping log following for resource that reached its final state")
+			logMessage = "Stopping log following for resource that reached its final state"
+			stopStreams = logs.DelayStopFollowing
 		}
 
 	case watch.Deleted:
-		stopResourceStreams("Stopping log streams for resource that was deleted")
+		logMessage = "Stopping log streams for resource that was deleted"
+		stopStreams = logs.DelayStopFollowing
 	}
+
+	if stopStreams == nil {
+		return
+	}
+
+	resourceID := resource.GetUID()
+	sls.lock.Lock()
+	if fwStreams, found := sls.activeStreams[resourceID]; found {
+		delete(sls.activeStreams, resourceID)
+		streamsToStop = maps.Values(fwStreams)
+	}
+	sls.lock.Unlock()
+
+	if len(streamsToStop) == 0 {
+		return
+	}
+
+	if log.V(1).Enabled() {
+		log.V(1).Info(logMessage, "Kind", evt.Object.GetObjectKind().GroupVersionKind().String(),
+			"Name", resource.NamespacedName().String(),
+			"StreamCount", len(streamsToStop),
+		)
+	}
+	stopStreams(streamsToStop)
 }
 
 func (sls *stdIoLogStreamer) Dispose() error {
 	sls.lock.Lock()
-	defer sls.lock.Unlock()
-
-	for _, w := range maps.FlattenValues(sls.activeStreams) {
-		w.StopFollow()
-	}
+	streamsToCancel := maps.FlattenValues(sls.activeStreams)
 	sls.activeStreams = make(logs.LogStreamMop)
+	sls.lock.Unlock()
 
+	logs.CancelFollowStreams(streamsToCancel)
 	return nil
 }
 

--- a/internal/logs/stdiologs/stdio_log_streamer_test.go
+++ b/internal/logs/stdiologs/stdio_log_streamer_test.go
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package stdiologs
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	apiv1 "github.com/microsoft/dcp/api/v1"
+	"github.com/microsoft/dcp/internal/logs"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
+	"github.com/microsoft/dcp/pkg/testutil"
+)
+
+const stdioLogStreamerTestTimeout = 20 * time.Second
+
+func TestOnResourceUpdatedDoesNotStopDeletingResourceStream(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stdioLogStreamerTestTimeout)
+	defer cancel()
+
+	streamer := &stdIoLogStreamer{
+		lock:          &sync.Mutex{},
+		activeStreams: make(logs.LogStreamMop),
+	}
+	log := testutil.NewLogForTesting("stdio-log-streamer-deleting")
+	followWriter := newBlockingFollowWriter(ctx)
+	resourceUID := types.UID("deleting-stream-test")
+	streamer.activeStreams[resourceUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		1: followWriter,
+	}
+	now := metav1.Now()
+	exe := &apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-stream-test",
+			UID:               resourceUID,
+			DeletionTimestamp: &now,
+		},
+		Status: apiv1.ExecutableStatus{
+			FinishTimestamp: metav1.NowMicro(),
+		},
+	}
+
+	streamer.OnResourceUpdated(apiv1.ResourceWatcherEvent{
+		Type:   watch.Modified,
+		Object: exe,
+	}, log)
+
+	assertStreamNotDoneImmediately(t, ctx, followWriter.Done())
+}
+
+func TestOnResourceUpdatedDelaysDeletedResourceStreamStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stdioLogStreamerTestTimeout)
+	defer cancel()
+
+	streamer := &stdIoLogStreamer{
+		lock:          &sync.Mutex{},
+		activeStreams: make(logs.LogStreamMop),
+	}
+	log := testutil.NewLogForTesting("stdio-log-streamer-delete")
+	followWriter := newEOFFollowWriter(ctx)
+	resourceUID := types.UID("delete-stream-test")
+	streamer.activeStreams[resourceUID] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		1: followWriter,
+	}
+	exe := &apiv1.Executable{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "delete-stream-test",
+			UID:  resourceUID,
+		},
+	}
+
+	streamer.OnResourceUpdated(apiv1.ResourceWatcherEvent{
+		Type:   watch.Deleted,
+		Object: exe,
+	}, log)
+
+	assertStreamNotDoneImmediately(t, ctx, followWriter.Done())
+	assertStreamDone(t, ctx, followWriter.Done())
+}
+
+func TestDisposeCancelsStreamsImmediately(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stdioLogStreamerTestTimeout)
+	defer cancel()
+
+	streamer := &stdIoLogStreamer{
+		lock:          &sync.Mutex{},
+		activeStreams: make(logs.LogStreamMop),
+	}
+	followWriter := newBlockingFollowWriter(ctx)
+	streamer.activeStreams[types.UID("dispose-stream-test")] = map[logs.LogStreamID]*usvc_io.FollowWriter{
+		1: followWriter,
+	}
+
+	require.NoError(t, streamer.Dispose())
+	assertDoneBeforeFollowDelay(t, ctx, followWriter.Done())
+}
+
+func newBlockingFollowWriter(ctx context.Context) *usvc_io.FollowWriter {
+	reader, _ := usvc_io.NewBufferedPipe()
+	return usvc_io.NewFollowWriter(ctx, reader, testutil.NewBufferWriter(), usvc_io.WithCloseSourceOnCancel())
+}
+
+func newEOFFollowWriter(ctx context.Context) *usvc_io.FollowWriter {
+	return usvc_io.NewFollowWriter(ctx, testutil.NewThreadSafeBuffer(), testutil.NewBufferWriter())
+}
+
+func assertDoneBeforeFollowDelay(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	timer := time.NewTimer(logs.FollowStreamCancellationDelay / 2)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("log stream was not canceled before follow cancellation delay")
+	case <-ctx.Done():
+		t.Fatal("test timed out before log stream was canceled")
+	}
+}
+
+func assertStreamNotDoneImmediately(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		t.Fatal("log stream was canceled immediately")
+	case <-timer.C:
+	case <-ctx.Done():
+		t.Fatal("test timed out while checking that log stream was not canceled immediately")
+	}
+}
+
+func assertStreamDone(t *testing.T, ctx context.Context, done <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("test timed out before log stream was canceled")
+	}
+}

--- a/internal/testutil/ctrlutil/apiserver_start.go
+++ b/internal/testutil/ctrlutil/apiserver_start.go
@@ -144,6 +144,8 @@ func StartApiServer(
 			}
 		}
 
+		logger.ReleaseResourceLogsInFolder(sessionFolder)
+
 		// Try a few times because it may not succeed immediately (e.g. AV software may be scanning the folder).
 		sessionFolderRemoveErr := resiliency.RetryExponentialWithTimeout(context.Background(), 5*time.Second, func() error {
 			return os.RemoveAll(sessionFolder)

--- a/pkg/io/follow_writer.go
+++ b/pkg/io/follow_writer.go
@@ -8,6 +8,7 @@ package io
 import (
 	"context"
 	"io"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -30,28 +31,45 @@ func WithNoDataStopRetries(n uint) FollowWriterOption {
 	}
 }
 
+// WithCloseSourceOnCancel makes Cancel synchronously close source if it implements io.Closer.
+// Once enabled, the FollowWriter owns source closure and closes it before Done on any exit.
+func WithCloseSourceOnCancel() FollowWriterOption {
+	return func(fw *FollowWriter) {
+		fw.closeSourceOnCancel = true
+	}
+}
+
 type FollowWriter struct {
-	err               atomic.Value
-	follow            atomic.Bool
-	cancel            context.CancelFunc
-	doneChan          chan struct{}
-	noDataStopRetries uint
+	err                 atomic.Value
+	follow              atomic.Bool
+	cancel              context.CancelFunc
+	closeSourceOnCancel bool
+	closeSourceOnce     func()
+	doneChan            chan struct{}
+	noDataStopRetries   uint
 }
 
 // Creates a FollowWriter that reads content from the reader source and writes it to the writer destination.
 // Keeps trying to read new content even after EOF until StopFollow() is called, after which the next EOF
 // received will cause the reader and writer to stop.
-// If the source is an io.Closer, it will be closed when the FollowWriter is cancelled.
+// Source ownership stays with the caller unless WithCloseSourceOnCancel is used.
 //
 // Use WithNoDataStopRetries option to specify extra read attempts after StopFollow() is called
 // when no data has been seen yet. This is useful when the data source might not be ready immediately.
 func NewFollowWriter(ctx context.Context, source io.Reader, dest io.Writer, opts ...FollowWriterOption) *FollowWriter {
 	followCtx, cancel := context.WithCancel(ctx)
+	closeSourceOnce := sync.OnceFunc(func() {})
+	if sourceCloser, isCloser := source.(io.Closer); isCloser {
+		closeSourceOnce = sync.OnceFunc(func() {
+			_ = sourceCloser.Close()
+		})
+	}
 	fw := &FollowWriter{
-		err:      atomic.Value{},
-		follow:   atomic.Bool{},
-		cancel:   cancel,
-		doneChan: make(chan struct{}),
+		err:             atomic.Value{},
+		follow:          atomic.Bool{},
+		cancel:          cancel,
+		closeSourceOnce: closeSourceOnce,
+		doneChan:        make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -61,14 +79,13 @@ func NewFollowWriter(ctx context.Context, source io.Reader, dest io.Writer, opts
 	fw.follow.Store(true)
 
 	go func() {
+		defer close(fw.doneChan)
+		defer cancel()
 		defer func() {
-			// If the source can be closed, do so
-			if closer, isCloser := source.(io.Closer); isCloser {
-				closer.Close()
+			if fw.closeSourceOnCancel {
+				fw.closeSourceOnce()
 			}
 		}()
-		defer cancel()
-		defer close(fw.doneChan)
 
 		buf := make([]byte, defaultBufferSize)
 		timer := time.NewTimer(0)
@@ -88,6 +105,9 @@ func NewFollowWriter(ctx context.Context, source io.Reader, dest io.Writer, opts
 
 				out, writeErr := dest.Write(buf[:read])
 				if writeErr != nil {
+					if followCtx.Err() != nil {
+						return
+					}
 					fw.err.Store(writeErr)
 					return
 				}
@@ -99,6 +119,9 @@ func NewFollowWriter(ctx context.Context, source io.Reader, dest io.Writer, opts
 			}
 
 			if readErr != nil && readErr != io.EOF {
+				if followCtx.Err() != nil {
+					return
+				}
 				fw.err.Store(readErr)
 				return
 			}
@@ -152,4 +175,7 @@ func (fw *FollowWriter) Done() <-chan struct{} {
 
 func (fw *FollowWriter) Cancel() {
 	fw.cancel()
+	if fw.closeSourceOnCancel {
+		fw.closeSourceOnce()
+	}
 }

--- a/pkg/io/follow_writer_test.go
+++ b/pkg/io/follow_writer_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -25,6 +26,140 @@ const (
 	defaultTestTimeout       = 20 * time.Second
 	cleanupReadyPollInterval = 200 * time.Millisecond
 )
+
+type orderedBlockingReadCloser struct {
+	closeCh chan struct{}
+	events  chan string
+	closed  atomic.Bool
+}
+
+func newOrderedBlockingReadCloser() *orderedBlockingReadCloser {
+	return &orderedBlockingReadCloser{
+		closeCh: make(chan struct{}),
+		events:  make(chan string, 2),
+	}
+}
+
+func (r *orderedBlockingReadCloser) Read(_ []byte) (int, error) {
+	<-r.closeCh
+	return 0, usvc_io.ErrClosedReader
+}
+
+func (r *orderedBlockingReadCloser) Close() error {
+	if r.closed.CompareAndSwap(false, true) {
+		r.events <- "source-closed"
+		close(r.closeCh)
+	}
+	return nil
+}
+
+type eofReadCloser struct {
+	closed atomic.Bool
+}
+
+type cancelAwareErrorWriter struct {
+	ctx     context.Context
+	started chan struct{}
+}
+
+func (w *cancelAwareErrorWriter) Write(_ []byte) (int, error) {
+	close(w.started)
+	<-w.ctx.Done()
+	return 0, errors.New("destination closed")
+}
+
+func (r *eofReadCloser) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (r *eofReadCloser) Close() error {
+	r.closed.Store(true)
+	return nil
+}
+
+func TestFollowWriterCancelClosesSourceBeforeDone(t *testing.T) {
+	t.Parallel()
+
+	source := newOrderedBlockingReadCloser()
+	buf := testutil.NewBufferWriter()
+	ctx, cancel := testutil.GetTestContext(t, defaultTestTimeout)
+	defer cancel()
+
+	writer := usvc_io.NewFollowWriter(ctx, source, buf, usvc_io.WithCloseSourceOnCancel())
+	go func() {
+		<-writer.Done()
+		source.events <- "done"
+	}()
+
+	writer.Cancel()
+
+	select {
+	case event := <-source.events:
+		require.Equal(t, "source-closed", event)
+	case <-ctx.Done():
+		t.Fatal("FollowWriter did not close source before test timeout")
+	}
+
+	select {
+	case event := <-source.events:
+		require.Equal(t, "done", event)
+	case <-ctx.Done():
+		t.Fatal("FollowWriter did not finish after source was closed")
+	}
+
+	require.NoError(t, writer.Err())
+}
+
+func TestFollowWriterDoesNotCloseSourceByDefault(t *testing.T) {
+	t.Parallel()
+
+	source := &eofReadCloser{}
+	buf := testutil.NewBufferWriter()
+	ctx, cancel := testutil.GetTestContext(t, defaultTestTimeout)
+	defer cancel()
+
+	writer := usvc_io.NewFollowWriter(ctx, source, buf)
+	writer.StopFollow()
+
+	select {
+	case <-writer.Done():
+	case <-ctx.Done():
+		t.Fatal("FollowWriter did not finish before test timeout")
+	}
+
+	require.False(t, source.closed.Load())
+	require.NoError(t, writer.Err())
+}
+
+func TestFollowWriterIgnoresWriteErrorAfterCancel(t *testing.T) {
+	t.Parallel()
+
+	testCtx, cancelTestCtx := testutil.GetTestContext(t, defaultTestTimeout)
+	defer cancelTestCtx()
+
+	followCtx, cancelFollowCtx := context.WithCancel(testCtx)
+	dest := &cancelAwareErrorWriter{
+		ctx:     followCtx,
+		started: make(chan struct{}),
+	}
+
+	writer := usvc_io.NewFollowWriter(followCtx, strings.NewReader("content"), dest)
+
+	select {
+	case <-dest.started:
+		cancelFollowCtx()
+	case <-testCtx.Done():
+		t.Fatal("FollowWriter did not start writing before test timeout")
+	}
+
+	select {
+	case <-writer.Done():
+	case <-testCtx.Done():
+		t.Fatal("FollowWriter did not finish before test timeout")
+	}
+
+	require.NoError(t, writer.Err())
+}
 
 // Ensure that follow writer in follow mode run on empty file does not return any data.
 func TestFollowWriterFollowEmptyFile(t *testing.T) {

--- a/pkg/logger/resource_sink.go
+++ b/pkg/logger/resource_sink.go
@@ -61,38 +61,66 @@ func makeResourceLogPath(resourceId string, dir string) string {
 
 func ReleaseResourceLog(resourceId string) {
 	resourceLoggerLock.Lock()
-	defer resourceLoggerLock.Unlock()
-
-	if sink, found := resourceSinks[resourceId]; found {
-		// Flush any buffered log entries to the file
-		sink.flush()
-		// We're making a best effort to close the file, but don't care if the operation failed
-		_ = sink.file.Close()
+	sink, found := resourceSinks[resourceId]
+	if found {
 		delete(resourceSinks, resourceId)
+	}
+	resourceLoggerLock.Unlock()
+
+	if found {
+		sink.flush()
+		_ = sink.file.Close()
+	}
+}
+
+func ReleaseResourceLogsInFolder(folder string) {
+	if folder == "" {
+		return
+	}
+
+	resourceLoggerLock.Lock()
+
+	sinksToRelease := []*resourceFileSink{}
+	for resourceId, sink := range resourceSinks {
+		if osutil.SameCleanPath(filepath.Dir(sink.file.Name()), folder) {
+			sinksToRelease = append(sinksToRelease, sink)
+			delete(resourceSinks, resourceId)
+		}
+	}
+	resourceLoggerLock.Unlock()
+
+	for _, sink := range sinksToRelease {
+		sink.flush()
+		_ = sink.file.Close()
 	}
 }
 
 func ReleaseAllResourceLogs() {
 	resourceLoggerLock.Lock()
-	defer resourceLoggerLock.Unlock()
 
 	resourceLoggerDisabled.Store(true)
 
-	wg := &sync.WaitGroup{}
-	wg.Add(len(resourceSinks))
+	sinksToRelease := make([]*resourceFileSink, 0, len(resourceSinks))
+	for _, sink := range resourceSinks {
+		sinksToRelease = append(sinksToRelease, sink)
+	}
 
-	for resourceId, sink := range resourceSinks {
-		go func(resourceId string, sink *resourceFileSink) {
+	// Clear out all resource sinks
+	resourceSinks = map[string]*resourceFileSink{}
+	resourceLoggerLock.Unlock()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(sinksToRelease))
+
+	for _, sink := range sinksToRelease {
+		go func(sink *resourceFileSink) {
 			defer wg.Done()
 			// Flush any buffered log entries to the file
 			sink.flush()
 			// We're making a best effort to close the file, but don't care if the operation failed
 			_ = sink.file.Close()
-		}(resourceId, sink)
+		}(sink)
 	}
-
-	// Clear out all resource sinks
-	resourceSinks = map[string]*resourceFileSink{}
 
 	wg.Wait()
 }
@@ -119,12 +147,17 @@ func newResourceSink(atomicLevel zap.AtomicLevel, innerSink logr.LogSink, resour
 
 func (s *resourceSink) Flush() {
 	resourceLoggerLock.Lock()
-	defer resourceLoggerLock.Unlock()
+
+	sinksToFlush := make([]*resourceFileSink, 0, len(resourceSinks))
+	for _, sink := range resourceSinks {
+		sinksToFlush = append(sinksToFlush, sink)
+	}
+	resourceLoggerLock.Unlock()
 
 	wg := &sync.WaitGroup{}
-	wg.Add(len(resourceSinks))
+	wg.Add(len(sinksToFlush))
 
-	for _, sink := range resourceSinks {
+	for _, sink := range sinksToFlush {
 		go func(rfs *resourceFileSink) {
 			defer wg.Done()
 			rfs.flush()

--- a/pkg/logger/resource_sink_test.go
+++ b/pkg/logger/resource_sink_test.go
@@ -37,6 +37,7 @@ func TestResourceSink(t *testing.T) {
 	log.Info("This is a test log entry", "Key1", "Value1")
 
 	logger.Flush()
+	defer ReleaseResourceLog(resourceId)
 
 	// Ensure that the resource log file exists
 	fileExistsErr := resiliency.RetryExponentialWithTimeout(t.Context(), 10*time.Second, func() error {
@@ -89,6 +90,7 @@ func TestResourceSinkNoResourceId(t *testing.T) {
 	log.Info("This log entry has no resource id", "Key3", "Value3")
 
 	logger.Flush()
+	defer ReleaseResourceLog(resourceId)
 
 	// Ensure that the resource log file exists
 	fileExistsErr := resiliency.RetryExponentialWithTimeout(t.Context(), 10*time.Second, func() error {
@@ -117,4 +119,40 @@ func TestResourceSinkNoResourceId(t *testing.T) {
 		require.Contains(c, string(contents), "info\tresource-sink-no-resource-id-log\tThis is a resource with an id\t{\"Key1\": \"Value1\", \"Key2\": \"Value2\"}")
 		require.Contains(c, string(contents), "error\tresource-sink-no-resource-id-log\tThis is an error record\t{\"Key1\": \"Value1\", \"error\": \"error of some sort\"}")
 	}, 10*time.Second, 200*time.Millisecond, "Expected to find a data and a log entry in resource log file")
+}
+
+func TestReleaseResourceLogsInFolder(t *testing.T) {
+	t.Parallel()
+
+	folderToRelease := t.TempDir()
+	folderToKeep := t.TempDir()
+	resourceIdSuffix, suffixErr := randdata.MakeRandomString(8)
+	require.NoError(t, suffixErr)
+	releasedResourceId := "resource-sink-release-folder-test-" + string(resourceIdSuffix)
+	keptResourceId := "resource-sink-keep-folder-test-" + string(resourceIdSuffix)
+	releasedResourceFilePath := makeResourceLogPath(releasedResourceId, folderToRelease)
+	keptResourceFilePath := makeResourceLogPath(keptResourceId, folderToKeep)
+
+	releasedLogger := New("resource-sink-release-folder-log").WithResourceSinkInto(folderToRelease)
+	keptLogger := New("resource-sink-keep-folder-log").WithResourceSinkInto(folderToKeep)
+	defer ReleaseResourceLog(keptResourceId)
+
+	releasedLogger.Logger.WithValues(RESOURCE_LOG_STREAM_ID, releasedResourceId).Info("release this resource log")
+	keptLog := keptLogger.Logger.WithValues(RESOURCE_LOG_STREAM_ID, keptResourceId)
+	keptLog.Info("keep this resource log")
+	releasedLogger.Flush()
+	keptLogger.Flush()
+
+	require.FileExists(t, releasedResourceFilePath)
+	require.FileExists(t, keptResourceFilePath)
+
+	ReleaseResourceLogsInFolder(folderToRelease)
+	require.NoError(t, os.RemoveAll(folderToRelease))
+
+	keptLog.Info("resource logging is still enabled")
+	keptLogger.Flush()
+	contents, readErr := os.ReadFile(keptResourceFilePath)
+	require.NoError(t, readErr)
+	require.Contains(t, string(contents), "keep this resource log")
+	require.Contains(t, string(contents), "resource logging is still enabled")
 }

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -144,4 +145,19 @@ func isRoot(path string) bool {
 // Should NOT be used for security-sensitive validation.
 func HasOnlyValidFilenameChars(name string) bool {
 	return validFilenameCharsRegex.MatchString(name)
+}
+
+func SameCleanPath(left string, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if leftAbs, leftErr := filepath.Abs(left); leftErr == nil {
+		left = leftAbs
+	}
+	if rightAbs, rightErr := filepath.Abs(right); rightErr == nil {
+		right = rightAbs
+	}
+	if IsWindows() {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -6,9 +6,11 @@
 package osutil
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHasOnlyValidFilenameChars(t *testing.T) {
@@ -63,4 +65,12 @@ func TestHasOnlyValidFilenameChars(t *testing.T) {
 			assert.Equal(t, tt.expected, result, "HasOnlyValidFilenameChars(%q)", tt.input)
 		})
 	}
+}
+
+func TestSameCleanPath(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	require.True(t, SameCleanPath(tempDir, filepath.Join(tempDir, ".")))
+	require.False(t, SameCleanPath(tempDir, filepath.Join(tempDir, "child")))
 }

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -3517,7 +3517,8 @@ func TestExecutableLogsRejectedWhenTerminalConfigured(t *testing.T) {
 	require.NoError(t, logsErr, "System logs should remain available for terminal-backed Executable '%s'", exeName)
 }
 
-// Verify that logs in follow mode end when Executable is deleted
+// Verify that logs in follow mode include output written after deletion is requested
+// and then end when Executable is deleted.
 func TestExecutableLogsFollowStreamEndsOnDelete(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
@@ -3555,6 +3556,8 @@ func TestExecutableLogsFollowStreamEndsOnDelete(t *testing.T) {
 			select {
 			case <-finishExecution.Wait():
 			case <-pe.Signal:
+				_, stdoutErr = pe.Cmd.Stdout.Write(osutil.WithNewline([]byte("Standard output log line after delete")))
+				require.NoError(t, stdoutErr, "Could not write delete-requested line to stdout of Executable '%s'", exeName)
 			}
 			return 0
 		},
@@ -3588,6 +3591,11 @@ func TestExecutableLogsFollowStreamEndsOnDelete(t *testing.T) {
 	t.Logf("Deleting Executable '%s'...", exeName)
 	err = client.Delete(ctx, &exe)
 	require.NoError(t, err, "Could not delete Executable '%s'", exeName)
+
+	t.Logf("Ensure log stream for Executable '%s' includes output written after deletion was requested...", exeName)
+	gotLine = scanner.Scan()
+	require.True(t, gotLine, "Could not read delete-requested line from log stream for Executable '%s', the reported error was %v", exeName, scanner.Err())
+	require.Equal(t, "Standard output log line after delete", scanner.Text(), "Delete-requested log line does not match expected content for Executable '%s'", exeName)
 
 	t.Logf("Ensure log stream for Executable '%s' has ended...", exeName)
 	gotLine = scanner.Scan()


### PR DESCRIPTION
Backports #156 to `release/0.25` so log stream files are released before resources are deleted. This keeps shutdown cleanup from holding stale log handles while resources are being removed.

## Summary
- Cherry-picks the merged PR #156 change onto `release/0.25`.
- Releases container and stdio log streams before deleting resources during cleanup.
- Adds regression coverage for log stream cleanup and updates related integration coverage.

## Validation
- `make test-prereqs`
- `go test -count 1 -parallel 32 -timeout 180s ./internal/dcp/bootstrap ./internal/logs/... ./pkg/io ./pkg/logger ./pkg/osutil ./test/integration`
- `make lint`