### PR TITLE
Create containers with initial network attachments

### DIFF
--- a/controllers/container_common.go
+++ b/controllers/container_common.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	std_slices "slices"
 	"strconv"
 	"strings"
 	"time"
@@ -283,26 +282,6 @@ func startContainer(
 
 	inspected, err := callWithRetryAndVerification(startCtx, defaultContainerOrchestratorBackoff(), action, verify)
 	return inspected, err
-}
-
-func disconnectNetwork(ctx context.Context, o containers.ContainerOrchestrator, opts containers.DisconnectNetworkOptions) error {
-	action := func(ctx context.Context) error {
-		return o.DisconnectNetwork(ctx, opts)
-	}
-
-	verify := func(ctx context.Context) (*containers.InspectedNetwork, error) {
-		return verifyNetworkState(ctx, o, opts.Network, func(i *containers.InspectedNetwork) error {
-			if !std_slices.ContainsFunc(i.Containers, func(c containers.InspectedNetworkContainer) bool {
-				return c.Name == opts.Container || strings.HasPrefix(c.Id, opts.Container)
-			}) {
-				return nil
-			}
-			return fmt.Errorf("container %s is still connected to network %s", opts.Container, opts.Network)
-		})
-	}
-
-	_, err := callWithRetryAndVerification(ctx, defaultContainerOrchestratorBackoff(), action, verify)
-	return err
 }
 
 func inspectNetwork(ctx context.Context, o containers.NetworkOrchestrator, network string) (*containers.InspectedNetwork, error) {

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -1275,6 +1275,14 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 
 			log.V(1).Info("Starting container", "Image", container.SpecifiedImageNameOrDefault())
 
+			createNetworks, networksReady, networkErr := r.getInitialCreateContainerNetworks(startupCtx, container, rcd.runSpec, log)
+			if networkErr != nil {
+				return networkErr
+			}
+			if !networksReady {
+				return errInitialContainerNetworksNotReady
+			}
+
 			// Add labels to the container for lifecycle management and other metadata
 			lifecycleKey, hashErr := r.addContainerCreationLabels(container, rcd, log)
 			if hashErr != nil {
@@ -1298,13 +1306,6 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 				// The derived image only exists locally; prevent docker create from
 				// attempting to pull it from a registry.
 				runSpecForCreation.PullPolicy = apiv1.PullPolicyNever
-			}
-			createNetworks, networksReady, networkErr := r.getInitialCreateContainerNetworks(startupCtx, container, &runSpecForCreation, log)
-			if networkErr != nil {
-				return networkErr
-			}
-			if !networksReady {
-				return errInitialContainerNetworksNotReady
 			}
 
 			// Create the container using the active orchestrator.

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -612,30 +612,6 @@ func ensureContainerStartingState(
 		r.scheduleContainerCreation(ctx, container, rcd, log, startupRetryDelay)
 		change |= statusChanged
 
-	case container.Spec.Networks != nil && rcd.hasValidContainerID():
-		// The second portion of startup sequence of a container with custom networks.
-		// Need to create ContainerNetworkConnection objects and start the container resource.
-
-		inspected, err := r.handleInitialNetworkConnections(ctx, container, rcd, log)
-
-		switch {
-		case err != nil:
-			rcd.startupError = err
-			rcd.containerState = apiv1.ContainerStateFailedToStart
-			rcd.startAttemptFinishedAt = metav1.NowMicro()
-			change |= statusChanged
-		case inspected != nil && inspected.Status == containers.ContainerStatusRunning:
-			rcd.containerState = apiv1.ContainerStateRunning
-			rcd.startAttemptFinishedAt = metav1.NowMicro()
-			change |= statusChanged
-		case inspected != nil && inspected.Status == containers.ContainerStatusExited:
-			rcd.containerState = apiv1.ContainerStateExited
-			rcd.startAttemptFinishedAt = metav1.NowMicro()
-			change |= statusChanged
-		default:
-			// We are waiting for the network connections to be established.
-			change |= additionalReconciliationNeeded
-		}
 	}
 
 	// The attempt to start the container is generally asynchronous, but it may fail or succeed immediately.
@@ -2063,51 +2039,6 @@ func (r *ContainerReconciler) enableEndpointsAndHealthProbes(
 }
 
 // NETWORKING SUPPORT METHODS
-
-// Creates initial set of ContainerNetworkConnection objects for this Container,
-// and if all connections are satisfied, starts the container.
-// Returns the inspected container data (if the container has been started successfully), and an error, if any.
-// The error should be treated as permanent startup failure.
-// If a startup error is returned, the inspected container data might be missing.
-// This method is executed as part of the reconciliation loop.
-func (r *ContainerReconciler) handleInitialNetworkConnections(
-	ctx context.Context,
-	container *apiv1.Container,
-	rcd *runningContainerData,
-	log logr.Logger,
-) (*containers.InspectedContainer, error) {
-	connected, connectionErr := r.ensureContainerNetworkConnections(ctx, container, nil, rcd, log)
-	if connectionErr != nil {
-		return nil, connectionErr
-	}
-
-	// Check to see if we are connected to all the ContainerNetworks listed in the Container object spec
-	if len(connected) != len(*container.Spec.Networks) && !container.Spec.Stop && container.DeletionTimestamp.IsZero() {
-		log.V(1).Info("Container not connected to expected number of networks, scheduling additional reconciliation...", "Expected", len(*container.Spec.Networks), "Connected", len(connected))
-		return nil, nil
-	}
-
-	cID := rcd.containerID
-	startupStdoutWriter, startupStderrWriter := rcd.getStartupLogWriters()
-	streamOptions := getStartupCommandOptions(startupStdoutWriter, startupStderrWriter)
-
-	inspected, startupErr := r.startContainerWithTimeout(ctx, container.Name, cID, streamOptions)
-	startupTaskFinished(startupStdoutWriter, startupStderrWriter)
-	if startupErr != nil {
-		log.Error(startupErr, "Failed to start Container")
-		return nil, startupErr
-	}
-	if inspected != nil && inspected.Status == containers.ContainerStatusRunning {
-		if attachErr := r.attachTerminalIfNeeded(container, rcd, log); attachErr != nil {
-			return nil, attachErr
-		}
-	}
-	if inspected != nil {
-		rcd.updateFromInspectedContainer(inspected)
-	}
-
-	return inspected, nil
-}
 
 func (r *ContainerReconciler) runContainerLifecycleMonitor(rcd *runningContainerData, log logr.Logger) {
 	if rcd == nil || rcd.runSpec == nil || !rcd.hasValidContainerID() {

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -2354,9 +2354,9 @@ func (r *ContainerReconciler) ensureContainerNetworkConnections(
 		}
 
 		var containerNetwork *apiv1.ContainerNetwork
-		for i := range networks.Items {
-			if networks.Items[i].NamespacedName() == namespacedNetworkName {
-				containerNetwork = &networks.Items[i]
+		for networkIndex := range networks.Items {
+			if networks.Items[networkIndex].NamespacedName() == namespacedNetworkName {
+				containerNetwork = &networks.Items[networkIndex]
 				break
 			}
 		}

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -77,6 +77,8 @@ var (
 	containerFinalizer string = fmt.Sprintf("%s/container-reconciler", apiv1.GroupVersion.Group)
 	containerKind             = apiv1.GroupVersion.WithKind(reflect.TypeOf(apiv1.Container{}).Name())
 
+	errInitialContainerNetworksNotReady = errors.New("initial container networks are not ready")
+
 	containerStateInitializers = map[apiv1.ContainerState]containerStateInitializerFunc{
 		apiv1.ContainerStateEmpty:            handleNewContainer,
 		apiv1.ContainerStatePending:          handleNewContainer,
@@ -600,7 +602,7 @@ func ensureContainerStartingState(
 		r.scheduleContainerCreation(ctx, container, rcd, log, startupWithNoDelay)
 		change |= statusChanged
 
-	case templating.IsTransientTemplateError(rcd.startupError), errors.Is(rcd.startupError, statestore.ErrResourceLeaseHeld):
+	case templating.IsTransientTemplateError(rcd.startupError), errors.Is(rcd.startupError, statestore.ErrResourceLeaseHeld), errors.Is(rcd.startupError, errInitialContainerNetworksNotReady):
 		// Retry startup after a transient error or while another DCP instance is creating the persistent container.
 
 		rcd.startupError = nil
@@ -974,6 +976,50 @@ func (r *ContainerReconciler) scheduleContainerCreation(
 	}
 }
 
+func (r *ContainerReconciler) getInitialCreateContainerNetworks(
+	ctx context.Context,
+	container *apiv1.Container,
+	runSpec *apiv1.ContainerSpec,
+	log logr.Logger,
+) ([]containers.CreateContainerNetworkOptions, bool, error) {
+	if runSpec.Networks == nil {
+		return nil, true, nil
+	}
+
+	createNetworks := make([]containers.CreateContainerNetworkOptions, 0, len(*runSpec.Networks))
+	for _, networkConfig := range *runSpec.Networks {
+		namespacedNetworkName := commonapi.AsNamespacedName(networkConfig.Name, container.Namespace)
+
+		var network apiv1.ContainerNetwork
+		getErr := r.Get(ctx, namespacedNetworkName, &network)
+		if apierrors.IsNotFound(getErr) {
+			log.V(1).Info("Initial Container network is not available yet", "Network", namespacedNetworkName.String())
+			return nil, false, nil
+		}
+		if getErr != nil {
+			log.Error(getErr, "Failed to get initial Container network", "Network", namespacedNetworkName.String())
+			return nil, false, getErr
+		}
+
+		if network.Status.State != apiv1.ContainerNetworkStateRunning || network.Status.ID == "" || network.Status.NetworkName == "" {
+			log.V(1).Info("Initial Container network is not ready yet",
+				"Network", namespacedNetworkName.String(),
+				"NetworkState", network.Status.State,
+			)
+			return nil, false, nil
+		}
+
+		aliases := make([]string, len(networkConfig.Aliases))
+		copy(aliases, networkConfig.Aliases)
+		createNetworks = append(createNetworks, containers.CreateContainerNetworkOptions{
+			Name:    network.Status.NetworkName,
+			Aliases: aliases,
+		})
+	}
+
+	return createNetworks, true, nil
+}
+
 // Returns a function that builds the Container image.
 // The method is called as part of the reconciliation loop, but the returned function is executed asynchronously.
 // The passed runningContainerData should be a clone independent from what is stored in the runningContainers map.
@@ -1229,13 +1275,6 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 
 			log.V(1).Info("Starting container", "Image", container.SpecifiedImageNameOrDefault())
 
-			// Determine the default bridge network name used by the active orchestrator
-			defaultNetwork := ""
-			if rcd.runSpec.Networks != nil {
-				// See comment below why we create the container with default network explicitly enabled here.
-				defaultNetwork = r.orchestrator.DefaultNetworkName()
-			}
-
 			// Add labels to the container for lifecycle management and other metadata
 			lifecycleKey, hashErr := r.addContainerCreationLabels(container, rcd, log)
 			if hashErr != nil {
@@ -1260,13 +1299,20 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 				// attempting to pull it from a registry.
 				runSpecForCreation.PullPolicy = apiv1.PullPolicyNever
 			}
+			createNetworks, networksReady, networkErr := r.getInitialCreateContainerNetworks(startupCtx, container, &runSpecForCreation, log)
+			if networkErr != nil {
+				return networkErr
+			}
+			if !networksReady {
+				return errInitialContainerNetworksNotReady
+			}
 
 			// Create the container using the active orchestrator.
 			// Persistent container reuse happens only in handleNewContainer before startup is scheduled.
 			creationOptions := containers.CreateContainerOptions{
 				ContainerSpec:        runSpecForCreation,
 				Name:                 containerName,
-				Network:              defaultNetwork,
+				Networks:             createNetworks,
 				StreamCommandOptions: streamOptions,
 			}
 			inspected, createErr := createContainer(startupCtx, r.orchestrator, creationOptions)
@@ -1300,7 +1346,7 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 			}
 
 			// Finish the container startup process, including any finalization steps
-			finishErr := r.finishCreatedContainerStartup(startupCtx, container, containerName, rcd, inspected, streamOptions, startupStdoutWriter, startupStderrWriter, log)
+			finishErr := r.finishCreatedContainerStartup(startupCtx, container, containerName, rcd, streamOptions, startupStdoutWriter, startupStderrWriter, log)
 			if finishErr != nil {
 				return finishErr
 			}
@@ -1311,7 +1357,7 @@ func (r *ContainerReconciler) startContainerWithOrchestrator(container *apiv1.Co
 			return nil
 		}()
 
-		retryableErr := templating.IsTransientTemplateError(err) || errors.Is(err, statestore.ErrResourceLeaseHeld)
+		retryableErr := templating.IsTransientTemplateError(err) || errors.Is(err, statestore.ErrResourceLeaseHeld) || errors.Is(err, errInitialContainerNetworksNotReady)
 		if !retryableErr && !errors.Is(err, statestore.ErrResourceLeaseNotHeld) {
 			releaseErr := r.releasePersistentContainerResourceLease(context.WithoutCancel(startupCtx), container, log, false)
 			err = errors.Join(err, releaseErr)
@@ -1768,55 +1814,34 @@ func (r *ContainerReconciler) copyContainerPemCertificates(
 	return nil
 }
 
-// finishCreatedContainerStartup either starts the container immediately or prepares it for custom network attachment.
+// finishCreatedContainerStartup starts the container after creation.
 func (r *ContainerReconciler) finishCreatedContainerStartup(
 	ctx context.Context,
 	container *apiv1.Container,
 	containerName string,
 	rcd *runningContainerData,
-	inspected *containers.InspectedContainer,
 	streamOptions containers.StreamCommandOptions,
 	startupStdoutWriter usvc_io.ParagraphWriter,
 	startupStderrWriter usvc_io.ParagraphWriter,
 	log logr.Logger,
 ) error {
-	if rcd.runSpec.Networks == nil {
-		startedContainer, startErr := r.startContainerWithTimeout(ctx, containerName, rcd.containerID, streamOptions)
-		rcd.startAttemptFinishedAt = metav1.NowMicro()
-		startupTaskFinished(startupStdoutWriter, startupStderrWriter)
-		if startErr != nil {
-			log.Error(startErr, "Could not start the container")
-			return startErr
-		}
-
-		if startedContainer.Status == containers.ContainerStatusRunning {
-			log.V(1).Info("Container started")
-			if attachErr := r.attachTerminalIfNeeded(container, rcd, log); attachErr != nil {
-				return attachErr
-			}
-			rcd.containerState = apiv1.ContainerStateRunning
-		} else {
-			log.V(1).Info("Container started and exited shortly after", "ContainerStatus", startedContainer.Status)
-			rcd.containerState = apiv1.ContainerStateExited
-		}
-		return nil
+	startedContainer, startErr := r.startContainerWithTimeout(ctx, containerName, rcd.containerID, streamOptions)
+	rcd.startAttemptFinishedAt = metav1.NowMicro()
+	startupTaskFinished(startupStdoutWriter, startupStderrWriter)
+	if startErr != nil {
+		log.Error(startErr, "Could not start the container")
+		return startErr
 	}
 
-	// If a container resource is created without a network, it cannot be connected to a network later (orchestrator limitation).
-	// So for Containers that request attaching to custom networks via Spec, we create the corresponding container resource
-	// attached to default network(s) (usually one: "bridge" for Docker or "podman" for Podman).
-	// Here we detach it from the default network(s). Then we leave the Container object in "starting" state,
-	// and save the changes.
-	//
-	// During next reconciliation loop we create ContainerNetworkConnection objects and start the container resource.
-	// The Network controller takes care of connecting the container resource to requested networks.
-	for i := range inspected.Networks {
-		networkID := inspected.Networks[i].Id
-		disconnectErr := disconnectNetwork(ctx, r.orchestrator, containers.DisconnectNetworkOptions{Network: networkID, Container: string(rcd.containerID), Force: true})
-		if disconnectErr != nil {
-			log.Error(disconnectErr, "Could not detach network from the container", "NetworkID", networkID)
-			return disconnectErr
+	if startedContainer.Status == containers.ContainerStatusRunning {
+		log.V(1).Info("Container started")
+		if attachErr := r.attachTerminalIfNeeded(container, rcd, log); attachErr != nil {
+			return attachErr
 		}
+		rcd.containerState = apiv1.ContainerStateRunning
+	} else {
+		log.V(1).Info("Container started and exited shortly after", "ContainerStatus", startedContainer.Status)
+		rcd.containerState = apiv1.ContainerStateExited
 	}
 
 	return nil
@@ -2328,6 +2353,14 @@ func (r *ContainerReconciler) ensureContainerNetworkConnections(
 			continue
 		}
 
+		var containerNetwork *apiv1.ContainerNetwork
+		for i := range networks.Items {
+			if networks.Items[i].NamespacedName() == namespacedNetworkName {
+				containerNetwork = &networks.Items[i]
+				break
+			}
+		}
+
 		uniqueName, _, err := MakeUniqueName(fmt.Sprint(container.Name, "-", namespacedNetworkName.Name))
 		if err != nil {
 			log.Error(err, "Could not generate unique name for ContainerNetworkConnection object")
@@ -2363,10 +2396,26 @@ func (r *ContainerReconciler) ensureContainerNetworkConnections(
 		} else {
 			log.Info("Added new ContainerNetworkConnection", "Network", namespacedNetworkName.String())
 			rcd.networkConnections[networkConnectionKey] = true
+			if inspected != nil && containerNetwork != nil && inspectedContainerConnectedToNetwork(inspected, containerNetwork) &&
+				!slices.Any(validConnectedNetworks, func(validNetwork *apiv1.ContainerNetwork) bool {
+					return validNetwork.NamespacedName() == containerNetwork.NamespacedName()
+				}) {
+				validConnectedNetworks = append(validConnectedNetworks, containerNetwork)
+			}
 		}
 	}
 
 	return validConnectedNetworks, nil
+}
+
+func inspectedContainerConnectedToNetwork(inspected *containers.InspectedContainer, network *apiv1.ContainerNetwork) bool {
+	if inspected == nil || network == nil || network.Status.NetworkName == "" {
+		return false
+	}
+
+	return slices.Any(inspected.Networks, func(existingNetworkConnection containers.InspectedContainerNetwork) bool {
+		return existingNetworkConnection.Name == network.Status.NetworkName
+	})
 }
 
 func (r *ContainerReconciler) createEndpoints(

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -1054,8 +1054,10 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 				{ContainerPort: dcptun.DefaultContainerProxyDataPort},
 			},
 		},
-		Name:    clientProxyCtrName,
-		Network: r.config.Orchestrator.DefaultNetworkName(),
+		Name: clientProxyCtrName,
+		Networks: []containers.CreateContainerNetworkOptions{
+			{Name: r.config.Orchestrator.DefaultNetworkName()},
+		},
 	}
 
 	thisProcess, thisProcessErr := process.This()

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -1027,15 +1027,6 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 		return false, StandardDelay
 	}
 
-	// We cannot really connect the client proxy container to the target network immediately because
-	// it is managed by the ContainerNetwork controller and that controller may remove it from the network
-	// if it does not see the corresponding ContainerNetworkConnection object.
-	// And we cannot create the ContainerNetworkConnection without having a container ID (sort of a chicken-vs-egg problem).
-	// So we do the same trick as the Container controller does: create the client proxy container
-	// with a default network connection, disconnect the default network, then create a ContainerNetworkConnection object.
-	// that binds the container to the target network.
-	// The network controller will then connect the client proxy container to target ContainerNetwork.
-
 	log.V(1).Info("Starting client proxy container...")
 
 	createOpts := containers.CreateContainerOptions{
@@ -1056,7 +1047,10 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 		},
 		Name: clientProxyCtrName,
 		Networks: []containers.CreateContainerNetworkOptions{
-			{Name: r.config.Orchestrator.DefaultNetworkName()},
+			{
+				Name:    containerNetwork.Status.NetworkName,
+				Aliases: tunnelProxy.Spec.Aliases,
+			},
 		},
 	}
 
@@ -1096,16 +1090,6 @@ func (r *ContainerNetworkTunnelProxyReconciler) startClientProxy(
 	}()
 
 	r.ContainerWatcher.EnsureContainerWatchForResource(tunnelProxy.UID, log)
-
-	disconnectErr := disconnectNetwork(ctx, r.config.Orchestrator, containers.DisconnectNetworkOptions{
-		Network: r.config.Orchestrator.DefaultNetworkName(), Container: created.Id, Force: true,
-	})
-	if disconnectErr != nil {
-		log.Error(disconnectErr, "Failed to disconnect client proxy container from default network")
-		pd.State = apiv1.ContainerNetworkTunnelProxyStateFailed
-		pd.Message = fmt.Sprintf("Failed to disconnect client proxy container from default network: %v", disconnectErr)
-		return false, NoDelay
-	}
 
 	cncName, _, nameErr := MakeUniqueName(fmt.Sprintf("%s", tunnelProxy.Name))
 	if nameErr != nil {

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -555,16 +555,9 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 	// Initialize the connected network containers map if needed
 	if networkState.connections == nil {
 		networkState.connections = make(map[string]*connectionState)
-
-		if !shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
-			// Session networks are fully managed by this resource, so assume these were all connected by us.
-			for _, containerID := range network.Status.ContainerIDs {
-				networkState.connections[containerID] = &connectionState{}
-			}
-		}
 	}
 
-	// Disconnect unexpected containers from the network
+	// Disconnect containers only if this reconciler previously managed their connection.
 	for i := range network.Status.ContainerIDs {
 		containerID := network.Status.ContainerIDs[i]
 
@@ -578,13 +571,8 @@ func (r *NetworkReconciler) ensureConnections(ctx context.Context, network *apiv
 		}
 
 		_, knownConnection := networkState.connections[containerID]
-		if !knownConnection && shouldKeepUnmanagedConnections(network.Spec.EffectiveMode()) {
-			// Reused networks may have unmanaged connections, so only disconnect containers explicitly connected by us.
-			continue
-		}
-
 		if !knownConnection {
-			networkState.connections[containerID] = &connectionState{}
+			continue
 		}
 
 		err := r.orchestrator.DisconnectNetwork(ctx, containers.DisconnectNetworkOptions{
@@ -788,10 +776,6 @@ func shouldDeleteNetwork(mode apiv1.ContainerNetworkMode) bool {
 	default:
 		return false
 	}
-}
-
-func shouldKeepUnmanagedConnections(mode apiv1.ContainerNetworkMode) bool {
-	return mode != apiv1.ContainerNetworkModeSession
 }
 
 func (r *NetworkReconciler) releasePersistentNetworkResourceLease(

--- a/internal/containers/container_orchestrator.go
+++ b/internal/containers/container_orchestrator.go
@@ -286,19 +286,9 @@ type CreateContainerOptions struct {
 	//       and not rely on ContainerSpec.ContainerName.
 	Name string
 
-	// Name or ID of a network to connect to _at creation time_.
-	// If not set, the container will be connected to default network.
-	//
-	// Note: ContainerSpec.Networks specifies which networks the container will be connected to eventually,
-	//       but that property should not be used at creation time.
-	Network string
-
-	// Network aliases to use for the container _at creation time_.
-	// This is only valid if Network is also specified.
-	//
-	// Note: ContainerSpec.Networks can include network alias information, but that applies to networks
-	//	     that the container will be connected to eventually, and not at creation time.
-	NetworkAliases []string
+	// Networks to connect to _at creation time_, with optional per-network aliases.
+	// If not set, the container will be connected to the default network.
+	Networks []CreateContainerNetworkOptions
 
 	// Healthcheck configuration for the container
 	// This is currently only used for testing purposes
@@ -308,6 +298,14 @@ type CreateContainerOptions struct {
 	TimeoutOption
 
 	apiv1.ContainerSpec
+}
+
+type CreateContainerNetworkOptions struct {
+	// Name or ID of a network to connect to _at creation time_.
+	Name string
+
+	// Network aliases to use for the container on this network _at creation time_.
+	Aliases []string
 }
 
 type ContainerHealthcheck struct {

--- a/internal/docker/cli_orchestrator.go
+++ b/internal/docker/cli_orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -45,6 +46,7 @@ var (
 	endpointAlreadyExistsRegEx = regexp.MustCompile(`(?i)endpoint with (.*) already exists in network`)
 	networkSubnetPoolFullRegEx = regexp.MustCompile(`(?i)could not find an available, non-overlapping (.*) address pool`)
 	dockerNotRunningRegEx      = regexp.MustCompile(`(?i)error during connect:`)
+	dockerVersionRegEx         = regexp.MustCompile(`(?i)^Docker version\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:[^\s,]*)`)
 	volumeInUseRegEx           = regexp.MustCompile(`(?i)volume is in use`)
 	imageNotFoundRegEx         = regexp.MustCompile(`(?i)(not found|no such image)`)
 
@@ -62,6 +64,9 @@ var (
 	// Telemetry shows there is a very long tail for Docker command completion times, so we use a conservative default.
 	ordinaryDockerCommandTimeout = 30 * time.Second
 
+	// Checking the Docker CLI version should never need to contact the Docker daemon.
+	dockerVersionCommandTimeout = 2 * time.Second
+
 	// We allow up to a minute for diagnostic commands to finish as we'd rather wait a bit longer than miss information.
 	diagnosticDockerCommandTimeout = 1 * time.Minute
 
@@ -77,7 +82,37 @@ var (
 	// Mutex to control read/write access to the cached status
 	updateStatus            = &sync.RWMutex{}
 	backgroundStatusUpdates atomic.Int32
+
+	errInvalidDockerVersionOutput = fmt.Errorf("invalid Docker CLI version output")
+
+	minimumSupportedDockerCliVersion = dockerCliVersion{
+		major: 25,
+		minor: 0,
+		patch: 0,
+	}
 )
+
+type dockerCliVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func (v dockerCliVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+func (v dockerCliVersion) isBefore(other dockerCliVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+
+	return v.patch < other.patch
+}
 
 type DockerCliOrchestrator struct {
 	log logr.Logger
@@ -193,6 +228,37 @@ func (dco *DockerCliOrchestrator) EnsureBackgroundStatusUpdates(ctx context.Cont
 }
 
 func (dco *DockerCliOrchestrator) getStatus(ctx context.Context) containers.ContainerRuntimeStatus {
+	versionErr := dco.ensureSupportedDockerCliVersion(ctx)
+	if errors.Is(versionErr, exec.ErrNotFound) {
+		if unwrapErr := errors.Unwrap(versionErr); errors.Is(unwrapErr, exec.ErrNotFound) {
+			versionErr = unwrapErr
+		}
+
+		return containers.ContainerRuntimeStatus{
+			Installed: false,
+			Running:   false,
+			Error:     versionErr.Error(),
+		}
+	} else if errors.Is(versionErr, context.DeadlineExceeded) {
+		return containers.ContainerRuntimeStatus{
+			Installed: true,
+			Running:   false,
+			Error:     "Docker CLI timed out while checking version. Ensure Docker CLI is functioning correctly and try again.",
+		}
+	} else if errors.Is(versionErr, errInvalidDockerVersionOutput) {
+		return containers.ContainerRuntimeStatus{
+			Installed: false,
+			Running:   false,
+			Error:     "Output from Docker CLI didn't match the expected format. The Docker CLI found on your PATH may not be a valid Docker installation.",
+		}
+	} else if versionErr != nil {
+		return containers.ContainerRuntimeStatus{
+			Installed: true,
+			Running:   false,
+			Error:     versionErr.Error(),
+		}
+	}
+
 	// Docker always includes default networks and formats its response in a consistent way, so we can use this to ensure we're talking to Docker
 	// and not a symlinked runtime like Podman.
 	_, err := dco.ListNetworks(ctx, containers.ListNetworksOptions{})
@@ -242,6 +308,59 @@ func (dco *DockerCliOrchestrator) getStatus(ctx context.Context) containers.Cont
 		Installed: true,
 		Running:   true,
 	}
+}
+
+func (dco *DockerCliOrchestrator) ensureSupportedDockerCliVersion(ctx context.Context) error {
+	// Use the non-JSON `docker --version` output because `docker version --format` contacts the daemon
+	// and can hang when the engine is unresponsive.
+	cmd := makeDockerCommand("--version")
+	outBuf, errBuf, err := dco.runBufferedDockerCommand(ctx, "Version", cmd, nil, nil, dockerVersionCommandTimeout)
+	if err != nil {
+		return errors.Join(err, normalizeCliErrors(errBuf))
+	}
+
+	version, parseErr := parseDockerCliVersion(outBuf.String())
+	if parseErr != nil {
+		return parseErr
+	}
+
+	if version.isBefore(minimumSupportedDockerCliVersion) {
+		return fmt.Errorf(
+			"docker CLI version %s is not supported; DCP requires Docker CLI version %s or newer",
+			version.String(),
+			minimumSupportedDockerCliVersion.String(),
+		)
+	}
+
+	return nil
+}
+
+func parseDockerCliVersion(versionOutput string) (dockerCliVersion, error) {
+	match := dockerVersionRegEx.FindStringSubmatch(strings.TrimSpace(versionOutput))
+	if match == nil {
+		return dockerCliVersion{}, errInvalidDockerVersionOutput
+	}
+
+	major, majorErr := strconv.Atoi(match[1])
+	if majorErr != nil {
+		return dockerCliVersion{}, fmt.Errorf("parse docker CLI major version: %w", majorErr)
+	}
+
+	minor, minorErr := strconv.Atoi(match[2])
+	if minorErr != nil {
+		return dockerCliVersion{}, fmt.Errorf("parse docker CLI minor version: %w", minorErr)
+	}
+
+	patch, patchErr := strconv.Atoi(match[3])
+	if patchErr != nil {
+		return dockerCliVersion{}, fmt.Errorf("parse docker CLI patch version: %w", patchErr)
+	}
+
+	return dockerCliVersion{
+		major: major,
+		minor: minor,
+		patch: patch,
+	}, nil
 }
 
 func (dco *DockerCliOrchestrator) GetDiagnostics(ctx context.Context) (containers.ContainerDiagnostics, error) {

--- a/internal/docker/cli_orchestrator.go
+++ b/internal/docker/cli_orchestrator.go
@@ -480,14 +480,15 @@ func applyCreateContainerOptions(args []string, options containers.CreateContain
 		args = append(args, "--name", options.Name)
 	}
 
-	if options.Network != "" {
-		args = append(args, "--network", options.Network)
-
-		if len(options.NetworkAliases) > 0 {
-			for _, alias := range options.NetworkAliases {
-				args = append(args, "--network-alias", alias)
+	for _, network := range options.Networks {
+		networkArg := network.Name
+		if len(network.Aliases) > 0 {
+			networkArg = "name=" + network.Name
+			for _, alias := range network.Aliases {
+				networkArg += ",alias=" + alias
 			}
 		}
+		args = append(args, "--network", networkArg)
 	}
 
 	for _, mount := range options.VolumeMounts {

--- a/internal/docker/cli_orchestrator_test.go
+++ b/internal/docker/cli_orchestrator_test.go
@@ -8,6 +8,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -319,6 +320,114 @@ func TestUnmarshalListedNetworks(t *testing.T) {
 	require.NoError(t, timestampErr)
 }
 
+func TestGetStatusChecksDockerVersionBeforeNetworks(t *testing.T) {
+	ctx, cancel := testutil.GetTestContext(t, 20*time.Second)
+	defer cancel()
+	executor := internal_testutil.NewTestProcessExecutor(ctx)
+	defer func() {
+		require.NoError(t, executor.Close())
+	}()
+	dco := NewDockerCliOrchestrator(testr.New(t), executor).(*DockerCliOrchestrator)
+	installDockerVersionAutoExecution(executor, "Docker version 25.0.0, build 1234567\n", 0)
+	installDockerNetworkListAutoExecution(executor)
+
+	status := dco.getStatus(ctx)
+
+	require.True(t, status.Installed)
+	require.True(t, status.Running)
+	require.Empty(t, status.Error)
+	require.Len(t, executor.FindAll([]string{"docker", "--version"}, "", nil), 1)
+	require.Len(t, executor.FindAll([]string{"docker", "network", "ls"}, "", nil), 1)
+}
+
+func TestGetStatusRejectsUnsupportedDockerVersion(t *testing.T) {
+	ctx, cancel := testutil.GetTestContext(t, 20*time.Second)
+	defer cancel()
+	executor := internal_testutil.NewTestProcessExecutor(ctx)
+	defer func() {
+		require.NoError(t, executor.Close())
+	}()
+	dco := NewDockerCliOrchestrator(testr.New(t), executor).(*DockerCliOrchestrator)
+	installDockerVersionAutoExecution(executor, "Docker version 24.0.9, build 2936816\n", 0)
+	installDockerNetworkListAutoExecution(executor)
+
+	status := dco.getStatus(ctx)
+
+	require.True(t, status.Installed)
+	require.False(t, status.Running)
+	require.Contains(t, status.Error, "requires Docker CLI version 25.0.0 or newer")
+	require.Len(t, executor.FindAll([]string{"docker", "--version"}, "", nil), 1)
+	require.Empty(t, executor.FindAll([]string{"docker", "network", "ls"}, "", nil))
+}
+
+func TestGetStatusRejectsInvalidDockerVersionOutput(t *testing.T) {
+	ctx, cancel := testutil.GetTestContext(t, 20*time.Second)
+	defer cancel()
+	executor := internal_testutil.NewTestProcessExecutor(ctx)
+	defer func() {
+		require.NoError(t, executor.Close())
+	}()
+	dco := NewDockerCliOrchestrator(testr.New(t), executor).(*DockerCliOrchestrator)
+	installDockerVersionAutoExecution(executor, "podman version 5.3.1\n", 0)
+	installDockerNetworkListAutoExecution(executor)
+
+	status := dco.getStatus(ctx)
+
+	require.False(t, status.Installed)
+	require.False(t, status.Running)
+	require.Contains(t, status.Error, "may not be a valid Docker installation")
+	require.Len(t, executor.FindAll([]string{"docker", "--version"}, "", nil), 1)
+	require.Empty(t, executor.FindAll([]string{"docker", "network", "ls"}, "", nil))
+}
+
+func TestParseDockerCliVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		want    dockerCliVersion
+		wantErr error
+	}{
+		{
+			name:   "release version",
+			output: "Docker version 25.0.0, build e758fe5\n",
+			want: dockerCliVersion{
+				major: 25,
+				minor: 0,
+				patch: 0,
+			},
+		},
+		{
+			name:   "prerelease suffix",
+			output: "Docker version 25.0.0-beta.1, build e758fe5\n",
+			want: dockerCliVersion{
+				major: 25,
+				minor: 0,
+				patch: 0,
+			},
+		},
+		{
+			name:    "non docker output",
+			output:  "podman version 5.3.1\n",
+			wantErr: errInvalidDockerVersionOutput,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, parseErr := parseDockerCliVersion(testCase.output)
+			if testCase.wantErr != nil {
+				require.True(t, errors.Is(parseErr, testCase.wantErr))
+				return
+			}
+
+			require.NoError(t, parseErr)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}
+
 func waitForDockerEventsExecution(
 	t *testing.T,
 	ctx context.Context,
@@ -328,6 +437,41 @@ func waitForDockerEventsExecution(
 	pe, err := internal_testutil.WaitForCommand(executor, ctx, []string{"docker", "events"}, "", cond)
 	require.NoError(t, err)
 	return pe
+}
+
+func installDockerVersionAutoExecution(executor *internal_testutil.TestProcessExecutor, output string, exitCode int32) {
+	executor.InstallAutoExecution(internal_testutil.AutoExecution{
+		Condition: internal_testutil.ProcessSearchCriteria{
+			Command: []string{"docker", "--version"},
+		},
+		RunCommand: func(execution *internal_testutil.ProcessExecution) int32 {
+			_, writeErr := execution.Cmd.Stdout.Write([]byte(output))
+			if writeErr != nil {
+				return 1
+			}
+
+			return exitCode
+		},
+	})
+}
+
+func installDockerNetworkListAutoExecution(executor *internal_testutil.TestProcessExecutor) {
+	executor.InstallAutoExecution(internal_testutil.AutoExecution{
+		Condition: internal_testutil.ProcessSearchCriteria{
+			Command: []string{"docker", "network", "ls"},
+		},
+		RunCommand: func(execution *internal_testutil.ProcessExecution) int32 {
+			listedNetworksText := []byte(
+				`{ "CreatedAt": "2024-12-18 16:46:32.448140173 +0000 UTC", "Driver": "bridge", "ID": "6fa4fe834c76", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "bridge", "Scope": "local" }` + "\n",
+			)
+			_, writeErr := execution.Cmd.Stdout.Write(listedNetworksText)
+			if writeErr != nil {
+				return 1
+			}
+
+			return 0
+		},
+	})
 }
 
 func waitForEvent(ctx context.Context, c <-chan ct.EventMessage) (ct.EventMessage, error) {

--- a/internal/docker/cli_orchestrator_test.go
+++ b/internal/docker/cli_orchestrator_test.go
@@ -425,3 +425,62 @@ func TestApplyCreateContainerOptionsVolumeMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCreateContainerOptionsNetworks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  ct.CreateContainerOptions
+		wantArgs []string
+	}{
+		{
+			name: "single network without aliases",
+			options: ct.CreateContainerOptions{
+				Networks: []ct.CreateContainerNetworkOptions{
+					{Name: "network-a"},
+				},
+			},
+			wantArgs: []string{"--network", "network-a"},
+		},
+		{
+			name: "single network with aliases",
+			options: ct.CreateContainerOptions{
+				Networks: []ct.CreateContainerNetworkOptions{
+					{
+						Name:    "network-a",
+						Aliases: []string{"alias-a", "alias-b"},
+					},
+				},
+			},
+			wantArgs: []string{"--network", "name=network-a,alias=alias-a,alias=alias-b"},
+		},
+		{
+			name: "multiple networks with aliases",
+			options: ct.CreateContainerOptions{
+				Networks: []ct.CreateContainerNetworkOptions{
+					{
+						Name:    "network-a",
+						Aliases: []string{"alias-a", "alias-b"},
+					},
+					{
+						Name:    "network-b",
+						Aliases: []string{"alias-c"},
+					},
+				},
+			},
+			wantArgs: []string{
+				"--network", "name=network-a,alias=alias-a,alias=alias-b",
+				"--network", "name=network-b,alias=alias-c",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := applyCreateContainerOptions([]string{}, tc.options)
+			require.Equal(t, tc.wantArgs, args)
+		})
+	}
+}

--- a/internal/podman/cli_orchestrator.go
+++ b/internal/podman/cli_orchestrator.go
@@ -465,14 +465,17 @@ func applyCreateContainerOptions(args []string, options containers.CreateContain
 		args = append(args, "--name", options.Name)
 	}
 
-	if options.Network != "" {
-		args = append(args, "--network", options.Network)
-
-		if len(options.NetworkAliases) > 0 {
-			for _, alias := range options.NetworkAliases {
-				args = append(args, "--network-alias", alias)
+	for _, network := range options.Networks {
+		networkArg := network.Name
+		for i, alias := range network.Aliases {
+			if i == 0 {
+				networkArg += ":"
+			} else {
+				networkArg += ","
 			}
+			networkArg += "alias=" + alias
 		}
+		args = append(args, "--network", networkArg)
 	}
 
 	for _, mount := range options.VolumeMounts {

--- a/internal/podman/cli_orchestrator_test.go
+++ b/internal/podman/cli_orchestrator_test.go
@@ -130,6 +130,65 @@ func TestApplyCreateContainerOptionsVolumeMounts(t *testing.T) {
 	}
 }
 
+func TestApplyCreateContainerOptionsNetworks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  containers.CreateContainerOptions
+		wantArgs []string
+	}{
+		{
+			name: "single network without aliases",
+			options: containers.CreateContainerOptions{
+				Networks: []containers.CreateContainerNetworkOptions{
+					{Name: "network-a"},
+				},
+			},
+			wantArgs: []string{"--network", "network-a"},
+		},
+		{
+			name: "single network with aliases",
+			options: containers.CreateContainerOptions{
+				Networks: []containers.CreateContainerNetworkOptions{
+					{
+						Name:    "network-a",
+						Aliases: []string{"alias-a", "alias-b"},
+					},
+				},
+			},
+			wantArgs: []string{"--network", "network-a:alias=alias-a,alias=alias-b"},
+		},
+		{
+			name: "multiple networks with aliases",
+			options: containers.CreateContainerOptions{
+				Networks: []containers.CreateContainerNetworkOptions{
+					{
+						Name:    "network-a",
+						Aliases: []string{"alias-a", "alias-b"},
+					},
+					{
+						Name:    "network-b",
+						Aliases: []string{"alias-c"},
+					},
+				},
+			},
+			wantArgs: []string{
+				"--network", "network-a:alias=alias-a,alias=alias-b",
+				"--network", "network-b:alias=alias-c",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := applyCreateContainerOptions([]string{}, tc.options)
+			require.Equal(t, tc.wantArgs, args)
+		})
+	}
+}
+
 const inspectedConsulJune2024 = `
 [
       {

--- a/internal/testutil/ctrlutil/test_container_orchestrator.go
+++ b/internal/testutil/ctrlutil/test_container_orchestrator.go
@@ -1317,35 +1317,62 @@ func (to *TestContainerOrchestrator) CreateContainer(ctx context.Context, option
 		return "", errRuntimeUnhealthy
 	}
 
+	createNetworks, err := to.resolveCreateContainerNetworks(options)
+	if err != nil {
+		return "", err
+	}
+
 	container, err := to.doCreateContainer(ctx, options)
 	if err != nil {
 		return "", err
 	}
 
-	effectiveNetwork := options.Network
-	if effectiveNetwork == "" {
-		effectiveNetwork = to.DefaultNetworkName()
-	}
-
-	allNetworks := maps.Values(to.networks)
-	i := slices.IndexFunc(allNetworks, func(n *containerNetwork) bool {
-		return n.matches(effectiveNetwork)
-	})
-	if i < 0 {
-		return "", errors.Join(containers.ErrNotFound, fmt.Errorf("network %s not found", effectiveNetwork))
-	}
-	net := allNetworks[i]
-
-	connectOpts := containers.ConnectNetworkOptions{
-		Network:   net.ID,
-		Container: container.ID,
-		Aliases:   options.NetworkAliases,
-	}
-	if err = to.doConnectNetwork(ctx, net, container, connectOpts); err != nil {
-		return container.ID, err
+	for _, createNetwork := range createNetworks {
+		connectOpts := containers.ConnectNetworkOptions{
+			Network:   createNetwork.network.ID,
+			Container: container.ID,
+			Aliases:   createNetwork.aliases,
+		}
+		if err = to.doConnectNetwork(ctx, createNetwork.network, container, connectOpts); err != nil {
+			return container.ID, err
+		}
 	}
 
 	return container.ID, nil
+}
+
+type resolvedCreateContainerNetwork struct {
+	network *containerNetwork
+	aliases []string
+}
+
+func (to *TestContainerOrchestrator) resolveCreateContainerNetworks(options containers.CreateContainerOptions) ([]resolvedCreateContainerNetwork, error) {
+	requestedNetworks := options.Networks
+	if len(requestedNetworks) == 0 {
+		requestedNetworks = []containers.CreateContainerNetworkOptions{
+			{Name: to.DefaultNetworkName()},
+		}
+	}
+
+	allNetworks := maps.Values(to.networks)
+	resolvedNetworks := make([]resolvedCreateContainerNetwork, 0, len(requestedNetworks))
+	for _, requestedNetwork := range requestedNetworks {
+		index := slices.IndexFunc(allNetworks, func(n *containerNetwork) bool {
+			return n.matches(requestedNetwork.Name)
+		})
+		if index < 0 {
+			return nil, errors.Join(containers.ErrNotFound, fmt.Errorf("network %s not found", requestedNetwork.Name))
+		}
+
+		aliases := make([]string, len(requestedNetwork.Aliases))
+		copy(aliases, requestedNetwork.Aliases)
+		resolvedNetworks = append(resolvedNetworks, resolvedCreateContainerNetwork{
+			network: allNetworks[index],
+			aliases: aliases,
+		})
+	}
+
+	return resolvedNetworks, nil
 }
 
 func (to *TestContainerOrchestrator) doCreateContainer(ctx context.Context, options containers.CreateContainerOptions) (*testContainer, error) {
@@ -1569,32 +1596,25 @@ func (to *TestContainerOrchestrator) RunContainer(ctx context.Context, options c
 		return "", errRuntimeUnhealthy
 	}
 
+	createNetworks, err := to.resolveCreateContainerNetworks(options.CreateContainerOptions)
+	if err != nil {
+		return "", err
+	}
+
 	container, err := to.doCreateContainer(ctx, options.CreateContainerOptions)
 	if err != nil {
 		return "", err
 	}
 
-	effectiveNetwork := options.Network
-	if effectiveNetwork == "" {
-		effectiveNetwork = to.DefaultNetworkName()
-	}
-
-	allNetworks := maps.Values(to.networks)
-	i := slices.IndexFunc(allNetworks, func(n *containerNetwork) bool {
-		return n.matches(effectiveNetwork)
-	})
-	if i < 0 {
-		return "", errors.Join(containers.ErrNotFound, fmt.Errorf("network %s not found", effectiveNetwork))
-	}
-	net := allNetworks[i]
-
-	connectOpts := containers.ConnectNetworkOptions{
-		Network:   net.ID,
-		Container: container.ID,
-		Aliases:   options.NetworkAliases,
-	}
-	if err = to.doConnectNetwork(ctx, net, container, connectOpts); err != nil {
-		return container.ID, err
+	for _, createNetwork := range createNetworks {
+		connectOpts := containers.ConnectNetworkOptions{
+			Network:   createNetwork.network.ID,
+			Container: container.ID,
+			Aliases:   createNetwork.aliases,
+		}
+		if err = to.doConnectNetwork(ctx, createNetwork.network, container, connectOpts); err != nil {
+			return container.ID, err
+		}
 	}
 
 	if _, err = to.doStartContainer(ctx, container, options.StreamCommandOptions); err != nil {

--- a/test/integration/container_network_connection_test.go
+++ b/test/integration/container_network_connection_test.go
@@ -7,6 +7,7 @@ package integration_test
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 	"time"
@@ -96,7 +97,8 @@ func TestContainerNetworkChanges(t *testing.T) {
 			Namespace: metav1.NamespaceNone,
 		},
 		Spec: apiv1.ContainerSpec{
-			Image: imageName,
+			Image:         imageName,
+			ContainerName: testName,
 			Networks: &[]apiv1.ContainerNetworkConnectionConfig{
 				{
 					Name: testName,
@@ -206,6 +208,8 @@ func TestContainerNetworkDoesNotStartUntilNetworkExists(t *testing.T) {
 
 	// Ensure the container is still starting
 	_ = ensureContainerState(t, ctx, client, &ctr, apiv1.ContainerStateStarting)
+	_, inspectErr := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{Containers: []string{testName}})
+	require.True(t, errors.Is(inspectErr, containers.ErrNotFound), "Container resource should not be created before its initial network exists")
 
 	net := apiv1.ContainerNetwork{
 		ObjectMeta: metav1.ObjectMeta{
@@ -226,6 +230,68 @@ func TestContainerNetworkDoesNotStartUntilNetworkExists(t *testing.T) {
 		return n.Name == updatedNetwork.Status.NetworkName
 	})
 	require.True(t, found)
+}
+
+func TestContainerNetworkKeepsUnmanagedConnections(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const testName = "test-container-network-keeps-unmanaged"
+
+	net := apiv1.ContainerNetwork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: metav1.NamespaceNone,
+		},
+	}
+
+	t.Logf("Creating ContainerNetwork object '%s'", net.ObjectMeta.Name)
+	err := client.Create(ctx, &net)
+	require.NoError(t, err, "could not create a ContainerNetwork object")
+
+	updatedNetwork := ensureNetworkCreated(t, ctx, &net)
+
+	containerName := testName + "-container"
+	containerID, err := containerOrchestrator.RunContainer(ctx, containers.RunContainerOptions{
+		CreateContainerOptions: containers.CreateContainerOptions{
+			Name: containerName,
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: updatedNetwork.Status.NetworkName},
+			},
+			ContainerSpec: apiv1.ContainerSpec{Image: testName + "-image"},
+		},
+	})
+	require.NoError(t, err, "could not run unmanaged container")
+	defer func() {
+		_, _ = containerOrchestrator.RemoveContainers(context.Background(), containers.RemoveContainersOptions{
+			Containers: []string{containerID},
+			Force:      true,
+		})
+	}()
+
+	err = retryOnConflict(ctx, updatedNetwork.NamespacedName(), func(ctx context.Context, currentNet *apiv1.ContainerNetwork) error {
+		networkPatch := currentNet.DeepCopy()
+		if networkPatch.Annotations == nil {
+			networkPatch.Annotations = map[string]string{}
+		}
+		networkPatch.Annotations["test.dcp.microsoft.com/reconcile"] = "after-unmanaged-connect"
+		return client.Patch(ctx, networkPatch, ctrl_client.MergeFromWithOptions(currentNet, ctrl_client.MergeFromWithOptimisticLock{}))
+	})
+	require.NoError(t, err, "could not trigger network reconciliation")
+
+	waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(updatedNetwork), func(currentNet *apiv1.ContainerNetwork) (bool, error) {
+		return slices.Contains(currentNet.Status.ContainerIDs, containerID), nil
+	})
+
+	inspectedContainers, err := containerOrchestrator.InspectContainers(ctx, containers.InspectContainersOptions{Containers: []string{containerID}})
+	require.NoError(t, err, "could not inspect unmanaged container")
+	require.Len(t, inspectedContainers, 1)
+
+	found := slices.ContainsFunc(inspectedContainers[0].Networks, func(n containers.InspectedContainerNetwork) bool {
+		return n.Name == updatedNetwork.Status.NetworkName
+	})
+	require.True(t, found, "network controller should not disconnect unmanaged session network connections")
 }
 
 // Ensures that network aliases are applied to containers if Container Spec requests them

--- a/test/integration/container_network_connection_test.go
+++ b/test/integration/container_network_connection_test.go
@@ -189,7 +189,8 @@ func TestContainerNetworkDoesNotStartUntilNetworkExists(t *testing.T) {
 			Namespace: metav1.NamespaceNone,
 		},
 		Spec: apiv1.ContainerSpec{
-			Image: imageName,
+			Image:         imageName,
+			ContainerName: testName,
 			Networks: &[]apiv1.ContainerNetworkConnectionConfig{
 				{
 					Name: testName,

--- a/test/integration/container_network_tunnel_proxy_test.go
+++ b/test/integration/container_network_tunnel_proxy_test.go
@@ -198,10 +198,18 @@ func TestTunnelProxyRunningStatus(t *testing.T) {
 	t.Logf("Creating ContainerNetwork object '%s'", network.ObjectMeta.Name)
 	err := serverInfo.Client.Create(ctx, &network)
 	require.NoError(t, err, "Could not create a ContainerNetwork object")
+	updatedNetwork := waitObjectAssumesStateEx(t, ctx, serverInfo.Client, network.NamespacedName(), func(currentNet *apiv1.ContainerNetwork) (bool, error) {
+		if currentNet.Status.State == apiv1.ContainerNetworkStateFailedToStart {
+			return false, fmt.Errorf("network creation failed: %s", currentNet.Status.Message)
+		}
+
+		return currentNet.Status.State == apiv1.ContainerNetworkStateRunning && currentNet.Status.NetworkName != "", nil
+	})
 
 	const serverControlPort int32 = 26444
 	simulateServerProxy(t, serverControlPort, teInfo.TestProcessExecutor)
 
+	aliases := []string{"client-proxy", "tunnel-client"}
 	tunnelProxy := apiv1.ContainerNetworkTunnelProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
@@ -209,6 +217,7 @@ func TestTunnelProxyRunningStatus(t *testing.T) {
 		},
 		Spec: apiv1.ContainerNetworkTunnelProxySpec{
 			ContainerNetworkName: network.ObjectMeta.Name,
+			Aliases:              aliases,
 			Tunnels: []apiv1.TunnelConfiguration{
 				{
 					Name:              "test-tunnel",
@@ -243,6 +252,9 @@ func TestTunnelProxyRunningStatus(t *testing.T) {
 	clientContainer := inspectedContainers[0]
 	require.Equal(t, updatedTunnelProxy.Status.ClientProxyContainerImage, clientContainer.Image, "Container should have the expected image")
 	require.Equal(t, containers.ContainerStatusRunning, clientContainer.Status, "Container should be running")
+	require.Len(t, clientContainer.Networks, 1, "Client proxy container should only be attached to the target network")
+	require.Equal(t, updatedNetwork.Status.NetworkName, clientContainer.Networks[0].Name, "Client proxy container should be attached to the target network during creation")
+	require.Equal(t, aliases, clientContainer.Networks[0].Aliases, "Client proxy container should have the requested aliases on the target network")
 
 	t.Log("Verifying client proxy container has correct labels...")
 	require.Contains(t, clientContainer.Labels, controllers.CreatorProcessIdLabel, "Container should have creator process ID label")

--- a/test/integration/resource_harvesting_test.go
+++ b/test/integration/resource_harvesting_test.go
@@ -67,8 +67,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 
 	_, containerCreateErr := co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "non-dcp-container-1",
-			Network: netPersistentWithContainer,
+			Name: prefix + "non-dcp-container-1",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netPersistentWithContainer},
+			},
 		},
 	})
 	require.NoError(t, containerCreateErr)
@@ -101,15 +103,19 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, netCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "non-dcp-container-2",
-			Network: netWithNonDcpContainers,
+			Name: prefix + "non-dcp-container-2",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithNonDcpContainers},
+			},
 		},
 	})
 	require.NoError(t, containerCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "non-dcp-container-3",
-			Network: netWithNonDcpContainers,
+			Name: prefix + "non-dcp-container-3",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithNonDcpContainers},
+			},
 		},
 	})
 	require.NoError(t, containerCreateErr)
@@ -127,8 +133,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, netCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "dcp-container-1",
-			Network: netWithMixedContainers,
+			Name: prefix + "dcp-container-1",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithMixedContainers},
+			},
 			ContainerSpec: apiv1.ContainerSpec{
 				Labels: []apiv1.ContainerLabel{
 					{
@@ -150,8 +158,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, containerCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "non-dcp-container-4",
-			Network: netWithMixedContainers,
+			Name: prefix + "non-dcp-container-4",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithMixedContainers},
+			},
 		},
 	})
 	require.NoError(t, containerCreateErr)
@@ -169,8 +179,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, netCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "abandoned-persistent-container",
-			Network: netWithAbandonedPersistentContainer,
+			Name: prefix + "abandoned-persistent-container",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithAbandonedPersistentContainer},
+			},
 			ContainerSpec: apiv1.ContainerSpec{
 				Labels: []apiv1.ContainerLabel{
 					{
@@ -204,8 +216,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, netCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "dcp-container-2",
-			Network: netWithDcpContainers,
+			Name: prefix + "dcp-container-2",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithDcpContainers},
+			},
 			ContainerSpec: apiv1.ContainerSpec{
 				Labels: []apiv1.ContainerLabel{
 					{
@@ -227,8 +241,10 @@ func TestUnusedNetworkHarvesting(t *testing.T) {
 	require.NoError(t, containerCreateErr)
 	_, containerCreateErr = co.RunContainer(ctx, containers.RunContainerOptions{
 		CreateContainerOptions: containers.CreateContainerOptions{
-			Name:    prefix + "dcp-container-3",
-			Network: netWithDcpContainers,
+			Name: prefix + "dcp-container-3",
+			Networks: []containers.CreateContainerNetworkOptions{
+				{Name: netWithDcpContainers},
+			},
 			ContainerSpec: apiv1.ContainerSpec{
 				Labels: []apiv1.ContainerLabel{
 					{


### PR DESCRIPTION
Initial container startup should not create on the default network and then wait for JIT attach just to reach the desired topology. This changes create-time networking so Docker and Podman receive the full initial network and alias set in the container create command once all requested networks are ready.

## Summary
- Add `CreateContainerOptions.Networks` as the only create-time networking API and emit runtime-specific multi-network arguments for Docker and Podman.
- Resolve initial `ContainerNetwork`s before creation, remove the startup-time JIT connection delay, and keep dynamic attach/detach reconciliation for later network changes.
- Update the test orchestrator and integration coverage, including preserving unmanaged runtime connections so the network controller does not disconnect create-time attachments before connection objects exist.

## Validation
- `go test -count 1 -parallel 32 ./internal/containers ./internal/docker ./internal/podman ./internal/testutil/ctrlutil ./controllers ./test/integration -run 'TestApplyCreateContainerOptionsNetworks|TestContainerNetworkKeepsUnmanagedConnections|TestContainerNetworkDoesNotStartUntilNetworkExists|TestContainerNetworkWithAliases|TestContainerFastExitingWithNetwork|TestResourceHarvesting' -timeout 180s`
- Manual Docker smoke test with `kubectl`-created `ContainerNetwork` and `Container` resources.
- Manual Podman smoke test with DCP forced to `--container-runtime podman`.