### PR TITLE
Add detached fork process command

### DIFF
--- a/internal/dcp/commands/root.go
+++ b/internal/dcp/commands/root.go
@@ -85,6 +85,12 @@ func NewRootCmd(log *logger.Logger) (*cobra.Command, error) {
 		rootCmd.AddCommand(cmd)
 	}
 
+	if cmd, err = dcpproc_cmds.NewForkProcessCommand(log.Logger); err != nil {
+		return nil, fmt.Errorf("could not set up 'fork-process' command: %w", err)
+	} else {
+		rootCmd.AddCommand(cmd)
+	}
+
 	// Add dcptun sub-commands
 	rootCmd.AddCommand(dcptun_cmds.NewRunServerCommand(log.Logger))
 

--- a/internal/dcpproc/commands/fork_process.go
+++ b/internal/dcpproc/commands/fork_process.go
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"github.com/microsoft/dcp/pkg/logger"
+	"github.com/microsoft/dcp/pkg/process"
+)
+
+func NewForkProcessCommand(log logr.Logger) (*cobra.Command, error) {
+	forkProcessCmd := &cobra.Command{
+		Use:                "fork-process command [args...]",
+		Short:              "Starts a detached child process and prints its PID.",
+		Long:               "Starts a child process outside of the parent process tree or process group and writes the child PID to stdout.",
+		RunE:               forkProcess(log),
+		SilenceUsage:       true,
+		Args:               validateForkProcessArgs,
+		DisableFlagParsing: true,
+	}
+
+	return forkProcessCmd, nil
+}
+
+func validateForkProcessArgs(_ *cobra.Command, args []string) error {
+	if len(trimForkProcessArgSeparator(args)) == 0 {
+		return fmt.Errorf("command is required")
+	}
+
+	return nil
+}
+
+func forkProcess(log logr.Logger) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		args = trimForkProcessArgSeparator(args)
+
+		childCmd := exec.Command(args[0], args[1:]...)
+		childCmd.Env = os.Environ()
+		logger.WithSessionId(childCmd)
+		process.ForkFromParent(childCmd)
+
+		if startErr := childCmd.Start(); startErr != nil {
+			log.Error(startErr, "Failed to start forked process", "Command", args[0], "Args", args[1:])
+			return fmt.Errorf("could not start forked process: %w", startErr)
+		}
+
+		pid := childCmd.Process.Pid
+		if releaseErr := childCmd.Process.Release(); releaseErr != nil {
+			log.Error(releaseErr, "Failed to release forked process", "PID", pid)
+			return fmt.Errorf("could not release forked process %d: %w", pid, releaseErr)
+		}
+
+		if _, writeErr := fmt.Fprintln(cmd.OutOrStdout(), pid); writeErr != nil {
+			log.Error(writeErr, "Failed to write forked process PID", "PID", pid)
+			return fmt.Errorf("could not write forked process pid: %w", writeErr)
+		}
+
+		return nil
+	}
+}
+
+func trimForkProcessArgSeparator(args []string) []string {
+	if len(args) > 0 && args[0] == "--" {
+		return args[1:]
+	}
+
+	return args
+}

--- a/internal/dcpproc/commands/root.go
+++ b/internal/dcpproc/commands/root.go
@@ -64,6 +64,12 @@ func NewRootCmd(log *logger.Logger) (*cobra.Command, error) {
 		rootCmd.AddCommand(cmd)
 	}
 
+	if cmd, err = NewForkProcessCommand(log.Logger); err != nil {
+		return nil, fmt.Errorf("could not set up 'fork-process' command: %w", err)
+	} else {
+		rootCmd.AddCommand(cmd)
+	}
+
 	return rootCmd, nil
 }
 

--- a/internal/dcpproc/fork_process_test.go
+++ b/internal/dcpproc/fork_process_test.go
@@ -32,10 +32,10 @@ func TestForkProcessStartsDetachedCommand(t *testing.T) {
 	require.False(t, forkedProcess.IdentityTime.IsZero(), "forked process start time should not be zero")
 	checkExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
 	defer checkExecutor.Dispose()
-	require.NoError(t, checkExecutor.CheckProcessRunning(forkedProcess.Pid, forkedProcess.IdentityTime))
+	require.NoError(t, checkExecutor.CheckProcessRunning(forkedProcess))
 }
 
-func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessTreeItem {
+func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessHandle {
 	t.Helper()
 
 	dcpProc, dcpProcErr := getDcpProcExecutablePath()
@@ -60,12 +60,12 @@ func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessTree
 	var identityTime time.Time
 	cleanupExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
 	t.Cleanup(func() {
-		_ = cleanupExecutor.StopProcess(pid, identityTime)
+		_ = cleanupExecutor.StopProcess(process.NewHandle(pid, identityTime))
 		cleanupExecutor.Dispose()
 	})
 
 	identityTime = process.ProcessIdentityTime(pid)
 	require.False(t, identityTime.IsZero(), "forked process %d should still be running", pid)
 
-	return process.ProcessTreeItem{Pid: pid, IdentityTime: identityTime}
+	return process.NewHandle(pid, identityTime)
 }

--- a/internal/dcpproc/fork_process_test.go
+++ b/internal/dcpproc/fork_process_test.go
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package dcpproc_test
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	int_testutil "github.com/microsoft/dcp/internal/testutil"
+	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/testutil"
+)
+
+func TestForkProcessStartsDetachedCommand(t *testing.T) {
+	t.Parallel()
+
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	forkedProcess := startForkedDelay(t, testCtx)
+
+	require.False(t, forkedProcess.IdentityTime.IsZero(), "forked process start time should not be zero")
+	checkExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
+	defer checkExecutor.Dispose()
+	require.NoError(t, checkExecutor.CheckProcessRunning(forkedProcess.Pid, forkedProcess.IdentityTime))
+}
+
+func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessTreeItem {
+	t.Helper()
+
+	dcpProc, dcpProcErr := getDcpProcExecutablePath()
+	require.NoError(t, dcpProcErr)
+
+	delayToolPath, toolPathErr := int_testutil.GetTestToolPath("delay")
+	require.NoError(t, toolPathErr)
+
+	dcpProcCmd := exec.CommandContext(testCtx, dcpProc, "fork-process", delayToolPath, "--delay=30s")
+	var stdout, stderr bytes.Buffer
+	dcpProcCmd.Stdout = &stdout
+	dcpProcCmd.Stderr = &stderr
+
+	runErr := dcpProcCmd.Run()
+	require.NoError(t, runErr, "dcp fork-process should exit cleanly; stderr: %s", stderr.String())
+
+	stdoutText := strings.TrimSpace(stdout.String())
+	childPid, parseErr := strconv.ParseInt(stdoutText, 10, 64)
+	require.NoError(t, parseErr, "dcp fork-process should print only a child PID, got %q", stdoutText)
+
+	pid := process.Pid_t(childPid)
+	var identityTime time.Time
+	cleanupExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
+	t.Cleanup(func() {
+		_ = cleanupExecutor.StopProcess(pid, identityTime)
+		cleanupExecutor.Dispose()
+	})
+
+	identityTime = process.ProcessIdentityTime(pid)
+	require.False(t, identityTime.IsZero(), "forked process %d should still be running", pid)
+
+	return process.ProcessTreeItem{Pid: pid, IdentityTime: identityTime}
+}

--- a/internal/dcpproc/fork_process_unix_test.go
+++ b/internal/dcpproc/fork_process_unix_test.go
@@ -9,11 +9,11 @@ package dcpproc_test
 
 import (
 	"context"
-	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	"github.com/microsoft/dcp/pkg/process"
 )
@@ -29,16 +29,16 @@ func TestForkProcessStartsOutsideParentSession(t *testing.T) {
 	childPid, childPidErr := process.PidT_ToInt(forkedProcess.Pid)
 	require.NoError(t, childPidErr)
 
-	childProcessGroup, childProcessGroupErr := syscall.Getpgid(childPid)
+	childProcessGroup, childProcessGroupErr := unix.Getpgid(childPid)
 	require.NoError(t, childProcessGroupErr)
 
-	currentProcessGroup, currentProcessGroupErr := syscall.Getpgid(0)
+	currentProcessGroup, currentProcessGroupErr := unix.Getpgid(0)
 	require.NoError(t, currentProcessGroupErr)
 
-	childSession, childSessionErr := syscall.Getsid(childPid)
+	childSession, childSessionErr := unix.Getsid(childPid)
 	require.NoError(t, childSessionErr)
 
-	currentSession, currentSessionErr := syscall.Getsid(0)
+	currentSession, currentSessionErr := unix.Getsid(0)
 	require.NoError(t, currentSessionErr)
 
 	require.Equal(t, childPid, childProcessGroup, "forked process should lead its own process group")

--- a/internal/dcpproc/fork_process_unix_test.go
+++ b/internal/dcpproc/fork_process_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package dcpproc_test
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/microsoft/dcp/pkg/process"
+)
+
+func TestForkProcessStartsOutsideParentSession(t *testing.T) {
+	t.Parallel()
+
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	forkedProcess := startForkedDelay(t, testCtx)
+
+	childPid, childPidErr := process.PidT_ToInt(forkedProcess.Pid)
+	require.NoError(t, childPidErr)
+
+	childProcessGroup, childProcessGroupErr := syscall.Getpgid(childPid)
+	require.NoError(t, childProcessGroupErr)
+
+	currentProcessGroup, currentProcessGroupErr := syscall.Getpgid(0)
+	require.NoError(t, currentProcessGroupErr)
+
+	childSession, childSessionErr := syscall.Getsid(childPid)
+	require.NoError(t, childSessionErr)
+
+	currentSession, currentSessionErr := syscall.Getsid(0)
+	require.NoError(t, currentSessionErr)
+
+	require.Equal(t, childPid, childProcessGroup, "forked process should lead its own process group")
+	require.NotEqual(t, currentProcessGroup, childProcessGroup, "forked process should be outside the parent's process group")
+	require.Equal(t, childPid, childSession, "forked process should lead its own session")
+	require.NotEqual(t, currentSession, childSession, "forked process should be outside the parent's session")
+}

--- a/pkg/process/process_util_unix.go
+++ b/pkg/process/process_util_unix.go
@@ -23,15 +23,13 @@ func DecoupleFromParent(cmd *exec.Cmd) {
 	cmd.SysProcAttr = sysProcAttr
 }
 
-// Use separate process group so this process exit will not affect the children.
-// This is the same as DecoupleFromParent on Unix systems.
+// Use a separate session so this process exit and terminal signals will not affect the children.
 func ForkFromParent(cmd *exec.Cmd) {
 	sysProcAttr := cmd.SysProcAttr
 	if sysProcAttr == nil {
 		sysProcAttr = &syscall.SysProcAttr{}
 	}
-	sysProcAttr.Setpgid = true
-	sysProcAttr.Pgid = 0
+	sysProcAttr.Setsid = true
 
 	cmd.SysProcAttr = sysProcAttr
 }


### PR DESCRIPTION
Aspire needs a simple way to start helper processes outside the parent process tree or Unix process group without adding native interop to the .NET CLI. This adds a DCP-provided `fork-process` command that treats its positional arguments as the command to launch, prints the child PID to stdout, and exits after releasing the child.

The command reuses DCP's platform-specific `ForkFromParent` behavior and is exposed through both `dcp` and `dcpproc`. On Unix, `ForkFromParent` now uses `setsid` so forked children get a separate session as well as a separate process group; `DecoupleFromParent` keeps the existing `setpgid` behavior for less-detached process starts.

Validation:
- `make test`
- `make lint`