### PR TITLE
[release/0.25] Backport terminal socket ownership and ProcessHandle

### DIFF
--- a/api/v1/container_types.go
+++ b/api/v1/container_types.go
@@ -1221,6 +1221,12 @@ type ContainerStatus struct {
 	// The path of a temporary file that contains captured standard error data from the Container startup process.
 	StartupStdErrFile string `json:"startupStdErrFile,omitempty"`
 
+	// The filesystem path of the terminal HMP v1 Unix domain socket, when the Container is
+	// configured with a terminal. In "listen" mode this is the socket DCP owns (and is the
+	// DCP-generated path when the spec left UDSPath empty); in "connect" mode it is the peer-owned
+	// socket DCP dials.
+	TerminalSocketPath string `json:"terminalSocketPath,omitempty"`
+
 	// Exit code of the Container.
 	// Default is -1, meaning the exit code is not known, or the container is still running.
 	// +kubebuilder:default:=-1

--- a/api/v1/executable_types.go
+++ b/api/v1/executable_types.go
@@ -765,6 +765,12 @@ type ExecutableStatus struct {
 	// The path of a temporary file that contains captured standard error data from the Executable process.
 	StdErrFile string `json:"stdErrFile,omitempty"`
 
+	// The filesystem path of the terminal HMP v1 Unix domain socket, when the Executable is
+	// configured with a terminal. In "listen" mode this is the socket DCP owns (and is the
+	// DCP-generated path when the spec left UDSPath empty); in "connect" mode it is the peer-owned
+	// socket DCP dials.
+	TerminalSocketPath string `json:"terminalSocketPath,omitempty"`
+
 	// Effective values of environment variables, after all substitutions are applied.
 	// +listType=map
 	// +listMapKey=name

--- a/api/v1/terminal_types.go
+++ b/api/v1/terminal_types.go
@@ -19,8 +19,11 @@ type TerminalSocketMode string
 
 const (
 	// TerminalSocketModeListen means DCP listens on the socket and the client connects to it.
+	// In this mode DCP owns the socket file: it creates the file and unlinks it when the terminal
+	// is torn down. If a file already exists at the path, DCP refuses to bind and returns an error.
 	TerminalSocketModeListen TerminalSocketMode = "listen"
 	// TerminalSocketModeConnect means the client listens on the socket and DCP connects to it.
+	// In this mode the peer owns the socket file; DCP never creates or removes it.
 	TerminalSocketModeConnect TerminalSocketMode = "connect"
 )
 
@@ -49,13 +52,19 @@ func (m TerminalSocketMode) Normalized() TerminalSocketMode {
 //
 // +k8s:openapi-gen=true
 type TerminalSpec struct {
-	// UDSPath is the Unix Domain Socket path used for the HMP v1 client connection.
-	// Required.
+	// Unix Domain Socket path used for the HMP v1 client connection.
+	// In "listen" mode UDSPath is optional: when empty, DCP chooses a unique socket path in the
+	// session/temp folder and reports the actual path in the resource Status.
+	// DCP owns the socket file in this mode (creates it and removes it on teardown); when UDSPath
+	// is provided it must not already exist, as DCP will not reuse or remove a pre-existing file.
+	// In "connect" mode UDSPath is required and refers to a socket the peer is listening on.
 	UDSPath string `json:"udsPath,omitempty"`
 
 	// SocketMode selects how DCP establishes the HMP v1 connection over UDSPath.
-	// "listen" (the default) means DCP listens on the socket and the client connects to it.
-	// "connect" means the client listens on the socket and DCP connects to it.
+	// "listen" (the default) means DCP listens on the socket and the client connects to it;
+	// DCP owns the socket file (creating and removing it).
+	// "connect" means the client listens on the
+	// socket (which it owns) and DCP connects to it.
 	// The terminal data flow is identical in both modes; only connection establishment differs.
 	// +kubebuilder:default:=listen
 	SocketMode TerminalSocketMode `json:"socketMode,omitempty"`
@@ -91,8 +100,9 @@ func (ts *TerminalSpec) Validate(specPath *field.Path) field.ErrorList {
 	if ts == nil {
 		return errorList
 	}
-	if ts.UDSPath == "" {
-		errorList = append(errorList, field.Invalid(specPath.Child("udsPath"), ts.UDSPath, "udsPath is required."))
+	if ts.UDSPath == "" && ts.SocketMode.Normalized() == TerminalSocketModeConnect {
+		errorList = append(errorList, field.Invalid(specPath.Child("udsPath"), ts.UDSPath,
+			"udsPath is required in \"connect\" socket mode."))
 	}
 	switch ts.SocketMode {
 	case "", TerminalSocketModeListen, TerminalSocketModeConnect:

--- a/api/v1/terminal_types_test.go
+++ b/api/v1/terminal_types_test.go
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestTerminalSpecValidateUDSPathRequirement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		spec        TerminalSpec
+		expectError bool
+	}{
+		{
+			name: "empty UDSPath allowed in default (listen) mode",
+			spec: TerminalSpec{Cols: 80, Rows: 24},
+		},
+		{
+			name: "empty UDSPath allowed in explicit listen mode",
+			spec: TerminalSpec{SocketMode: TerminalSocketModeListen, Cols: 80, Rows: 24},
+		},
+		{
+			name:        "empty UDSPath rejected in connect mode",
+			spec:        TerminalSpec{SocketMode: TerminalSocketModeConnect, Cols: 80, Rows: 24},
+			expectError: true,
+		},
+		{
+			name: "non-empty UDSPath allowed in listen mode",
+			spec: TerminalSpec{UDSPath: "/tmp/app.sock", SocketMode: TerminalSocketModeListen, Cols: 80, Rows: 24},
+		},
+		{
+			name: "non-empty UDSPath allowed in connect mode",
+			spec: TerminalSpec{UDSPath: "/tmp/app.sock", SocketMode: TerminalSocketModeConnect, Cols: 80, Rows: 24},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			errs := testCase.spec.Validate(field.NewPath("spec", "terminal"))
+			if testCase.expectError {
+				require.NotEmpty(t, errs)
+				require.Equal(t, "spec.terminal.udsPath", errs[0].Field)
+			} else {
+				require.Empty(t, errs)
+			}
+		})
+	}
+}

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -99,7 +99,7 @@ type ContainerReconcilerConfig struct {
 	MaxParallelContainerStarts      uint8
 	ContainerStartupTimeoutOverride time.Duration
 	StateStore                      *statestore.Store
-	ResourceLeaseOwner              process.ProcessTreeItem
+	ResourceLeaseOwner              process.ProcessHandle
 	ProcessExecutor                 process.Executor
 }
 

--- a/controllers/container_controller.go
+++ b/controllers/container_controller.go
@@ -1962,6 +1962,7 @@ func (r *ContainerReconciler) attachTerminalIfNeeded(
 	})
 	if attachErr != nil {
 		log.Error(attachErr, "Failed to attach terminal to container")
+		connMgr.Shutdown()
 		if _, stopErr := r.stopContainerIfNecessary(r.LifetimeCtx, rcd.containerID, nil, log); stopErr != nil {
 			log.Error(stopErr, "Failed to stop container after terminal attach failure")
 		}
@@ -1977,6 +1978,7 @@ func (r *ContainerReconciler) attachTerminalIfNeeded(
 		if closeErr := ptp.PTY.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
 			log.Error(closeErr, "Failed to close PTY after terminal connection manager creation failure")
 		}
+		connMgr.Shutdown()
 		if _, stopErr := r.stopContainerIfNecessary(r.LifetimeCtx, rcd.containerID, nil, log); stopErr != nil {
 			log.Error(stopErr, "Failed to stop container after terminal connection manager creation failure")
 		}
@@ -1994,7 +1996,7 @@ func (r *ContainerReconciler) attachTerminalIfNeeded(
 	rcd.ptp = ptp
 	rcd.connMgr = connMgr
 
-	log.V(1).Info("Container terminal attached", "UDSPath", terminalSpec.UDSPath)
+	log.V(1).Info("Container terminal attached", "UDSPath", connMgr.SocketPath())
 	return nil
 }
 

--- a/controllers/container_network_tunnel_proxy_controller.go
+++ b/controllers/container_network_tunnel_proxy_controller.go
@@ -1280,7 +1280,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 		r.onServerProcessExit(tunnelProxy.NamespacedName(), pid, exitCode, err, stdoutFile, stderrFile)
 	})
 
-	pid, startTime, startWaitForExit, startErr := r.config.ProcessExecutor.StartProcess(context.Background(), cmd, exitHandler, process.CreationFlagsNone, nil)
+	handle, startWaitForExit, startErr := r.config.ProcessExecutor.StartProcess(context.Background(), cmd, exitHandler, process.CreationFlagsNone, nil)
 	if startErr != nil {
 		log.Error(startErr, "Failed to start server proxy process")
 		startFailed = true
@@ -1295,7 +1295,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 	tc, tcErr := readServerProxyConfig(ctx, stdoutFile.Name())
 	if tcErr != nil {
 		log.Error(tcErr, "Failed to read connection information from the server proxy")
-		stopProcessErr := r.config.ProcessExecutor.StopProcess(pid, startTime)
+		stopProcessErr := r.config.ProcessExecutor.StopProcess(handle)
 		if stopProcessErr != nil {
 			log.Error(stopProcessErr, "Failed to stop server proxy process after being unable to read its configuration")
 		}
@@ -1303,11 +1303,11 @@ func (r *ContainerNetworkTunnelProxyReconciler) startServerProxy(
 		return false
 	}
 
-	dcpproc.RunProcessWatcher(r.config.ProcessExecutor, pid, startTime, log)
+	dcpproc.RunProcessWatcher(r.config.ProcessExecutor, handle, log)
 
-	pointers.SetValue(&pd.ServerProxyProcessID, int64(pid))
+	pointers.SetValue(&pd.ServerProxyProcessID, int64(handle.Pid))
 	pd.ServerProxyControlPort = tc.ServerControlPort
-	pd.ServerProxyStartupTimestamp = metav1.NewMicroTime(startTime)
+	pd.ServerProxyStartupTimestamp = metav1.NewMicroTime(handle.IdentityTime)
 	pd.ServerProxyStdOutFile = stdoutFile.Name()
 	pd.ServerProxyStdErrFile = stderrFile.Name()
 
@@ -1399,7 +1399,7 @@ func (r *ContainerNetworkTunnelProxyReconciler) cleanupProxyPair(
 
 		// The process may have already exited because the client container has been stopped.
 
-		stopErr := r.config.ProcessExecutor.StopProcess(pid, startTime)
+		stopErr := r.config.ProcessExecutor.StopProcess(process.NewHandle(pid, startTime))
 		if stopErr != nil && !errors.Is(stopErr, process.ErrorProcessNotFound) {
 			log.Error(stopErr, "Failed to stop server proxy process")
 		} else {

--- a/controllers/controller_harvest.go
+++ b/controllers/controller_harvest.go
@@ -283,7 +283,7 @@ func (rh *resourceHarvester) isRunningDCPProcess(pid process.Pid_t, startTime ti
 	}
 
 	// If the process is not in the cache, we need to check if it is running.
-	_, findErr := process.FindProcess(pid, startTime)
+	_, findErr := process.FindProcess(process.NewHandle(pid, startTime))
 	if findErr != nil {
 		return false // Process not found, so it's not running.
 	}

--- a/controllers/executable_controller.go
+++ b/controllers/executable_controller.go
@@ -67,7 +67,7 @@ type runStateMap = ObjectStateMap[RunID, ExecutableRunInfo, *ExecutableRunInfo, 
 
 type ExecutableReconcilerConfig struct {
 	StateStore         *statestore.Store
-	ResourceLeaseOwner process.ProcessTreeItem
+	ResourceLeaseOwner process.ProcessHandle
 }
 
 // ExecutableReconciler reconciles a Executable object
@@ -343,7 +343,7 @@ func handleNewExecutable(
 				return r.setExecutableState(exe, apiv1.ExecutableStateFailedToStart)
 			}
 
-			findErr := persistentRunner.CheckProcessRunning(record.PID, record.IdentityTime)
+			findErr := persistentRunner.CheckProcessRunning(record.ProcessHandle())
 			if exe.Spec.Stop {
 				stopChange := noChange
 				if findErr == nil {

--- a/controllers/executable_run_info.go
+++ b/controllers/executable_run_info.go
@@ -81,6 +81,9 @@ type ExecutableRunInfo struct {
 	StdOutFile string
 	StdErrFile string
 
+	// Filesystem path of the terminal HMP v1 Unix domain socket, when the Executable has a terminal.
+	TerminalSocketPath string
+
 	// Paths to capture debug, info, and error logs
 	DebugLogFile string
 	InfoLogFile  string
@@ -188,6 +191,11 @@ func (ri *ExecutableRunInfo) UpdateFrom(other *ExecutableRunInfo) bool {
 		updated = true
 	}
 
+	if other.TerminalSocketPath != "" && ri.TerminalSocketPath != other.TerminalSocketPath {
+		ri.TerminalSocketPath = other.TerminalSocketPath
+		updated = true
+	}
+
 	if other.DebugLogFile != "" && ri.DebugLogFile != other.DebugLogFile {
 		ri.DebugLogFile = other.DebugLogFile
 		updated = true
@@ -266,6 +274,7 @@ func (ri *ExecutableRunInfo) Clone() *ExecutableRunInfo {
 	retval.FinishTimestamp = ri.FinishTimestamp
 	retval.StdOutFile = ri.StdOutFile
 	retval.StdErrFile = ri.StdErrFile
+	retval.TerminalSocketPath = ri.TerminalSocketPath
 	retval.DebugLogFile = ri.DebugLogFile
 	retval.InfoLogFile = ri.InfoLogFile
 	retval.ErrorLogFile = ri.ErrorLogFile
@@ -324,6 +333,11 @@ func (ri *ExecutableRunInfo) ApplyTo(exe *apiv1.Executable, log logr.Logger) obj
 		changed = statusChanged
 	}
 
+	if ri.TerminalSocketPath != "" && status.TerminalSocketPath != ri.TerminalSocketPath {
+		status.TerminalSocketPath = ri.TerminalSocketPath
+		changed = statusChanged
+	}
+
 	updatedHealthResults, healthResultsChanged := health.UpdateHealthProbeResults(status.HealthProbeResults, ri.healthProbeResults)
 	if healthResultsChanged {
 		status.HealthProbeResults = updatedHealthResults
@@ -341,7 +355,7 @@ func (ri *ExecutableRunInfo) ApplyTo(exe *apiv1.Executable, log logr.Logger) obj
 
 func (ri *ExecutableRunInfo) String() string {
 	return fmt.Sprintf(
-		"{exeState=%s, pid=%s, executionID=%s, exitCode=%s, startupTimestamp=%s, finishTimestamp=%s, stdOutFile=%s, stdErrFile=%s, healthProbeResults=%s, healthProbesEnabled=%s, stopAttemptInitiated=%t, startupStage=%s, startResults=%s}",
+		"{exeState=%s, pid=%s, executionID=%s, exitCode=%s, startupTimestamp=%s, finishTimestamp=%s, stdOutFile=%s, stdErrFile=%s, terminalSocketPath=%s, healthProbeResults=%s, healthProbesEnabled=%s, stopAttemptInitiated=%t, startupStage=%s, startResults=%s}",
 		ri.ExeState,
 		logger.IntPtrValToString(ri.Pid),
 		logger.FriendlyString(string(ri.RunID)),
@@ -350,6 +364,7 @@ func (ri *ExecutableRunInfo) String() string {
 		logger.FriendlyMetav1Timestamp(ri.FinishTimestamp),
 		logger.FriendlyString(ri.StdOutFile),
 		logger.FriendlyString(ri.StdErrFile),
+		logger.FriendlyString(ri.TerminalSocketPath),
 		ri.healthProbesFriendlyString(),
 		logger.BoolPtrValToString(ri.healthProbesEnabled),
 		ri.stopAttemptInitiated,

--- a/controllers/executable_runner.go
+++ b/controllers/executable_runner.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,7 +64,7 @@ type PersistentExecutableRunner interface {
 	StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error
 
 	// Checks that the process associated with a persistent run is running.
-	CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error
+	CheckProcessRunning(handle process.ProcessHandle) error
 }
 
 type RunMessageLevel string

--- a/controllers/executable_start_result.go
+++ b/controllers/executable_start_result.go
@@ -37,6 +37,9 @@ type ExecutableStartResult struct {
 	StdOutFile string
 	StdErrFile string
 
+	// Filesystem path of the terminal HMP v1 Unix domain socket, when the Executable has a terminal.
+	TerminalSocketPath string
+
 	// Timestamp for when the startup attempt was completed
 	CompletionTimestamp metav1.MicroTime
 
@@ -95,6 +98,10 @@ func (res *ExecutableStartResult) Equal(other *ExecutableStartResult) bool {
 		return false
 	}
 
+	if res.TerminalSocketPath != other.TerminalSocketPath {
+		return false
+	}
+
 	if !osutil.MicroEqual(res.CompletionTimestamp, other.CompletionTimestamp) {
 		return false
 	}
@@ -126,6 +133,7 @@ func (res *ExecutableStartResult) applyTo(ri *ExecutableRunInfo) {
 	ri.RunID = res.RunID
 	ri.StdOutFile = res.StdOutFile
 	ri.StdErrFile = res.StdErrFile
+	ri.TerminalSocketPath = res.TerminalSocketPath
 	ri.StartupTimestamp = res.CompletionTimestamp
 	ri.ProcessIdentityTime = res.ProcessIdentityTime
 	if res.ExeState == apiv1.ExecutableStateFinished {
@@ -154,6 +162,7 @@ func (res *ExecutableStartResult) Clone() *ExecutableStartResult {
 		ExitCode:                  pointers.Duplicate(res.ExitCode),
 		StdOutFile:                res.StdOutFile,
 		StdErrFile:                res.StdErrFile,
+		TerminalSocketPath:        res.TerminalSocketPath,
 		CompletionTimestamp:       res.CompletionTimestamp,
 		ProcessIdentityTime:       res.ProcessIdentityTime,
 		StartupError:              res.StartupError,
@@ -202,6 +211,11 @@ func (res *ExecutableStartResult) UpdateFrom(other *ExecutableStartResult) bool 
 		updated = true
 	}
 
+	if other.TerminalSocketPath != "" && res.TerminalSocketPath != other.TerminalSocketPath {
+		res.TerminalSocketPath = other.TerminalSocketPath
+		updated = true
+	}
+
 	updated = setTimestampIfAfterOrUnknown(other.CompletionTimestamp, &res.CompletionTimestamp) || updated
 
 	if !other.ProcessIdentityTime.IsZero() && !res.ProcessIdentityTime.Equal(other.ProcessIdentityTime) {
@@ -227,13 +241,14 @@ func (res *ExecutableStartResult) String() string {
 		return "{}"
 	}
 
-	return fmt.Sprintf("{exeState: %s, pid: %v, runID: %s, exitCode: %s, stdOutFile: %s, stdErrFile: %s, startupCompletedTimestamp: %s, processIdentityTime: %s, startupError: %s}",
+	return fmt.Sprintf("{exeState: %s, pid: %v, runID: %s, exitCode: %s, stdOutFile: %s, stdErrFile: %s, terminalSocketPath: %s, startupCompletedTimestamp: %s, processIdentityTime: %s, startupError: %s}",
 		res.ExeState,
 		logger.IntPtrValToString(res.Pid),
 		logger.FriendlyString(string(res.RunID)),
 		logger.IntPtrValToString(res.ExitCode),
 		logger.FriendlyString(res.StdOutFile),
 		logger.FriendlyString(res.StdErrFile),
+		logger.FriendlyString(res.TerminalSocketPath),
 		logger.FriendlyMetav1Timestamp(res.CompletionTimestamp),
 		logger.FriendlyString(process.FormatIdentityTime(res.ProcessIdentityTime)),
 		logger.FriendlyErrorString(res.StartupError),

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -139,7 +139,7 @@ type NetworkReconciler struct {
 
 type NetworkReconcilerConfig struct {
 	StateStore         *statestore.Store
-	ResourceLeaseOwner process.ProcessTreeItem
+	ResourceLeaseOwner process.ProcessHandle
 }
 
 var (

--- a/controllers/running_container_data.go
+++ b/controllers/running_container_data.go
@@ -426,6 +426,15 @@ func (rcd *runningContainerData) applyTo(ctr *apiv1.Container, log logr.Logger) 
 		change |= statusChanged
 	}
 
+	terminalSocketPath := ""
+	if rcd.connMgr != nil {
+		terminalSocketPath = rcd.connMgr.SocketPath()
+	}
+	if terminalSocketPath != "" && ctr.Status.TerminalSocketPath != terminalSocketPath {
+		ctr.Status.TerminalSocketPath = terminalSocketPath
+		change |= statusChanged
+	}
+
 	// From the runSpec the runningContainerData has, only Env and Args will ever be modified
 	// (as a result of evaluating template expressions that may be embedded in environment variables or command arguments).
 
@@ -493,8 +502,17 @@ func (rcd *runningContainerData) applyTo(ctr *apiv1.Container, log logr.Logger) 
 // ExitHandler, which in turn drives the ConnManager shutdown.
 func (rcd *runningContainerData) closeTerminalResources(pe process.Executor, log logr.Logger) {
 	ptp := rcd.ptp
+	connMgr := rcd.connMgr
 	rcd.ptp = nil
 	rcd.connMgr = nil
+
+	// Deterministically tear down the connection manager so the owned listen-mode socket file is
+	// removed promptly, rather than waiting for the lifetime context to cancel. Shutdown is
+	// idempotent, so this is safe even if process-exit observation also triggers it.
+	if connMgr != nil {
+		connMgr.Shutdown()
+	}
+
 	if ptp == nil {
 		return
 	}

--- a/controllers/running_container_data.go
+++ b/controllers/running_container_data.go
@@ -517,7 +517,7 @@ func (rcd *runningContainerData) closeTerminalResources(pe process.Executor, log
 		return
 	}
 
-	if ptp.PID != 0 && ptp.PID != process.UnknownPID {
+	if ptp.Handle.Pid != 0 && ptp.Handle.Pid != process.UnknownPID {
 		// Only attempt to stop the attach process if it has not already
 		// exited. The exit handler may already have fired (e.g., the
 		// container itself exited and the OS noticed the attach process
@@ -533,8 +533,8 @@ func (rcd *runningContainerData) closeTerminalResources(pe process.Executor, log
 		}
 		if !alreadyExited {
 			var notFound *process.ErrProcessNotFound
-			if stopErr := pe.StopProcess(ptp.PID, ptp.IdentityTime); stopErr != nil && !errors.As(stopErr, &notFound) {
-				log.V(1).Info("Failed to stop container terminal attach process", "PID", ptp.PID, "Error", stopErr.Error())
+			if stopErr := pe.StopProcess(ptp.Handle); stopErr != nil && !errors.As(stopErr, &notFound) {
+				log.V(1).Info("Failed to stop container terminal attach process", "PID", ptp.Handle.Pid, "Error", stopErr.Error())
 			}
 		}
 	}

--- a/internal/commands/monitor.go
+++ b/internal/commands/monitor.go
@@ -29,22 +29,21 @@ func AddMonitorFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint8VarP(&monitorInterval, "monitor-interval", "i", 0, "If present, specifies the time in seconds between checks for the monitor PID.")
 }
 
-// Starts monitoring a process with a given PID and (optional) start time.
+// Starts monitoring a process identified by the given handle.
 // Returns a context that will be cancelled when the monitored process exits, or if the returned cancellation function is called.
 // The returned context (and the cancellation function) is valid even if an error occurs (e.g. the process cannot be found),
 // but it will be already cancelled in that case.
 func MonitorPid(
 	ctx context.Context,
-	pid process.Pid_t,
-	expectedProcessStartTime time.Time,
+	handle process.ProcessHandle,
 	pollInterval uint8,
 	logger logr.Logger,
 ) (context.Context, context.CancelFunc, error) {
 	monitorCtx, monitorCtxCancel := context.WithCancel(ctx)
 
-	monitorProc, monitorProcErr := process.FindWaitableProcess(pid, expectedProcessStartTime)
+	monitorProc, monitorProcErr := process.FindWaitableProcess(handle)
 	if monitorProcErr != nil {
-		logger.Info("Error finding process", "PID", pid)
+		logger.Info("Error finding process", "PID", handle.Pid)
 		monitorCtxCancel()
 		return monitorCtx, monitorCtxCancel, monitorProcErr
 	}
@@ -53,18 +52,18 @@ func MonitorPid(
 		monitorProc.WaitPollInterval = time.Second * time.Duration(pollInterval)
 	}
 
-	logger.Info("Started monitoring process", "PID", pid)
+	logger.Info("Started monitoring process", "PID", handle.Pid)
 
 	go func() {
 		defer monitorCtxCancel()
 		if waitErr := monitorProc.Wait(monitorCtx); waitErr != nil {
 			if errors.Is(waitErr, context.Canceled) {
-				logger.V(1).Info("Monitoring cancelled by context", "PID", pid)
+				logger.V(1).Info("Monitoring cancelled by context", "PID", handle.Pid)
 			} else {
-				logger.Error(waitErr, "Error waiting for process", "PID", pid)
+				logger.Error(waitErr, "Error waiting for process", "PID", handle.Pid)
 			}
 		} else {
-			logger.Info("Monitor process exited, shutting down", "PID", pid)
+			logger.Info("Monitor process exited, shutting down", "PID", handle.Pid)
 		}
 	}()
 
@@ -85,6 +84,6 @@ func GetMonitorContextFromFlags(ctx context.Context, logger logr.Logger) (contex
 	}
 
 	// Ignore errors as they're logged by MonitorPid and we always return a valid context
-	monitorCtx, monitorCtxCancel, _ := MonitorPid(ctx, monitorPid, monitorProcessStartTime, monitorInterval, logger)
+	monitorCtx, monitorCtxCancel, _ := MonitorPid(ctx, process.NewHandle(monitorPid, monitorProcessStartTime), monitorInterval, logger)
 	return monitorCtx, monitorCtxCancel
 }

--- a/internal/contextdata/contextdata.go
+++ b/internal/contextdata/contextdata.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/microsoft/dcp/pkg/process"
@@ -58,20 +57,20 @@ func GetProcessExecutor(ctx context.Context) process.Executor {
 
 type dummyProcessExecutor struct{}
 
-func (*dummyProcessExecutor) StartProcess(_ context.Context, _ *exec.Cmd, _ process.ProcessExitHandler, _ process.ProcessCreationFlag, _ process.SysCreateProcessFunc) (process.Pid_t, time.Time, func(), error) {
-	return process.UnknownPID, time.Time{}, nil, fmt.Errorf("there is no process executor configured, no processes can be started")
+func (*dummyProcessExecutor) StartProcess(_ context.Context, _ *exec.Cmd, _ process.ProcessExitHandler, _ process.ProcessCreationFlag, _ process.SysCreateProcessFunc) (process.ProcessHandle, func(), error) {
+	return process.ProcessHandle{Pid: process.UnknownPID}, nil, fmt.Errorf("there is no process executor configured, no processes can be started")
 }
 
-func (*dummyProcessExecutor) StopProcess(_ process.Pid_t, _ time.Time, _ ...process.ProcessStopOption) error {
+func (*dummyProcessExecutor) StopProcess(_ process.ProcessHandle, _ ...process.ProcessStopOption) error {
 	return fmt.Errorf("there is no process executor configured, no processes can be stopped")
 }
 
-func (*dummyProcessExecutor) CheckProcessRunning(_ process.Pid_t, _ time.Time) error {
+func (*dummyProcessExecutor) CheckProcessRunning(_ process.ProcessHandle) error {
 	return fmt.Errorf("there is no process executor configured, no processes can be checked")
 }
 
-func (*dummyProcessExecutor) StartAndForget(_ *exec.Cmd, _ process.ProcessCreationFlag) (process.Pid_t, time.Time, error) {
-	return process.UnknownPID, time.Time{}, fmt.Errorf("there is no process executor configured, no processes can be started")
+func (*dummyProcessExecutor) StartAndForget(_ *exec.Cmd, _ process.ProcessCreationFlag) (process.ProcessHandle, error) {
+	return process.ProcessHandle{Pid: process.UnknownPID}, fmt.Errorf("there is no process executor configured, no processes can be started")
 }
 
 func (*dummyProcessExecutor) Dispose() {

--- a/internal/dcp/bootstrap/dcp_run.go
+++ b/internal/dcp/bootstrap/dcp_run.go
@@ -223,14 +223,7 @@ func DcpRun(
 func createNotificationSource(lifetimeCtx context.Context, log logr.Logger) (notifications.UnixSocketNotificationSource, error) {
 	const noNotifications = "Notifications will not be sent to controller process"
 
-	socketPath, socketPathErr := notifications.PrepareNotificationSocketPath("", "dcp-notify-sock-")
-	if socketPathErr != nil {
-		retErr := fmt.Errorf("failed to prepare notification socket path: %w", socketPathErr)
-		log.Error(socketPathErr, noNotifications)
-		return nil, retErr
-	}
-
-	ns, nsErr := notifications.NewNotificationSource(lifetimeCtx, socketPath, log)
+	ns, nsErr := notifications.NewNotificationSource(lifetimeCtx, "", "dcp-notify-sock-", log)
 	if nsErr != nil {
 		retErr := fmt.Errorf("failed to create notification source: %w", nsErr)
 		log.Error(nsErr, noNotifications)

--- a/internal/dcpctrl/commands/persistent_process_cleanup.go
+++ b/internal/dcpctrl/commands/persistent_process_cleanup.go
@@ -30,7 +30,7 @@ func (r persistentProcessLeaseResource) GetLeaseKey() string {
 func startInvalidPersistentExecutableRecordCleanup(
 	ctx context.Context,
 	stateStore *statestore.Store,
-	leaseOwner process.ProcessTreeItem,
+	leaseOwner process.ProcessHandle,
 	log logr.Logger,
 ) <-chan struct{} {
 	done := make(chan struct{})
@@ -49,7 +49,7 @@ func startInvalidPersistentExecutableRecordCleanup(
 func cleanupInvalidPersistentExecutableRecords(
 	ctx context.Context,
 	stateStore *statestore.Store,
-	leaseOwner process.ProcessTreeItem,
+	leaseOwner process.ProcessHandle,
 	log logr.Logger,
 ) error {
 	if stateStore == nil {
@@ -63,7 +63,7 @@ func cleanupInvalidPersistentExecutableRecords(
 
 	var cleanupErr error
 	for _, record := range records {
-		if _, findErr := process.FindProcess(record.PID, record.IdentityTime); findErr == nil {
+		if _, findErr := process.FindProcess(record.ProcessHandle()); findErr == nil {
 			continue
 		}
 
@@ -79,7 +79,7 @@ func cleanupInvalidPersistentExecutableRecords(
 func cleanupInvalidPersistentExecutableRecord(
 	ctx context.Context,
 	stateStore *statestore.Store,
-	leaseOwner process.ProcessTreeItem,
+	leaseOwner process.ProcessHandle,
 	record statestore.PersistentProcessRecord,
 	log logr.Logger,
 ) error {
@@ -95,7 +95,7 @@ func cleanupInvalidPersistentExecutableRecord(
 			return fmt.Errorf("could not reload persistent Executable process record '%s': %w", record.ResourceKey, getErr)
 		}
 
-		_, findErr := process.FindProcess(currentRecord.PID, currentRecord.IdentityTime)
+		_, findErr := process.FindProcess(currentRecord.ProcessHandle())
 		if findErr == nil {
 			log.V(1).Info("Persistent Executable process record became valid before cleanup, leaving it intact",
 				"ResourceKey", currentRecord.ResourceKey,

--- a/internal/dcpctrl/commands/persistent_process_cleanup_test.go
+++ b/internal/dcpctrl/commands/persistent_process_cleanup_test.go
@@ -119,7 +119,7 @@ func TestCleanupInvalidPersistentExecutableRecordsSkipsRecordsWithHeldLease(t *t
 	stateStore := openPersistentProcessCleanupTestStore(t, ctx)
 	heldLeaseOwner, heldLeaseOwnerErr := statestore.CurrentResourceLeaseOwner()
 	require.NoError(t, heldLeaseOwnerErr)
-	cleanupLeaseOwner := process.ProcessTreeItem{
+	cleanupLeaseOwner := process.ProcessHandle{
 		Pid:          heldLeaseOwner.Pid,
 		IdentityTime: heldLeaseOwner.IdentityTime.Add(-time.Hour),
 	}

--- a/internal/dcppaths/dcppaths.go
+++ b/internal/dcppaths/dcppaths.go
@@ -21,7 +21,6 @@ import (
 const (
 	DcpUserDir           = ".dcp"
 	DcpExtensionsDir     = "ext"
-	DcpWorkDir           = "dcp-work"
 	DcpExtensionsPathEnv = "DCP_EXTENSIONS_PATH"
 	BuildOutputDir       = "bin"
 )

--- a/internal/dcpproc/commands/container.go
+++ b/internal/dcpproc/commands/container.go
@@ -111,7 +111,7 @@ func monitorContainer(log logr.Logger) func(cmd *cobra.Command, args []string) e
 		}
 		defer pe.Dispose()
 
-		monitorCtx, monitorCtxCancel, monitorCtxErr := cmds.MonitorPid(cmd.Context(), monitorPid, monitorProcessStartTime, monitorInterval, log)
+		monitorCtx, monitorCtxCancel, monitorCtxErr := cmds.MonitorPid(cmd.Context(), process.NewHandle(monitorPid, monitorProcessStartTime), monitorInterval, log)
 		defer monitorCtxCancel()
 		if monitorCtxErr != nil {
 			if isMonitorProcessGoneErr(monitorCtxErr) {

--- a/internal/dcpproc/commands/process.go
+++ b/internal/dcpproc/commands/process.go
@@ -63,7 +63,7 @@ func monitorProcess(log logr.Logger) func(cmd *cobra.Command, args []string) err
 			log = log.WithValues(logger.RESOURCE_LOG_STREAM_ID, resourceId)
 		}
 
-		monitorCtx, monitorCtxCancel, monitorCtxErr := cmds.MonitorPid(cmd.Context(), monitorPid, monitorProcessStartTime, monitorInterval, log)
+		monitorCtx, monitorCtxCancel, monitorCtxErr := cmds.MonitorPid(cmd.Context(), process.NewHandle(monitorPid, monitorProcessStartTime), monitorInterval, log)
 		defer monitorCtxCancel()
 		if monitorCtxErr != nil {
 			if isMonitorProcessGoneErr(monitorCtxErr) {
@@ -74,7 +74,7 @@ func monitorProcess(log logr.Logger) func(cmd *cobra.Command, args []string) err
 				// an unrelated process even if the child PID has been reused as well.
 				log.Info("Monitored process already exited, shutting down child process", "Reason", monitorCtxErr)
 				executor := process.NewOSExecutor(log)
-				stopErr := process.StopViaConsole(log, executor, childPid, childProcessStartTime)
+				stopErr := process.StopViaConsole(log, executor, process.NewHandle(childPid, childProcessStartTime))
 				if stopErr != nil {
 					log.Error(stopErr, "Failed to stop child process")
 					return stopErr
@@ -87,7 +87,7 @@ func monitorProcess(log logr.Logger) func(cmd *cobra.Command, args []string) err
 			}
 		}
 
-		childProcessCtx, childProcessCtxCancel, childMonitorErr := cmds.MonitorPid(cmd.Context(), childPid, childProcessStartTime, monitorInterval, log)
+		childProcessCtx, childProcessCtxCancel, childMonitorErr := cmds.MonitorPid(cmd.Context(), process.NewHandle(childPid, childProcessStartTime), monitorInterval, log)
 		defer childProcessCtxCancel()
 		if childMonitorErr != nil {
 			// Log as Info--we might leak the child process if regular cleanup fails, but this should be rare.
@@ -101,7 +101,7 @@ func monitorProcess(log logr.Logger) func(cmd *cobra.Command, args []string) err
 			if childProcessCtx.Err() == nil {
 				log.Info("Monitored process exited, shutting down child process")
 				executor := process.NewOSExecutor(log)
-				stopErr := process.StopViaConsole(log, executor, childPid, childProcessStartTime)
+				stopErr := process.StopViaConsole(log, executor, process.NewHandle(childPid, childProcessStartTime))
 				if stopErr != nil {
 					log.Error(stopErr, "Failed to stop child service process")
 					return stopErr

--- a/internal/dcpproc/commands/stop_process_tree.go
+++ b/internal/dcpproc/commands/stop_process_tree.go
@@ -51,7 +51,8 @@ func stopProcessTree(log logr.Logger) func(cmd *cobra.Command, args []string) er
 			"SkipDescendants", stopSkipDescendants,
 		)
 
-		_, procErr := process.FindWaitableProcess(stopPid, stopProcessStartTime)
+		handle := process.NewHandle(stopPid, stopProcessStartTime)
+		_, procErr := process.FindWaitableProcess(handle)
 		if procErr != nil {
 			log.Error(procErr, "Could not find the process to stop")
 			return procErr
@@ -63,7 +64,7 @@ func stopProcessTree(log logr.Logger) func(cmd *cobra.Command, args []string) er
 			stopOptions = append(stopOptions, process.StopRootOnly())
 		}
 
-		stopErr := process.StopViaConsole(log, pe, stopPid, stopProcessStartTime, stopOptions...)
+		stopErr := process.StopViaConsole(log, pe, handle, stopOptions...)
 		if stopErr != nil {
 			log.Error(stopErr, "Failed to stop process tree")
 			return stopErr

--- a/internal/dcpproc/dcpproc_api.go
+++ b/internal/dcpproc/dcpproc_api.go
@@ -33,23 +33,20 @@ type ContainerWatcherOptions struct {
 	StopOnly bool
 }
 
-func MonitorTargetFromFields(monitorPID *int64, monitorTimestamp metav1.MicroTime) (process.ProcessTreeItem, bool, error) {
+func MonitorTargetFromFields(monitorPID *int64, monitorTimestamp metav1.MicroTime) (process.ProcessHandle, bool, error) {
 	if monitorPID == nil {
-		return process.ProcessTreeItem{}, false, nil
+		return process.ProcessHandle{}, false, nil
 	}
 	if monitorTimestamp.IsZero() {
-		return process.ProcessTreeItem{}, false, fmt.Errorf("monitor timestamp must be set when monitor PID is set")
+		return process.ProcessHandle{}, false, fmt.Errorf("monitor timestamp must be set when monitor PID is set")
 	}
 
 	pid, pidErr := process.Int64_ToPidT(*monitorPID)
 	if pidErr != nil {
-		return process.ProcessTreeItem{}, false, fmt.Errorf("invalid monitor PID %d: %w", *monitorPID, pidErr)
+		return process.ProcessHandle{}, false, fmt.Errorf("invalid monitor PID %d: %w", *monitorPID, pidErr)
 	}
 
-	return process.ProcessTreeItem{
-		Pid:          pid,
-		IdentityTime: monitorTimestamp.Time,
-	}, true, nil
+	return process.NewHandle(pid, monitorTimestamp.Time), true, nil
 }
 
 // Starts the process monitor for the given child process, using current process as the "monitored", or watched, process.
@@ -60,34 +57,32 @@ func MonitorTargetFromFields(monitorPID *int64, monitorTimestamp metav1.MicroTim
 // so monitoring DCPCTRL is a safe bet.
 func RunProcessWatcher(
 	pe process.Executor,
-	childPid process.Pid_t,
-	childStartTime time.Time,
+	child process.ProcessHandle,
 	log logr.Logger,
 ) {
 	monitorPid := process.Uint32_ToPidT(uint32(os.Getpid()))
 	monitorIdentityTime := process.ProcessIdentityTime(monitorPid)
-	RunProcessWatcherForMonitor(pe, process.ProcessTreeItem{Pid: monitorPid, IdentityTime: monitorIdentityTime}, childPid, childStartTime, log)
+	RunProcessWatcherForMonitor(pe, process.NewHandle(monitorPid, monitorIdentityTime), child, log)
 }
 
 func RunProcessWatcherForMonitor(
 	pe process.Executor,
-	monitor process.ProcessTreeItem,
-	childPid process.Pid_t,
-	childStartTime time.Time,
+	monitor process.ProcessHandle,
+	child process.ProcessHandle,
 	log logr.Logger,
 ) {
 	if _, found := os.LookupEnv(DCP_DISABLE_MONITOR_PROCESS); found {
 		return
 	}
 
-	log = log.WithValues("ChildPID", childPid)
+	log = log.WithValues("ChildPID", child.Pid)
 
 	cmdArgs := []string{
 		"monitor-process",
-		"--child", strconv.FormatInt(int64(childPid), 10),
+		"--child", strconv.FormatInt(int64(child.Pid), 10),
 	}
-	if !childStartTime.IsZero() {
-		cmdArgs = append(cmdArgs, "--child-identity-time", childStartTime.Format(osutil.RFC3339MiliTimestampFormat))
+	if !child.IdentityTime.IsZero() {
+		cmdArgs = append(cmdArgs, "--child-identity-time", child.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat))
 	}
 	cmdArgs = append(cmdArgs, getMonitorCmdArgs(monitor)...)
 
@@ -108,12 +103,12 @@ func RunContainerWatcher(
 ) {
 	monitorPid := process.Uint32_ToPidT(uint32(os.Getpid()))
 	monitorIdentityTime := process.ProcessIdentityTime(monitorPid)
-	RunContainerWatcherForMonitor(pe, process.ProcessTreeItem{Pid: monitorPid, IdentityTime: monitorIdentityTime}, containerID, log)
+	RunContainerWatcherForMonitor(pe, process.NewHandle(monitorPid, monitorIdentityTime), containerID, log)
 }
 
 func RunContainerWatcherForMonitor(
 	pe process.Executor,
-	monitor process.ProcessTreeItem,
+	monitor process.ProcessHandle,
 	containerID string,
 	log logr.Logger,
 ) {
@@ -122,7 +117,7 @@ func RunContainerWatcherForMonitor(
 
 func RunContainerWatcherForMonitorWithOptions(
 	pe process.Executor,
-	monitor process.ProcessTreeItem,
+	monitor process.ProcessHandle,
 	containerID string,
 	options ContainerWatcherOptions,
 	log logr.Logger,
@@ -152,18 +147,17 @@ func RunContainerWatcherForMonitorWithOptions(
 func StopProcessTree(
 	ctx context.Context,
 	pe process.Executor,
-	rootPid process.Pid_t,
-	rootProcessStartTime time.Time,
+	root process.ProcessHandle,
 	log logr.Logger,
 ) error {
-	log = log.WithValues("RootPID", rootPid)
+	log = log.WithValues("RootPID", root.Pid)
 
 	cmdArgs := []string{
 		"stop-process-tree",
-		"--pid", strconv.FormatInt(int64(rootPid), 10),
+		"--pid", strconv.FormatInt(int64(root.Pid), 10),
 	}
-	if !rootProcessStartTime.IsZero() {
-		cmdArgs = append(cmdArgs, "--process-start-time", rootProcessStartTime.Format(osutil.RFC3339MiliTimestampFormat))
+	if !root.IdentityTime.IsZero() {
+		cmdArgs = append(cmdArgs, "--process-start-time", root.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat))
 	}
 
 	dcpPath, dcpPathErr := dcppaths.GetDcpExePath()
@@ -180,7 +174,7 @@ func StopProcessTree(
 		log.Error(err, "Failed to stop process tree", "ExitCode", exitCode)
 		return err
 	} else if exitCode != 0 {
-		err = fmt.Errorf("'dcp stop-process-tree --pid %d' command returned non-zero exit code: %d", rootPid, exitCode)
+		err = fmt.Errorf("'dcp stop-process-tree --pid %d' command returned non-zero exit code: %d", root.Pid, exitCode)
 		log.Error(err, "Failed to stop process tree", "ExitCode", exitCode)
 		return err
 	}
@@ -188,7 +182,7 @@ func StopProcessTree(
 	return nil
 }
 
-func getMonitorCmdArgs(monitor process.ProcessTreeItem) []string {
+func getMonitorCmdArgs(monitor process.ProcessHandle) []string {
 	// Add monitor PID to the command args
 	cmdArgs := []string{"--monitor", strconv.FormatInt(int64(monitor.Pid), 10)}
 
@@ -208,7 +202,7 @@ func startDcpProc(pe process.Executor, cmdArgs []string) error {
 	dcpProcCmd := exec.Command(dcpPath, cmdArgs...)
 	dcpProcCmd.Env = os.Environ()    // Use DCP CLI environment
 	logger.WithSessionId(dcpProcCmd) // Ensure the session ID is passed to the monitor command
-	_, _, monitorErr := pe.StartAndForget(dcpProcCmd, process.CreationFlagsNone)
+	_, monitorErr := pe.StartAndForget(dcpProcCmd, process.CreationFlagsNone)
 	return monitorErr
 }
 
@@ -237,7 +231,7 @@ func SimulateStopProcessTreeCommand(pe *internal_testutil.ProcessExecution) int3
 	// We do not simulate stopping the whole process tree (or process parent-child relationships, for that matter).
 	// We can consider adding it if we have tests that require it (currently none).
 
-	stopErr := pe.Executor.StopProcess(pid, startTime)
+	stopErr := pe.Executor.StopProcess(process.NewHandle(pid, startTime))
 	if stopErr != nil {
 		return 5 // Failed to stop the process
 	}

--- a/internal/dcpproc/dcpproc_api_test.go
+++ b/internal/dcpproc/dcpproc_api_test.go
@@ -45,7 +45,7 @@ func TestRunProcessWatcher(t *testing.T) {
 	testPid := process.Pid_t(28869)
 	testStartTime := time.Now()
 
-	RunProcessWatcher(pe, testPid, testStartTime, log)
+	RunProcessWatcher(pe, process.NewHandle(testPid, testStartTime), log)
 
 	dcpProc, dcpProcErr := findRunningDcp(pe)
 	require.NoError(t, dcpProcErr)
@@ -71,12 +71,12 @@ func TestRunProcessWatcherForMonitor(t *testing.T) {
 
 	testPid := process.Pid_t(28869)
 	testStartTime := time.Now()
-	monitor := process.ProcessTreeItem{
+	monitor := process.ProcessHandle{
 		Pid:          12345,
 		IdentityTime: testStartTime.Add(-time.Minute),
 	}
 
-	RunProcessWatcherForMonitor(pe, monitor, testPid, testStartTime, log)
+	RunProcessWatcherForMonitor(pe, monitor, process.NewHandle(testPid, testStartTime), log)
 
 	dcpProc, dcpProcErr := findRunningDcp(pe)
 	require.NoError(t, dcpProcErr)
@@ -126,7 +126,7 @@ func TestRunContainerWatcherForMonitor(t *testing.T) {
 	dcppaths.EnableTestPathProbing()
 
 	testContainerID := "test-container-123"
-	monitor := process.ProcessTreeItem{
+	monitor := process.ProcessHandle{
 		Pid:          12345,
 		IdentityTime: time.Now().Add(-time.Minute),
 	}
@@ -153,7 +153,7 @@ func TestRunContainerWatcherForMonitorWithStopOnly(t *testing.T) {
 	dcppaths.EnableTestPathProbing()
 
 	testContainerID := "test-container-123"
-	monitor := process.ProcessTreeItem{
+	monitor := process.ProcessHandle{
 		Pid:          12345,
 		IdentityTime: time.Now().Add(-time.Minute),
 	}
@@ -194,9 +194,9 @@ func TestStopProcessTree(t *testing.T) {
 		},
 	})
 
-	pid, startTime, startErr := pex.StartAndForget(testCmd, process.CreationFlagsNone)
+	handle, startErr := pex.StartAndForget(testCmd, process.CreationFlagsNone)
 	require.NoError(t, startErr, "Could not simulate starting test process")
-	testProc, found := pex.FindByPid(pid)
+	testProc, found := pex.FindByPid(handle.Pid)
 	require.True(t, found, "Could not find the started process")
 
 	var dcpProc *internal_testutil.ProcessExecution
@@ -210,7 +210,7 @@ func TestStopProcessTree(t *testing.T) {
 		},
 	})
 
-	stopProcessTreeErr := StopProcessTree(ctx, pex, pid, startTime, log)
+	stopProcessTreeErr := StopProcessTree(ctx, pex, handle, log)
 	require.NoError(t, stopProcessTreeErr, "Could not stop the process tree")
 	require.True(t, testProc.Finished(), "The test processed should have been stopped")
 
@@ -220,9 +220,9 @@ func TestStopProcessTree(t *testing.T) {
 	require.Equal(t, "stop-process-tree", dcpProc.Cmd.Args[1], "Should use 'stop-process-tree' subcommand")
 
 	require.Equal(t, dcpProc.Cmd.Args[2], "--pid", "Should include --pid flag")
-	require.Equal(t, dcpProc.Cmd.Args[3], strconv.FormatInt(int64(pid), 10), "Should include test process ID")
+	require.Equal(t, dcpProc.Cmd.Args[3], strconv.FormatInt(int64(handle.Pid), 10), "Should include test process ID")
 	require.Equal(t, dcpProc.Cmd.Args[4], "--process-start-time", "Should include --process-start-time flag")
-	require.Equal(t, dcpProc.Cmd.Args[5], startTime.Format(osutil.RFC3339MiliTimestampFormat), "Should include formatted process start time")
+	require.Equal(t, dcpProc.Cmd.Args[5], handle.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat), "Should include formatted process start time")
 }
 
 func findRunningDcp(pe *internal_testutil.TestProcessExecutor) (*internal_testutil.ProcessExecution, error) {

--- a/internal/dcpproc/dcpproc_test.go
+++ b/internal/dcpproc/dcpproc_test.go
@@ -84,10 +84,10 @@ func TestMonitorProcessTerminatesWatchedProcesses(t *testing.T) {
 	parentCmdErr := parentCmd.Start()
 	require.NoError(t, parentCmdErr, "command should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "parent process start time should not be zero")
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: parentPid, IdentityTime: parentIdentityTime}, 1, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, parentHandle, 1, testTimeout/3)
 
 	childrenCmd := exec.CommandContext(testCtx, "./delay", delayFlag, childSpecFlag)
 	childrenCmd.Dir = delayToolDir
@@ -95,12 +95,12 @@ func TestMonitorProcessTerminatesWatchedProcesses(t *testing.T) {
 	childrenCmdErr := childrenCmd.Start()
 	require.NoError(t, childrenCmdErr, "command should start without error")
 
-	pid := process.Uint32_ToPidT(uint32(childrenCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(pid)
+	childHandle := process.ProcessHandleFromCmd(childrenCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "child process start time should not be zero")
 	int_testutil.EnsureProcessTree(
 		t,
-		process.ProcessTreeItem{Pid: pid, IdentityTime: childIdentityTime},
+		childHandle,
 		expectedChildCount,
 		testTimeout/3,
 	)
@@ -165,10 +165,10 @@ func TestMonitorProcessExitsCleanlyIfChildStartTimeDoesNotMatch(t *testing.T) {
 		_ = parentCmd.Wait()
 	}()
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "parent process start time should not be zero")
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: parentPid, IdentityTime: parentIdentityTime}, 1, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, parentHandle, 1, testTimeout/3)
 
 	childCmd := exec.CommandContext(testCtx, "./delay", delayFlag)
 	childCmd.Dir = delayToolDir
@@ -178,10 +178,10 @@ func TestMonitorProcessExitsCleanlyIfChildStartTimeDoesNotMatch(t *testing.T) {
 		_ = childCmd.Wait()
 	}()
 
-	childPid := process.Uint32_ToPidT(uint32(childCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(childPid)
+	childHandle := process.ProcessHandleFromCmd(childCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "child process start time should not be zero")
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: childPid, IdentityTime: childIdentityTime}, 1, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, childHandle, 1, testTimeout/3)
 
 	bogusChildIdentityTime := childIdentityTime.Add(1 * time.Second)
 
@@ -206,7 +206,7 @@ func TestMonitorProcessExitsCleanlyIfChildStartTimeDoesNotMatch(t *testing.T) {
 
 	// The child process must still be alive: dcpproc must NOT kill a process it could not
 	// positively identify.
-	childStillAlive := process.ProcessIdentityTime(childPid)
+	childStillAlive := process.ProcessIdentityTime(childHandle.Pid)
 	require.False(t, childStillAlive.IsZero(), "child process should still be running")
 	require.True(t, childStillAlive.Equal(childIdentityTime), "child process should still be the same instance")
 }
@@ -244,10 +244,10 @@ func TestMonitorProcessCleansUpChildIfMonitorStartTimeDoesNotMatch(t *testing.T)
 		_ = parentCmd.Wait()
 	}()
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "parent process start time should not be zero")
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: parentPid, IdentityTime: parentIdentityTime}, 1, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, parentHandle, 1, testTimeout/3)
 
 	childCmd := exec.CommandContext(testCtx, "./delay", delayFlag)
 	childCmd.Dir = delayToolDir
@@ -258,14 +258,14 @@ func TestMonitorProcessCleansUpChildIfMonitorStartTimeDoesNotMatch(t *testing.T)
 		_ = childCmd.Wait()
 	}()
 
-	childPid := process.Uint32_ToPidT(uint32(childCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(childPid)
+	childHandle := process.ProcessHandleFromCmd(childCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "child process start time should not be zero")
 	expectedChildTreeSize := 1
 	if osutil.IsWindows() {
 		expectedChildTreeSize = 2 // Account for conhost.exe hosting separate console for the child
 	}
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: childPid, IdentityTime: childIdentityTime}, expectedChildTreeSize, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, childHandle, expectedChildTreeSize, testTimeout/3)
 
 	// Pass an identity time that does not match the actual one to simulate a reused PID.
 	bogusMonitorIdentityTime := parentIdentityTime.Add(1 * time.Hour)
@@ -338,8 +338,8 @@ func TestMonitorProcessCleansUpChildWhenMonitoredProcessAlreadyExited(t *testing
 	process.DecoupleFromParent(parentCmd)
 	require.NoError(t, parentCmd.Start(), "Monitored process should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	require.NoError(t, parentCmd.Wait(), "Monitored process should exit without error")
@@ -354,14 +354,14 @@ func TestMonitorProcessCleansUpChildWhenMonitoredProcessAlreadyExited(t *testing
 		_ = childCmd.Wait()
 	}()
 
-	childPid := process.Uint32_ToPidT(uint32(childCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(childPid)
+	childHandle := process.ProcessHandleFromCmd(childCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "child process start time should not be zero")
 	expectedChildTreeSize := 1
 	if osutil.IsWindows() {
 		expectedChildTreeSize = 2 // Account for conhost.exe hosting separate console for the child
 	}
-	int_testutil.EnsureProcessTree(t, process.ProcessTreeItem{Pid: childPid, IdentityTime: childIdentityTime}, expectedChildTreeSize, testTimeout/3)
+	int_testutil.EnsureProcessTree(t, childHandle, expectedChildTreeSize, testTimeout/3)
 
 	dcpProcOut := &dcpProcOutput{}
 	defer dcpProcOut.DumpOnFailure(t, "dcpproc (TestMonitorProcessCleansUpChildWhenMonitoredProcessAlreadyExited)")
@@ -453,8 +453,8 @@ func TestMonitorContainerTerminatesWatchedContainer(t *testing.T) {
 	parentCmdErr := parentCmd.Start()
 	require.NoError(t, parentCmdErr, "Monitored process should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	// Start dcpproc to monitor the parent process and clean up the container when it exits
@@ -549,8 +549,8 @@ func TestMonitorContainerStopsWatchedContainerWithoutRemoving(t *testing.T) {
 	parentCmdErr := parentCmd.Start()
 	require.NoError(t, parentCmdErr, "Monitored process should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	dcpProcOut := &dcpProcOutput{}
@@ -658,8 +658,8 @@ func TestMonitorContainerExitWhenContainerRemoved(t *testing.T) {
 	parentCmdErr := parentCmd.Start()
 	require.NoError(t, parentCmdErr, "Monitored process should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	// Start dcpproc to monitor the parent process and container, with a short poll interval for the test
@@ -752,8 +752,8 @@ func TestMonitorContainerCleansUpWhenMonitoredProcessAlreadyExited(t *testing.T)
 	process.DecoupleFromParent(parentCmd)
 	require.NoError(t, parentCmd.Start(), "Monitored process should start without error")
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	require.NoError(t, parentCmd.Wait(), "Monitored process should exit without error")
@@ -843,8 +843,8 @@ func TestMonitorContainerCleansUpOnIdentityTimeMismatch(t *testing.T) {
 		_ = parentCmd.Wait()
 	}()
 
-	parentPid := process.Uint32_ToPidT(uint32(parentCmd.Process.Pid))
-	parentIdentityTime := process.ProcessIdentityTime(parentPid)
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	parentIdentityTime := parentHandle.IdentityTime
 	require.False(t, parentIdentityTime.IsZero(), "Monitored process start time should not be zero")
 
 	// Pass an identity time that does not match the actual one to simulate a reused PID.
@@ -918,12 +918,12 @@ func TestStopProcessTreeWorks(t *testing.T) {
 	childrenCmdErr := childrenCmd.Start()
 	require.NoError(t, childrenCmdErr, "command should start without error")
 
-	pid := process.Uint32_ToPidT(uint32(childrenCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(pid)
+	childHandle := process.ProcessHandleFromCmd(childrenCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "child process start time should not be zero")
 	int_testutil.EnsureProcessTree(
 		t,
-		process.ProcessTreeItem{Pid: pid, IdentityTime: childIdentityTime},
+		childHandle,
 		expectedChildCount,
 		testTimeout/3,
 	)

--- a/internal/dcpproc/dcpproc_windows_test.go
+++ b/internal/dcpproc/dcpproc_windows_test.go
@@ -67,20 +67,20 @@ func TestStopProcessTreeDeliversSIGINT(t *testing.T) {
 	process.ForkFromParent(childrenCmd)
 	require.NoError(t, childrenCmd.Start(), "delay tree should start without error")
 
-	pid := process.Uint32_ToPidT(uint32(childrenCmd.Process.Pid))
-	childIdentityTime := process.ProcessIdentityTime(pid)
+	childHandle := process.ProcessHandleFromCmd(childrenCmd)
+	childIdentityTime := childHandle.IdentityTime
 	require.False(t, childIdentityTime.IsZero(), "process identity time should not be zero")
 
 	int_testutil.EnsureProcessTree(
 		t,
-		process.ProcessTreeItem{Pid: pid, IdentityTime: childIdentityTime},
+		childHandle,
 		expectedCount,
 		testTimeout/3,
 	)
 
 	// Snapshot the full tree and open handles BEFORE stopping so that the process objects
 	// remain queryable (via GetExitCodeProcess) even after the processes terminate.
-	tree, treeErr := process.GetProcessTree(process.ProcessTreeItem{Pid: pid, IdentityTime: childIdentityTime})
+	tree, treeErr := process.GetProcessTree(childHandle)
 	require.NoError(t, treeErr)
 
 	handles := openProcessHandles(t, tree)
@@ -132,16 +132,15 @@ func TestStopProcessTreeSkipDescendantsLeavesForkedChildRunning(t *testing.T) {
 	process.ForkFromParent(rootCmd)
 	require.NoError(t, rootCmd.Start(), "delay root process should start without error")
 
-	rootPid := process.Uint32_ToPidT(uint32(rootCmd.Process.Pid))
-	rootIdentityTime := process.ProcessIdentityTime(rootPid)
+	rootItem := process.ProcessHandleFromCmd(rootCmd)
+	rootIdentityTime := rootItem.IdentityTime
 	require.False(t, rootIdentityTime.IsZero(), "root process identity time should not be zero")
-	rootItem := process.ProcessTreeItem{Pid: rootPid, IdentityTime: rootIdentityTime}
 
 	forkedChild := requireDelayDescendant(t, rootItem, testTimeout/3)
 	cleanupExecutor := process.NewOSExecutor(logr.Discard())
 	defer func() {
-		_ = cleanupExecutor.StopProcess(forkedChild.Pid, forkedChild.IdentityTime)
-		_ = cleanupExecutor.StopProcess(rootItem.Pid, rootItem.IdentityTime)
+		_ = cleanupExecutor.StopProcess(forkedChild)
+		_ = cleanupExecutor.StopProcess(rootItem)
 		_ = rootCmd.Wait()
 	}()
 
@@ -184,7 +183,7 @@ func logCommandOutput(t *testing.T, name string, stdout *bytes.Buffer, stderr *b
 // openProcessHandles opens a PROCESS_QUERY_LIMITED_INFORMATION handle for each delay process
 // in the tree. Holding these handles prevents Windows from releasing the process objects before
 // we can query their exit codes. The console host process is intentionally skipped.
-func openProcessHandles(t *testing.T, tree []process.ProcessTreeItem) map[process.Pid_t]syscall.Handle {
+func openProcessHandles(t *testing.T, tree []process.ProcessHandle) map[process.Pid_t]syscall.Handle {
 	t.Helper()
 	handles := make(map[process.Pid_t]syscall.Handle, len(tree))
 	for _, item := range tree {
@@ -204,7 +203,7 @@ func openProcessHandles(t *testing.T, tree []process.ProcessTreeItem) map[proces
 	return handles
 }
 
-func getProcessInfo(t *testing.T, item process.ProcessTreeItem) (uint32, string) {
+func getProcessInfo(t *testing.T, item process.ProcessHandle) (uint32, string) {
 	t.Helper()
 
 	osPid, processName, processInfoErr := tryGetProcessInfo(item)
@@ -213,7 +212,7 @@ func getProcessInfo(t *testing.T, item process.ProcessTreeItem) (uint32, string)
 	return osPid, processName
 }
 
-func tryGetProcessInfo(item process.ProcessTreeItem) (uint32, string, error) {
+func tryGetProcessInfo(item process.ProcessHandle) (uint32, string, error) {
 	osPid, pidErr := process.PidT_ToUint32(item.Pid)
 	if pidErr != nil {
 		return 0, "", fmt.Errorf("could not convert PID %d to Windows PID: %w", item.Pid, pidErr)
@@ -232,7 +231,7 @@ func tryGetProcessInfo(item process.ProcessTreeItem) (uint32, string, error) {
 	return osPid, processName, nil
 }
 
-func openProcessHandle(t *testing.T, item process.ProcessTreeItem) syscall.Handle {
+func openProcessHandle(t *testing.T, item process.ProcessHandle) syscall.Handle {
 	t.Helper()
 
 	osPid, pidErr := process.PidT_ToUint32(item.Pid)
@@ -243,13 +242,13 @@ func openProcessHandle(t *testing.T, item process.ProcessTreeItem) syscall.Handl
 	return handle
 }
 
-func requireDelayDescendant(t *testing.T, root process.ProcessTreeItem, timeout time.Duration) process.ProcessTreeItem {
+func requireDelayDescendant(t *testing.T, root process.ProcessHandle, timeout time.Duration) process.ProcessHandle {
 	t.Helper()
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	var descendant process.ProcessTreeItem
+	var descendant process.ProcessHandle
 	pollErr := wait.PollUntilContextCancel(waitCtx, 100*time.Millisecond, true,
 		func(_ context.Context) (bool, error) {
 			tree, treeErr := process.GetProcessTree(root)

--- a/internal/docker/cli_orchestrator.go
+++ b/internal/docker/cli_orchestrator.go
@@ -689,7 +689,7 @@ func (dco *DockerCliOrchestrator) ExecContainer(ctx context.Context, options con
 	}
 
 	dco.log.V(1).Info("Running Docker command", "Command", cmd.String())
-	_, _, startWaitForProcessExit, err := dco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
+	_, startWaitForProcessExit, err := dco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
 	if err != nil {
 		close(exitCh)
 		return nil, errors.Join(err, fmt.Errorf("failed to start Docker command '%s'", "ExecContainer"))
@@ -1129,13 +1129,13 @@ func (dco *DockerCliOrchestrator) doWatchContainers(watcherCtx context.Context, 
 	// Container events are delivered on best-effort basis.
 	// If the "docker events" command fails unexpectedly, we will log the error,
 	// but we won't try to restart it.
-	pid, startTime, startWaitForProcessExit, err := dco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := dco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
 	if err != nil {
 		dco.log.Error(err, "Could not execute 'docker events' command; container events unavailable")
 		return
 	}
 
-	dcpproc.RunProcessWatcher(dco.executor, pid, startTime, dco.log)
+	dcpproc.RunProcessWatcher(dco.executor, handle, dco.log)
 
 	startWaitForProcessExit()
 
@@ -1147,7 +1147,7 @@ func (dco *DockerCliOrchestrator) doWatchContainers(watcherCtx context.Context, 
 		}
 	case <-watcherCtx.Done():
 		// We are asked to shut down
-		dco.log.V(1).Info("Stopping 'docker events' command", "pid", pid)
+		dco.log.V(1).Info("Stopping 'docker events' command", "pid", handle.Pid)
 	}
 }
 
@@ -1188,13 +1188,13 @@ func (dco *DockerCliOrchestrator) doWatchNetworks(watcherCtx context.Context, ss
 	// Container events are delivered on best-effort basis.
 	// If the "docker events" command fails unexpectedly, we will log the error,
 	// but we won't try to restart it.
-	pid, startTime, startWaitForProcessExit, err := dco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := dco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
 	if err != nil {
 		dco.log.Error(err, "Could not execute 'docker events' command; network events unavailable")
 		return
 	}
 
-	dcpproc.RunProcessWatcher(dco.executor, pid, startTime, dco.log)
+	dcpproc.RunProcessWatcher(dco.executor, handle, dco.log)
 
 	startWaitForProcessExit()
 
@@ -1206,7 +1206,7 @@ func (dco *DockerCliOrchestrator) doWatchNetworks(watcherCtx context.Context, ss
 		}
 	case <-watcherCtx.Done():
 		// We are asked to shut down
-		dco.log.V(1).Info("Stopping 'docker events' command", "PID", pid)
+		dco.log.V(1).Info("Stopping 'docker events' command", "PID", handle.Pid)
 	}
 }
 
@@ -1241,14 +1241,14 @@ func (dco *DockerCliOrchestrator) streamDockerCommand(
 	}
 
 	dco.log.V(1).Info("Running Docker command", "Command", cmd.String())
-	pid, startTime, startWaitForProcessExit, err := dco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := dco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
 	if err != nil {
 		close(exitCh)
 		return nil, errors.Join(err, fmt.Errorf("failed to start Docker command '%s'", commandName))
 	}
 
 	if opts&streamCommandOptionUseWatcher != 0 {
-		dcpproc.RunProcessWatcher(dco.executor, pid, startTime, dco.log)
+		dcpproc.RunProcessWatcher(dco.executor, handle, dco.log)
 	}
 
 	startWaitForProcessExit()

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -62,8 +62,7 @@ func persistentExecutableOutputBaseDir() string {
 }
 
 type processRunState struct {
-	pid          process.Pid_t
-	identityTime time.Time
+	handle process.ProcessHandle
 
 	// File handles for the process's output (applicable to non-terminal processes)
 	stdOutFile *os.File
@@ -205,7 +204,7 @@ func (r *ProcessExecutableRunner) startProcessRun(
 		}
 	})
 
-	pid, processIdentityTime, startWaitForProcessExit, startErr := r.pe.StartProcess(processCtx, cmd, processExitHandler, creationFlags, nil)
+	handle, startWaitForProcessExit, startErr := r.pe.StartProcess(processCtx, cmd, processExitHandler, creationFlags, nil)
 	if startErr != nil {
 		startLog.Error(startErr, "Failed to start a process")
 		result.CompletionTimestamp = metav1.NowMicro()
@@ -225,24 +224,22 @@ func (r *ProcessExecutableRunner) startProcessRun(
 		runChangeHandler.OnStartupCompleted(exe.NamespacedName(), result)
 		return result
 	}
+	r.runExecutableLifecycleMonitor(exe, handle, startLog)
 
-	r.runExecutableLifecycleMonitor(exe, pid, processIdentityTime, startLog)
-
-	r.runningProcesses.Store(pidToRunID(pid), &processRunState{
-		pid:              pid,
-		identityTime:     processIdentityTime,
+	r.runningProcesses.Store(pidToRunID(handle.Pid), &processRunState{
+		handle:           handle,
 		stdOutFile:       stdOutFile,
 		stdErrFile:       stdErrFile,
 		cmdInfo:          cmd.String(),
 		runChangeHandler: runChangeHandler,
 	})
 
-	displayStartTime := process.StartTimeForProcess(pid)
-	result.RunID = pidToRunID(pid)
-	pointers.SetValue(&result.Pid, int64(pid))
+	displayStartTime := process.StartTimeForProcess(handle.Pid)
+	result.RunID = pidToRunID(handle.Pid)
+	pointers.SetValue(&result.Pid, int64(handle.Pid))
 	result.ExeState = apiv1.ExecutableStateRunning
 	result.CompletionTimestamp = metav1.NewMicroTime(displayStartTime)
-	result.ProcessIdentityTime = processIdentityTime
+	result.ProcessIdentityTime = handle.IdentityTime
 	result.StartWaitForRunCompletion = startWaitForProcessExit
 
 	runChangeHandler.OnStartupCompleted(exe.NamespacedName(), result)
@@ -332,12 +329,12 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 		return result
 	}
 
-	runID := pidToRunID(ptp.PID)
-	r.runExecutableLifecycleMonitor(exe, ptp.PID, ptp.IdentityTime, startLog)
+	handle := ptp.Handle
+	runID := pidToRunID(handle.Pid)
+	r.runExecutableLifecycleMonitor(exe, handle, startLog)
 
 	r.runningProcesses.Store(runID, &processRunState{
-		pid:              ptp.PID,
-		identityTime:     ptp.IdentityTime,
+		handle:           handle,
 		ptp:              ptp,
 		connMgr:          connMgr,
 		cmdInfo:          cmd.String(),
@@ -348,12 +345,12 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 	// resources, and notify the run-change handler.
 	go r.watchTerminalRunExit(processCtx, runID, ptp, runChangeHandler, startLog)
 
-	displayStartTime := process.StartTimeForProcess(ptp.PID)
+	displayStartTime := process.StartTimeForProcess(handle.Pid)
 	result.RunID = runID
-	pointers.SetValue(&result.Pid, int64(ptp.PID))
+	pointers.SetValue(&result.Pid, int64(handle.Pid))
 	result.ExeState = apiv1.ExecutableStateRunning
 	result.CompletionTimestamp = metav1.NewMicroTime(displayStartTime)
-	result.ProcessIdentityTime = ptp.IdentityTime
+	result.ProcessIdentityTime = handle.IdentityTime
 	result.StartWaitForRunCompletion = ptp.StartWaitForExit
 	result.TerminalSocketPath = connMgr.SocketPath()
 
@@ -432,10 +429,11 @@ func (r *ProcessExecutableRunner) AdoptRun(
 		return fmt.Errorf("cannot adopt process run %s without process identity time", runID)
 	}
 
-	if findErr := r.pe.CheckProcessRunning(record.PID, record.IdentityTime); findErr != nil {
+	handle := record.ProcessHandle()
+	if findErr := r.pe.CheckProcessRunning(handle); findErr != nil {
 		return fmt.Errorf("cannot adopt process run %s: %w", runID, findErr)
 	}
-	r.runExecutableLifecycleMonitor(exe, record.PID, record.IdentityTime, log)
+	r.runExecutableLifecycleMonitor(exe, handle, log)
 
 	stopWatching := make(chan struct{})
 	var stopWatchingOnce sync.Once
@@ -446,30 +444,28 @@ func (r *ProcessExecutableRunner) AdoptRun(
 	}
 
 	r.runningProcesses.Store(runID, &processRunState{
-		pid:              record.PID,
-		identityTime:     record.IdentityTime,
+		handle:           handle,
 		cmdInfo:          exe.Spec.ExecutablePath,
 		adopted:          true,
 		cancelWatch:      cancelWatch,
 		runChangeHandler: runChangeHandler,
 	})
 
-	go r.watchAdoptedProcess(runID, record.PID, record.IdentityTime, stopWatching, log)
+	go r.watchAdoptedProcess(runID, handle, stopWatching, log)
 
 	return nil
 }
 
 func (r *ProcessExecutableRunner) runExecutableLifecycleMonitor(
 	exe *apiv1.Executable,
-	pid process.Pid_t,
-	identityTime time.Time,
+	handle process.ProcessHandle,
 	log logr.Logger,
 ) {
 	effectiveMode := exe.Spec.EffectiveMode()
 	switch {
 	case effectiveMode.ShouldStopProcessOnDelete():
 		// Use original log here, the watcher is a different process.
-		dcpproc.RunProcessWatcher(r.pe, pid, identityTime, log)
+		dcpproc.RunProcessWatcher(r.pe, handle, log)
 		return
 
 	case effectiveMode == apiv1.ExecutableModePersistent:
@@ -483,7 +479,7 @@ func (r *ProcessExecutableRunner) runExecutableLifecycleMonitor(
 		}
 
 		// Use original log here, the watcher is a different process.
-		dcpproc.RunProcessWatcherForMonitor(r.pe, monitor, pid, identityTime, log)
+		dcpproc.RunProcessWatcherForMonitor(r.pe, monitor, handle, log)
 
 	default:
 		return
@@ -510,17 +506,15 @@ func (r *ProcessExecutableRunner) StopPersistentProcess(ctx context.Context, exe
 	}
 
 	return r.stopProcessRunState(ctx, runID, &processRunState{
-		pid:          record.PID,
-		identityTime: record.IdentityTime,
-		cmdInfo:      exe.Spec.ExecutablePath,
-		adopted:      true,
+		handle:  record.ProcessHandle(),
+		cmdInfo: exe.Spec.ExecutablePath,
+		adopted: true,
 	}, log)
 }
 
 func (r *ProcessExecutableRunner) watchAdoptedProcess(
 	runID controllers.RunID,
-	pid process.Pid_t,
-	identityTime time.Time,
+	handle process.ProcessHandle,
 	stopWatching <-chan struct{},
 	log logr.Logger,
 ) {
@@ -533,12 +527,12 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 			return
 
 		case <-timer.C:
-			if findErr := r.pe.CheckProcessRunning(pid, identityTime); findErr != nil {
+			if findErr := r.pe.CheckProcessRunning(handle); findErr != nil {
 				runState, found := r.runningProcesses.Load(runID)
 				if !found {
 					return
 				}
-				if runState.pid != pid || !runState.identityTime.Equal(identityTime) {
+				if runState.handle != handle {
 					return
 				}
 				if !r.runningProcesses.CompareAndDelete(runID, runState) {
@@ -551,7 +545,7 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 					runState.runChangeHandler.OnRunCompleted(runID, apiv1.UnknownExitCode, waitErr)
 				}
 				if waitErr != nil {
-					log.Error(waitErr, "Error watching adopted process", "RunID", runID, "PID", runState.pid)
+					log.Error(waitErr, "Error watching adopted process", "RunID", runID, "PID", runState.handle.Pid)
 				}
 				return
 			}
@@ -560,8 +554,8 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 	}
 }
 
-func (r *ProcessExecutableRunner) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
-	return r.pe.CheckProcessRunning(pid, processStartTime)
+func (r *ProcessExecutableRunner) CheckProcessRunning(handle process.ProcessHandle) error {
+	return r.pe.CheckProcessRunning(handle)
 }
 
 func (r *ProcessExecutableRunner) StopRun(ctx context.Context, runID controllers.RunID, log logr.Logger) error {
@@ -595,9 +589,9 @@ func (r *ProcessExecutableRunner) stopProcessRunState(ctx context.Context, runID
 			// This means we cannot send Ctrl-C to that process directly and need to use dcpproc StopProcessTree facility instead.
 			stopCtx, stopCtxCancel := context.WithTimeout(ctx, ProcessStopTimeout)
 			defer stopCtxCancel()
-			errCh <- dcpproc.StopProcessTree(stopCtx, r.pe, runState.pid, runState.identityTime, stopLog)
+			errCh <- dcpproc.StopProcessTree(stopCtx, r.pe, runState.handle, stopLog)
 		} else {
-			errCh <- r.pe.StopProcess(runState.pid, runState.identityTime)
+			errCh <- r.pe.StopProcess(runState.handle)
 		}
 	}()
 

--- a/internal/exerunners/process_executable_runner.go
+++ b/internal/exerunners/process_executable_runner.go
@@ -38,6 +38,8 @@ const (
 	DCP_PERSISTENT_EXECUTABLE_OUTPUT_DIR = "DCP_PERSISTENT_EXECUTABLE_OUTPUT_DIR"
 
 	persistentExecutableOutputDirName = "dcp-peo"
+
+	defaultProcessCleanupTimeout = 2 * time.Second
 )
 
 var persistentExecutableOutputDir = func() (string, error) {
@@ -195,7 +197,7 @@ func (r *ProcessExecutableRunner) startProcessRun(
 		runID := pidToRunID(pid)
 
 		if runState, found := r.runningProcesses.LoadAndDelete(runID); found {
-			err = errors.Join(closeProcessRunResources(runState), err)
+			err = errors.Join(closeRunFiles(nil, runState), err)
 		}
 
 		if runChangeHandler != nil {
@@ -260,7 +262,7 @@ func (r *ProcessExecutableRunner) startProcessRun(
 // is reachable only for non-persistent Executables; we still honor the
 // creationFlags / processCtx returned by makeProcessCommand for consistency.
 func (r *ProcessExecutableRunner) startTerminalRun(
-	ctx context.Context,
+	_ context.Context,
 	processCtx context.Context,
 	exe *apiv1.Executable,
 	cmd *exec.Cmd,
@@ -304,6 +306,7 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 	ptp, startErr := r.terminalProcessFactory(processCtx, r.pe, commandSpec)
 	if startErr != nil {
 		startLog.Error(startErr, "Failed to start a process attached to a pseudo-terminal")
+		connMgr.Shutdown()
 		result.CompletionTimestamp = metav1.NowMicro()
 		result.ExeState = apiv1.ExecutableStateFailedToStart
 		result.StartupError = startErr
@@ -321,6 +324,7 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 		if closeErr := ptp.PTY.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
 			startLog.Error(closeErr, "Failed to close PTY after terminal connection manager creation failure")
 		}
+		connMgr.Shutdown()
 		result.CompletionTimestamp = metav1.NowMicro()
 		result.ExeState = apiv1.ExecutableStateFailedToStart
 		result.StartupError = attachErr
@@ -342,7 +346,7 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 
 	// Watch for process exit so we can deregister the run, tear down the PTY/ConnManager
 	// resources, and notify the run-change handler.
-	go r.watchTerminalRunExit(processCtx, runID, ptp, connMgr, runChangeHandler, startLog)
+	go r.watchTerminalRunExit(processCtx, runID, ptp, runChangeHandler, startLog)
 
 	displayStartTime := process.StartTimeForProcess(ptp.PID)
 	result.RunID = runID
@@ -351,12 +355,9 @@ func (r *ProcessExecutableRunner) startTerminalRun(
 	result.CompletionTimestamp = metav1.NewMicroTime(displayStartTime)
 	result.ProcessIdentityTime = ptp.IdentityTime
 	result.StartWaitForRunCompletion = ptp.StartWaitForExit
+	result.TerminalSocketPath = connMgr.SocketPath()
 
 	runChangeHandler.OnStartupCompleted(exe.NamespacedName(), result)
-
-	// Reference the unused ctx parameter (kept for symmetry with startProcessRun and to
-	// allow future extensions that may need the caller-supplied context).
-	_ = ctx
 
 	return result
 }
@@ -373,7 +374,6 @@ func (r *ProcessExecutableRunner) watchTerminalRunExit(
 	processCtx context.Context,
 	runID controllers.RunID,
 	ptp *termpty.PseudoTerminalProcess,
-	connMgr *termpty.ConnManager,
 	runChangeHandler controllers.RunChangeHandler,
 	log logr.Logger,
 ) {
@@ -393,19 +393,11 @@ func (r *ProcessExecutableRunner) watchTerminalRunExit(
 	var closeErr error
 	if runState, found := r.runningProcesses.LoadAndDelete(runID); found {
 		// We are the first to observe the exit (no concurrent StopRun/ReleaseRun);
-		// own the resource cleanup. If StopRun/ReleaseRun already deleted the state,
-		// they also took care of closing the PTY and waiting on ConnManager — skip both.
-		closeErr = closeProcessRunResources(runState)
-		if closeErr != nil {
-			log.Error(closeErr, "Failed to close terminal run resources after process exit", "RunID", runID)
-		}
+		// need to do resource cleanup.
 
-		// Wait for the ConnManager to fully shut down so socket-file cleanup is observable
-		// to callers (notably tests). ConnManager triggers its own shutdown when it observes
-		// the process exit, so this should resolve promptly.
-		select {
-		case <-connMgr.Done():
-		case <-processCtx.Done():
+		closeErr = closeRunFiles(nil, runState)
+		if closeErr != nil {
+			log.Error(closeErr, "Failed to close files associated with Executable process after process exited", "RunID", runID)
 		}
 	}
 
@@ -553,7 +545,8 @@ func (r *ProcessExecutableRunner) watchAdoptedProcess(
 					return
 				}
 
-				waitErr := closeProcessRunResources(runState)
+				waitErr := closeRunFiles(nil, runState)
+
 				if runState.runChangeHandler != nil {
 					runState.runChangeHandler.OnRunCompleted(runID, apiv1.UnknownExitCode, waitErr)
 				}
@@ -616,8 +609,7 @@ func (r *ProcessExecutableRunner) stopProcessRunState(ctx context.Context, runID
 		stopErr = fmt.Errorf("timed out waiting for process associated with run %s to stop", runID)
 	}
 
-	stopErr = errors.Join(stopErr, closeProcessRunResources(runState))
-	waitForConnManagerShutdown(ctx, runState, stopLog)
+	stopErr = errors.Join(stopErr, closeRunFiles(ctx, runState))
 
 	if stopErr != nil {
 		stopLog.Error(stopErr, "Failed to stop run")
@@ -637,41 +629,25 @@ func (r *ProcessExecutableRunner) ReleaseRun(ctx context.Context, runID controll
 		runState.cancelWatch()
 	}
 
-	closeErr := closeProcessRunResources(runState)
+	closeErr := closeRunFiles(ctx, runState)
 	if closeErr != nil {
 		log.Error(closeErr, "Could not close process run resources while releasing run", "RunID", runID)
 	}
-	waitForConnManagerShutdown(ctx, runState, log)
 	return closeErr
 }
 
-// waitForConnManagerShutdown waits for a terminal run's ConnManager to finish
-// shutting down (i.e. close its listener and any in-flight Serve loop, after
-// which its background goroutines have terminated). It is a no-op for
-// non-terminal runs. The wait is bounded by the supplied context so callers do
-// not block indefinitely on a misbehaving manager.
-//
-// Note: ConnManager does not own the UDS socket file lifecycle, so the file
-// at SocketPath() is not removed as part of shutdown.
-func waitForConnManagerShutdown(ctx context.Context, runState *processRunState, log logr.Logger) {
-	if runState.connMgr == nil {
-		return
-	}
-	select {
-	case <-runState.connMgr.Done():
-	case <-ctx.Done():
-		log.V(1).Info("Context cancelled while waiting for terminal connection manager to shut down")
-	}
-}
-
-// closeProcessRunResources releases the OS resources owned by a process run:
-// the stdout/stderr capture files (for non-terminal runs) and the PTY (for
-// terminal runs). It is safe to call multiple times. The ConnManager owned by
-// a terminal run is NOT closed here — its lifetime is governed by its parent
-// context and by process-exit observation; callers that need to observe its
-// shutdown should wait on connMgr.Done().
-func closeProcessRunResources(runState *processRunState) error {
+// closeRunFiles closes files associated with a process run
+// (including the pseudo-terminal the process is using, if any).
+// The passed context is used to control the timeout of the cleanup operation.
+// If nil, a default timeout of 2 seconds is used.
+func closeRunFiles(ctx context.Context, runState *processRunState) error {
 	var closeErr error
+	if ctx == nil {
+		var ctxCancel context.CancelFunc
+		ctx, ctxCancel = context.WithTimeout(context.Background(), defaultProcessCleanupTimeout)
+		defer ctxCancel()
+	}
+
 	for _, file := range []*os.File{runState.stdOutFile, runState.stdErrFile} {
 		if file != nil {
 			fileErr := file.Close()
@@ -686,6 +662,16 @@ func closeProcessRunResources(runState *processRunState) error {
 			closeErr = errors.Join(closeErr, ptyErr)
 		}
 	}
+
+	if runState.connMgr != nil {
+		runState.connMgr.Shutdown()
+		select {
+		case <-runState.connMgr.Done():
+		case <-ctx.Done():
+			closeErr = errors.Join(closeErr, fmt.Errorf("context cancelled while waiting for terminal connection manager to shut down: %w", ctx.Err()))
+		}
+	}
+
 	return closeErr
 }
 

--- a/internal/exerunners/process_executable_runner_test.go
+++ b/internal/exerunners/process_executable_runner_test.go
@@ -226,13 +226,13 @@ func TestAdoptedProcessStopUsesAdoptedPID(t *testing.T) {
 	processExecutor := testutil.NewTestProcessExecutor(ctx)
 	runner := NewProcessExecutableRunner(processExecutor)
 	runner.disableConsoleStop = true // We are just simulating the run, so stopping via dcpproc/console would fail.
-	pid, identityTime, _, startErr := processExecutor.StartProcess(ctx, exec.Command("./delay", "--delay=1s"), nil, process.CreationFlagsNone, nil)
+	handle, _, startErr := processExecutor.StartProcess(ctx, exec.Command("./delay", "--delay=1s"), nil, process.CreationFlagsNone, nil)
 	require.NoError(t, startErr)
+	pid := handle.Pid
 	adoptedRunID := controllers.RunID(pidToRunID(pid + 1))
 	changeHandler := newRecordingRunChangeHandler()
 	runner.runningProcesses.Store(adoptedRunID, &processRunState{
-		pid:              pid,
-		identityTime:     identityTime,
+		handle:           handle,
 		cmdInfo:          "./delay --delay=1s",
 		adopted:          true,
 		runChangeHandler: changeHandler,
@@ -294,12 +294,13 @@ func TestAdoptedProcessStartsLifecycleMonitor(t *testing.T) {
 
 			processExecutor := testutil.NewTestProcessExecutor(ctx)
 			runner := NewProcessExecutableRunner(processExecutor)
-			pid, identityTime, _, startErr := processExecutor.StartProcess(ctx, exec.Command("/test/app"), nil, process.CreationFlagsNone, nil)
+			handle, _, startErr := processExecutor.StartProcess(ctx, exec.Command("/test/app"), nil, process.CreationFlagsNone, nil)
 			require.NoError(t, startErr)
+			pid := handle.Pid
 			runID := pidToRunID(pid)
 			t.Cleanup(func() {
 				_ = runner.ReleaseRun(context.Background(), runID, logr.Discard())
-				_ = processExecutor.StopProcess(pid, identityTime)
+				_ = processExecutor.StopProcess(handle)
 			})
 
 			exe := &apiv1.Executable{
@@ -313,7 +314,7 @@ func TestAdoptedProcessStartsLifecycleMonitor(t *testing.T) {
 			record := &statestore.PersistentProcessRecord{
 				RunID:        string(runID),
 				PID:          pid,
-				IdentityTime: identityTime,
+				IdentityTime: handle.IdentityTime,
 			}
 
 			adoptErr := runner.AdoptRun(ctx, exe, record, newRecordingRunChangeHandler(), logr.Discard())
@@ -339,10 +340,10 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 
 	processExecutor := testutil.NewTestProcessExecutor(ctx)
 	cmd := exec.Command("./delay", "--delay=1s")
-	pid, identityTime, _, startProcessErr := processExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	handle, _, startProcessErr := processExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
 	require.NoError(t, startProcessErr)
 	runner := NewProcessExecutableRunner(processExecutor)
-	runID := pidToRunID(pid)
+	runID := pidToRunID(handle.Pid)
 	changeHandler := newRecordingRunChangeHandler()
 	exe := &apiv1.Executable{
 		Spec: apiv1.ExecutableSpec{
@@ -351,14 +352,14 @@ func TestAdoptedProcessReportsCompletionWhenProcessExits(t *testing.T) {
 	}
 	record := &statestore.PersistentProcessRecord{
 		RunID:        string(runID),
-		PID:          pid,
-		IdentityTime: identityTime,
+		PID:          handle.Pid,
+		IdentityTime: handle.IdentityTime,
 	}
 
 	adoptErr := runner.AdoptRun(ctx, exe, record, changeHandler, logr.Discard())
 	require.NoError(t, adoptErr)
 
-	processExecutor.SimulateProcessExit(t, pid, 0)
+	processExecutor.SimulateProcessExit(t, handle.Pid, 0)
 
 	select {
 	case completedRun := <-changeHandler.completedRuns:
@@ -384,14 +385,14 @@ func TestAdoptedProcessWatcherDoesNotDeleteReusedRunID(t *testing.T) {
 	watchedIdentityTime := time.Unix(1, 0).UTC()
 	reusedIdentityTime := watchedIdentityTime.Add(time.Minute)
 	changeHandler := newRecordingRunChangeHandler()
+	watchedHandle := process.NewHandle(watchedPID, watchedIdentityTime)
 	reusedRunState := &processRunState{
-		pid:              watchedPID,
-		identityTime:     reusedIdentityTime,
+		handle:           process.NewHandle(watchedPID, reusedIdentityTime),
 		runChangeHandler: changeHandler,
 	}
 	runner.runningProcesses.Store(runID, reusedRunState)
 
-	runner.watchAdoptedProcess(runID, watchedPID, watchedIdentityTime, make(chan struct{}), logr.Discard())
+	runner.watchAdoptedProcess(runID, watchedHandle, make(chan struct{}), logr.Discard())
 
 	storedRunState, found := runner.runningProcesses.Load(runID)
 	require.True(t, found)

--- a/internal/hosting/command_service.go
+++ b/internal/hosting/command_service.go
@@ -79,7 +79,7 @@ func (s *CommandService) Run(ctx context.Context) error {
 	pic := make(chan process.ProcessExitInfo, 1)
 	peh := process.NewChannelProcessExitHandler(pic)
 
-	_, _, startWaitForProcessExit, startErr := s.executor.StartProcess(runCtx, s.cmd, peh, process.CreationFlagsNone, nil)
+	_, startWaitForProcessExit, startErr := s.executor.StartProcess(runCtx, s.cmd, peh, process.CreationFlagsNone, nil)
 	if startErr != nil {
 		return startErr
 	}

--- a/internal/notifications/notification_source.go
+++ b/internal/notifications/notification_source.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"sync/atomic"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/microsoft/dcp/internal/notifications/proto"
 	"github.com/microsoft/dcp/pkg/concurrency"
 	"github.com/microsoft/dcp/pkg/grpcutil"
+	"github.com/microsoft/dcp/pkg/osutil"
 )
 
 var (
@@ -40,7 +40,7 @@ type unixSocketNotificationSource struct {
 	lock        *sync.Mutex
 
 	// The Unix domain socket listener for incoming connections.
-	listener *net.UnixListener
+	listener *osutil.UnixSocketListener
 
 	// Subscriptions are just long-lived gRPC calls returning a stream of notifications.
 	// Each channel gets an unbounded channel for sending notifications to the client/subscriber.

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -20,12 +18,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/microsoft/dcp/internal/dcppaths"
 	"github.com/microsoft/dcp/internal/notifications/proto"
 	"github.com/microsoft/dcp/pkg/concurrency"
 	"github.com/microsoft/dcp/pkg/grpcutil"
 	"github.com/microsoft/dcp/pkg/osutil"
-	"github.com/microsoft/dcp/pkg/randdata"
 )
 
 type NotificationKind string
@@ -129,49 +125,6 @@ func asNotification(nd *proto.NotificationData) (Notification, error) {
 	}
 }
 
-// A helper function that ensures the notification socket can be created
-// in a folder that is writable only by the current user, and that the path
-// is reasonably unique to the calling process.
-// If the `rootDir` is empty, it will use the user's cache directory.
-func PrepareNotificationSocketPath(rootDir string, socketNamePrefix string) (string, error) {
-	if rootDir == "" {
-		cacheDir, cacheDirErr := os.UserCacheDir()
-		if cacheDirErr != nil {
-			return "", fmt.Errorf("failed to get user cache directory when creating a notification socket: %w", cacheDirErr)
-		} else {
-			rootDir = cacheDir
-		}
-	}
-
-	socketDir := filepath.Join(rootDir, dcppaths.DcpWorkDir)
-	if err := os.MkdirAll(socketDir, osutil.PermissionOnlyOwnerReadWriteTraverse); err != nil {
-		return "", fmt.Errorf("failed to create directory for notification socket: %w", err)
-	}
-
-	// On Windows the user cache directory always exists and is always private to the user,
-	// but on Unix-like systems, we need to ensure the directory is private.
-	if !osutil.IsWindows() {
-		info, infoErr := os.Stat(socketDir)
-		if infoErr != nil {
-			return "", fmt.Errorf("failed to check permissions on the notification socket directory: %w", infoErr)
-		}
-		if !info.IsDir() {
-			return "", fmt.Errorf("notification socket path %s is not a directory", socketDir)
-		}
-		if info.Mode().Perm() != osutil.PermissionOnlyOwnerReadWriteTraverse {
-			return "", fmt.Errorf("notification socket directory %s is not private to the user", socketDir)
-		}
-	}
-
-	suffix, suffixErr := randdata.MakeRandomString(8)
-	if suffixErr != nil {
-		return "", fmt.Errorf("failed to create random string for notification socket path suffix: %w", suffixErr)
-	}
-
-	socketPath := filepath.Join(socketDir, socketNamePrefix+string(suffix))
-	return socketPath, nil
-}
-
 // NotificationSubscription represents a subscription to notifications.
 type NotificationSubscription interface {
 	Active() bool // True if the subscription is active and receiving notifications.
@@ -218,16 +171,18 @@ type UnixSocketNotificationSource interface {
 	SocketPath() string
 }
 
-func NewNotificationSource(lifetimeCtx context.Context, socketPath string, log logr.Logger) (UnixSocketNotificationSource, error) {
-	listener, listenErr := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+// NewNotificationSource creates a notification source that listens on a random
+// Unix domain socket in a private per-program directory.
+func NewNotificationSource(lifetimeCtx context.Context, rootDir string, socketNamePrefix string, log logr.Logger) (UnixSocketNotificationSource, error) {
+	listener, listenErr := osutil.CreateRandomUnixSocketListener(rootDir, socketNamePrefix)
 	if listenErr != nil {
-		return nil, fmt.Errorf("could not create notification socket at %s: %w", socketPath, listenErr)
+		return nil, fmt.Errorf("could not create notification socket: %w", listenErr)
 	}
 
 	ns := &unixSocketNotificationSource{
 		lifetimeCtx:     lifetimeCtx,
 		log:             log,
-		socketPath:      socketPath,
+		socketPath:      listener.SocketPath(),
 		lock:            &sync.Mutex{},
 		listener:        listener,
 		subscriptions:   make(map[uint32]*concurrency.UnboundedChan[Notification]),

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -32,12 +32,11 @@ func TestNotificationSendReceive(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultNotificationsTestTimeout)
 	defer cancel()
 
-	socketPath, socketPathErr := PrepareNotificationSocketPath(testutil.TestTempDir(), "test-notification-socket-")
-	require.NoError(t, socketPathErr)
-	nsi, nsErr := NewNotificationSource(ctx, socketPath, sourceLog)
+	nsi, nsErr := NewNotificationSource(ctx, testutil.TestTempDir(), "test-notification-socket-", sourceLog)
 	require.NoError(t, nsErr)
 	require.NotNil(t, nsi)
 	usns := nsi.(*unixSocketNotificationSource)
+	socketPath := nsi.SocketPath()
 
 	const numNotifications = 10
 	notes := make(chan Notification, numNotifications)
@@ -85,12 +84,11 @@ func TestNotificationMultipleReceivers(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, defaultNotificationsTestTimeout)
 	defer cancel()
 
-	socketPath, socketPathErr := PrepareNotificationSocketPath(testutil.TestTempDir(), "test-notification-socket-")
-	require.NoError(t, socketPathErr)
-	ns, err := NewNotificationSource(ctx, socketPath, testLog)
+	ns, err := NewNotificationSource(ctx, testutil.TestTempDir(), "test-notification-socket-", testLog)
 	require.NoError(t, err)
 	require.NotNil(t, ns)
 	usns := ns.(*unixSocketNotificationSource)
+	socketPath := ns.SocketPath()
 
 	// Start with two receivers
 	r1Ctx, r1CtxCancel := context.WithCancel(ctx)

--- a/internal/podman/cli_orchestrator.go
+++ b/internal/podman/cli_orchestrator.go
@@ -675,7 +675,7 @@ func (pco *PodmanCliOrchestrator) ExecContainer(ctx context.Context, options con
 	}
 
 	pco.log.V(1).Info("Running Podman command", "Command", cmd.String())
-	_, _, startWaitForProcessExit, err := pco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
+	_, startWaitForProcessExit, err := pco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
 	if err != nil {
 		close(exitCh)
 		return nil, errors.Join(err, fmt.Errorf("failed to start Podman command '%s'", "ExecContainer"))
@@ -1120,13 +1120,13 @@ func (pco *PodmanCliOrchestrator) doWatchContainers(watcherCtx context.Context, 
 	// Container events are delivered on best-effort basis.
 	// If the "podman events" command fails unexpectedly, we will log the error,
 	// but we won't try to restart it.
-	pid, startTime, startWaitForProcessExit, err := pco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := pco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
 	if err != nil {
 		pco.log.Error(err, "Could not execute 'podman events' command; container events unavailable")
 		return
 	}
 
-	dcpproc.RunProcessWatcher(pco.executor, pid, startTime, pco.log)
+	dcpproc.RunProcessWatcher(pco.executor, handle, pco.log)
 
 	startWaitForProcessExit()
 
@@ -1138,7 +1138,7 @@ func (pco *PodmanCliOrchestrator) doWatchContainers(watcherCtx context.Context, 
 		}
 	case <-watcherCtx.Done():
 		// We are asked to shut down
-		pco.log.V(1).Info("Stopping 'podman events' command", "PID", pid)
+		pco.log.V(1).Info("Stopping 'podman events' command", "PID", handle.Pid)
 	}
 }
 
@@ -1180,13 +1180,13 @@ func (pco *PodmanCliOrchestrator) doWatchNetworks(watcherCtx context.Context, ss
 	// Container events are delivered on best-effort basis.
 	// If the "podman events" command fails unexpectedly, we will log the error,
 	// but we won't try to restart it.
-	pid, startTime, startWaitForProcessExit, err := pco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := pco.executor.StartProcess(watcherCtx, cmd, peh, process.CreationFlagsNone, nil)
 	if err != nil {
 		pco.log.Error(err, "Could not execute 'podman events' command; network events unavailable")
 		return
 	}
 
-	dcpproc.RunProcessWatcher(pco.executor, pid, startTime, pco.log)
+	dcpproc.RunProcessWatcher(pco.executor, handle, pco.log)
 
 	startWaitForProcessExit()
 
@@ -1198,7 +1198,7 @@ func (pco *PodmanCliOrchestrator) doWatchNetworks(watcherCtx context.Context, ss
 		}
 	case <-watcherCtx.Done():
 		// We are asked to shut down
-		pco.log.V(1).Info("Stopping 'podman events' command", "PID", pid)
+		pco.log.V(1).Info("Stopping 'podman events' command", "PID", handle.Pid)
 	}
 }
 
@@ -1233,14 +1233,14 @@ func (pco *PodmanCliOrchestrator) streamPodmanCommand(
 	}
 
 	pco.log.V(1).Info("Running podman command", "Command", cmd.String())
-	pid, startTime, startWaitForProcessExit, err := pco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
+	handle, startWaitForProcessExit, err := pco.executor.StartProcess(ctx, cmd, process.ProcessExitHandlerFunc(exitHandler), process.CreationFlagsNone, nil)
 	if err != nil {
 		close(exitCh)
 		return nil, errors.Join(err, fmt.Errorf("failed to start podman command '%s'", commandName))
 	}
 
 	if opts&streamCommandOptionUseWatcher != 0 {
-		dcpproc.RunProcessWatcher(pco.executor, pid, startTime, pco.log)
+		dcpproc.RunProcessWatcher(pco.executor, handle, pco.log)
 	}
 
 	startWaitForProcessExit()

--- a/internal/statestore/lease_owner.go
+++ b/internal/statestore/lease_owner.go
@@ -11,52 +11,52 @@ import (
 	"github.com/microsoft/dcp/pkg/process"
 )
 
-func CurrentResourceLeaseOwner() (process.ProcessTreeItem, error) {
+func CurrentResourceLeaseOwner() (process.ProcessHandle, error) {
 	currentProcess, currentProcessErr := process.This()
 	if currentProcessErr != nil {
-		return process.ProcessTreeItem{}, fmt.Errorf("could not get current process identity: %w", currentProcessErr)
+		return process.ProcessHandle{}, fmt.Errorf("could not get current process identity: %w", currentProcessErr)
 	}
 
 	return normalizeResourceLeaseOwner(currentProcess)
 }
 
-func normalizeResourceLeaseOwner(owner process.ProcessTreeItem) (process.ProcessTreeItem, error) {
+func normalizeResourceLeaseOwner(owner process.ProcessHandle) (process.ProcessHandle, error) {
 	if owner.Pid <= 0 {
-		return process.ProcessTreeItem{}, fmt.Errorf("resource lease owner process ID must be positive")
+		return process.ProcessHandle{}, fmt.Errorf("resource lease owner process ID must be positive")
 	}
 	if owner.IdentityTime.IsZero() {
-		return process.ProcessTreeItem{}, fmt.Errorf("resource lease owner process identity time cannot be zero")
+		return process.ProcessHandle{}, fmt.Errorf("resource lease owner process identity time cannot be zero")
 	}
 
-	return process.ProcessTreeItem{
+	return process.ProcessHandle{
 		Pid:          owner.Pid,
 		IdentityTime: owner.IdentityTime.UTC(),
 	}, nil
 }
 
-func resourceLeaseOwnerFromDB(ownerPID int64, ownerIdentityTime string) (process.ProcessTreeItem, error) {
+func resourceLeaseOwnerFromDB(ownerPID int64, ownerIdentityTime string) (process.ProcessHandle, error) {
 	pid, pidConvertErr := process.Int64_ToPidT(ownerPID)
 	if pidConvertErr != nil {
-		return process.ProcessTreeItem{}, fmt.Errorf("could not convert resource lease owner process ID: %w", pidConvertErr)
+		return process.ProcessHandle{}, fmt.Errorf("could not convert resource lease owner process ID: %w", pidConvertErr)
 	}
 	identityTime, identityTimeErr := timeFromString(ownerIdentityTime)
 	if identityTimeErr != nil {
-		return process.ProcessTreeItem{}, fmt.Errorf("could not parse resource lease owner process identity time: %w", identityTimeErr)
+		return process.ProcessHandle{}, fmt.Errorf("could not parse resource lease owner process identity time: %w", identityTimeErr)
 	}
 
-	owner := process.ProcessTreeItem{
+	owner := process.ProcessHandle{
 		Pid:          pid,
 		IdentityTime: identityTime,
 	}
 	return normalizeResourceLeaseOwner(owner)
 }
 
-func resourceLeaseOwnerIsActive(owner process.ProcessTreeItem) bool {
+func resourceLeaseOwnerIsActive(owner process.ProcessHandle) bool {
 	normalizedOwner, normalizeErr := normalizeResourceLeaseOwner(owner)
 	if normalizeErr != nil {
 		return false
 	}
 
-	_, findErr := process.FindProcess(normalizedOwner.Pid, normalizedOwner.IdentityTime)
+	_, findErr := process.FindProcess(normalizedOwner)
 	return findErr == nil
 }

--- a/internal/statestore/leases.go
+++ b/internal/statestore/leases.go
@@ -23,7 +23,7 @@ var (
 
 type ResourceLease struct {
 	ResourceKey  string
-	OwnerProcess process.ProcessTreeItem
+	OwnerProcess process.ProcessHandle
 	UpdatedAt    time.Time
 	store        *Store
 }
@@ -76,7 +76,7 @@ func resourceLeaseKey(resource LeasableResource) (string, error) {
 	return resourceKey, nil
 }
 
-func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessTreeItem, revalidationInterval time.Duration) (*ResourceLease, error) {
+func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessHandle, revalidationInterval time.Duration) (*ResourceLease, error) {
 	resourceKey, resourceKeyErr := resourceLeaseKey(resource)
 	if resourceKeyErr != nil {
 		return nil, resourceKeyErr
@@ -152,7 +152,7 @@ func (s *Store) AcquireResourceLease(ctx context.Context, resource LeasableResou
 	return lease, nil
 }
 
-func (s *Store) ReleaseResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessTreeItem) error {
+func (s *Store) ReleaseResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessHandle) error {
 	resourceKey, resourceKeyErr := resourceLeaseKey(resource)
 	if resourceKeyErr != nil {
 		return resourceKeyErr
@@ -160,7 +160,7 @@ func (s *Store) ReleaseResourceLease(ctx context.Context, resource LeasableResou
 	return s.releaseResourceLease(ctx, resourceKey, ownerProcess)
 }
 
-func (s *Store) releaseResourceLease(ctx context.Context, resourceKey string, ownerProcess process.ProcessTreeItem) error {
+func (s *Store) releaseResourceLease(ctx context.Context, resourceKey string, ownerProcess process.ProcessHandle) error {
 	resourceKey = strings.TrimSpace(resourceKey)
 	if resourceKey == "" {
 		return fmt.Errorf("%w: resource lease key cannot be empty", ErrInvalidArgument)
@@ -196,7 +196,7 @@ func (s *Store) releaseResourceLease(ctx context.Context, resourceKey string, ow
 	})
 }
 
-func (s *Store) VerifyResourceLeaseHeld(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessTreeItem) error {
+func (s *Store) VerifyResourceLeaseHeld(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessHandle) error {
 	resourceKey, resourceKeyErr := resourceLeaseKey(resource)
 	if resourceKeyErr != nil {
 		return resourceKeyErr
@@ -238,7 +238,7 @@ func (s *Store) VerifyResourceLeaseHeld(ctx context.Context, resource LeasableRe
 	return nil
 }
 
-func (s *Store) WithResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessTreeItem, revalidationInterval time.Duration, f func(context.Context, *ResourceLease) error) error {
+func (s *Store) WithResourceLease(ctx context.Context, resource LeasableResource, ownerProcess process.ProcessHandle, revalidationInterval time.Duration, f func(context.Context, *ResourceLease) error) error {
 	if f == nil {
 		return fmt.Errorf("%w: lease callback cannot be nil", ErrInvalidArgument)
 	}
@@ -385,7 +385,7 @@ func updateResourceLeaseTimestamp(ctx context.Context, conn *sql.Conn, resourceK
 	return nil
 }
 
-func updateResourceLeaseOwner(ctx context.Context, conn *sql.Conn, resourceKey string, ownerProcess process.ProcessTreeItem, now time.Time) error {
+func updateResourceLeaseOwner(ctx context.Context, conn *sql.Conn, resourceKey string, ownerProcess process.ProcessHandle, now time.Time) error {
 	_, execErr := conn.ExecContext(
 		ctx,
 		`UPDATE resource_locks

--- a/internal/statestore/processes.go
+++ b/internal/statestore/processes.go
@@ -31,6 +31,10 @@ type PersistentProcessRecord struct {
 	store             *Store
 }
 
+func (r PersistentProcessRecord) ProcessHandle() process.ProcessHandle {
+	return process.NewHandle(r.PID, r.IdentityTime)
+}
+
 func (r *PersistentProcessRecord) Delete(ctx context.Context) error {
 	if r == nil {
 		return fmt.Errorf("%w: persistent process record cannot be nil", ErrInvalidArgument)

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -119,12 +119,12 @@ func createUnversionedCurrentSchema(t *testing.T, ctx context.Context, path stri
 	require.NoError(t, execErr)
 }
 
-func testResourceLeaseOwner(t *testing.T, identityOffset time.Duration) (process.ProcessTreeItem, error) {
+func testResourceLeaseOwner(t *testing.T, identityOffset time.Duration) (process.ProcessHandle, error) {
 	t.Helper()
 
 	currentProcess, currentProcessErr := process.This()
 	if currentProcessErr != nil {
-		return process.ProcessTreeItem{}, currentProcessErr
+		return process.ProcessHandle{}, currentProcessErr
 	}
 
 	currentProcess.IdentityTime = currentProcess.IdentityTime.Add(identityOffset)
@@ -357,7 +357,7 @@ func TestResourceLeasePreservesOutOfUnixNanoRangeOwnerIdentityTime(t *testing.T)
 	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
 	store := openTestStore(t, ctx, storePath)
 
-	owner, ownerErr := normalizeResourceLeaseOwner(process.ProcessTreeItem{
+	owner, ownerErr := normalizeResourceLeaseOwner(process.ProcessHandle{
 		Pid:          process.Pid_t(1234),
 		IdentityTime: time.Date(1, time.January, 1, 0, 3, 10, 720000000, time.UTC),
 	})
@@ -453,7 +453,7 @@ func TestResourceLeaseCanBeAcquiredFromInactiveOwnerAfterRevalidationInterval(t 
 
 	currentProcess, currentProcessErr := process.This()
 	require.NoError(t, currentProcessErr)
-	staleOwner, staleOwnerErr := normalizeResourceLeaseOwner(process.ProcessTreeItem{
+	staleOwner, staleOwnerErr := normalizeResourceLeaseOwner(process.ProcessHandle{
 		Pid:          currentProcess.Pid,
 		IdentityTime: currentProcess.IdentityTime.Add(-time.Hour),
 	})
@@ -509,7 +509,7 @@ func TestDeleteInactiveResourceLeasesUsesOwnerProcessIdentity(t *testing.T) {
 	require.NoError(t, currentProcessErr)
 	activeOwner, activeOwnerErr := normalizeResourceLeaseOwner(currentProcess)
 	require.NoError(t, activeOwnerErr)
-	staleOwner, staleOwnerErr := normalizeResourceLeaseOwner(process.ProcessTreeItem{
+	staleOwner, staleOwnerErr := normalizeResourceLeaseOwner(process.ProcessHandle{
 		Pid:          currentProcess.Pid,
 		IdentityTime: currentProcess.IdentityTime.Add(-time.Hour),
 	})

--- a/internal/termpty/conn_manager.go
+++ b/internal/termpty/conn_manager.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/microsoft/dcp/pkg/concurrency"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
+	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/resiliency"
 )
 
@@ -30,6 +32,10 @@ const (
 
 	// reconnectMinInterval bounds how frequently the manager will re-dial the peer in connect mode.
 	reconnectMinInterval = 500 * time.Millisecond
+
+	// terminalSocketNamePrefix is prepended to the random suffix when DCP generates a listen-mode
+	// terminal socket path because the spec left UDSPath empty.
+	terminalSocketNamePrefix = "term-sock-"
 )
 
 // SocketMode selects how a ConnManager establishes the HMP v1 connection over its Unix domain socket.
@@ -72,7 +78,7 @@ type ConnManager struct {
 
 	// Listener for the incoming HMP v1 connections.
 	// Only used when socketMode == SocketModeListen
-	listener *net.UnixListener
+	listener *osutil.UnixSocketListener
 
 	// ctx is an internal context cancelled when the manager begins to shut
 	// down (because the lifetime context was cancelled, because the process
@@ -84,9 +90,7 @@ type ConnManager struct {
 	// Runs shutdown code at most once.
 	shutdownOnce func()
 
-	// done is closed when the accept loop has fully terminated, which
-	// happens after any in-progress Serve has returned and the listener has
-	// been closed.
+	// done is closed when the ConnManager is fully shut down.
 	done chan struct{}
 }
 
@@ -98,6 +102,12 @@ type ConnManager struct {
 // In either case the manager will connect to- (SocketModeConnect)
 // or listen on- (SocketModeListen) the client socket immediately,
 // but the terminal data will flow only after the process is available.
+//
+// In listen mode socketPath may be empty, in which case the manager generates a
+// unique path in the DCP session/temp folder and owns the socket file (creating
+// it and removing it on shutdown). When socketPath is provided, it must not already
+// exist; a file already present at the path is treated as an error. The resolved
+// path is available via SocketPath(). In connect mode socketPath is required.
 func NewConnManager(
 	lifetimeCtx context.Context,
 	ptp *PseudoTerminalProcess,
@@ -110,7 +120,7 @@ func NewConnManager(
 	if lifetimeCtx == nil {
 		return nil, errors.New("lifetime context must not be nil")
 	}
-	if socketPath == "" {
+	if socketPath == "" && mode != SocketModeListen {
 		return nil, errors.New("socket path must not be empty")
 	}
 	// In eager mode the process must be valid up front; in attach-process mode
@@ -133,10 +143,7 @@ func NewConnManager(
 	} else {
 		cm.ptpP.Set(ptp)
 		go cm.watchProcessExit()
-		go func() {
-			defer close(cm.done)
-			cm.serveLoop(time.Time{})
-		}()
+		go cm.serveLoop(time.Time{})
 		return cm, nil
 	}
 }
@@ -149,21 +156,24 @@ func createConnManager(
 	initialRows uint16,
 	log logr.Logger,
 ) (*ConnManager, error) {
-	var listener *net.UnixListener
+	var listener *osutil.UnixSocketListener
 	if mode == SocketModeListen {
-		boundListener, listenErr := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
-		if listenErr != nil {
-			return nil, fmt.Errorf("could not create terminal socket at %s: %w", socketPath, listenErr)
+		var listenErr error
+		if socketPath == "" {
+			listener, listenErr = osutil.CreateRandomUnixSocketListener(usvc_io.DcpTempDir(), terminalSocketNamePrefix)
+			if listenErr != nil {
+				return nil, fmt.Errorf("could not create random terminal socket listener: %w", listenErr)
+			}
+			socketPath = listener.SocketPath()
+		} else {
+			listener, listenErr = osutil.CreateUnixSocketListener(socketPath)
+			if listenErr != nil {
+				return nil, fmt.Errorf("could not create terminal socket at %s: %w", socketPath, listenErr)
+			}
 		}
-
-		// Socket file lifecycle is owned by the caller, not by ConnManager.
-		// Without this opt-out, net.UnixListener.Close() would unlink the path.
-		boundListener.SetUnlinkOnClose(false)
-
-		listener = boundListener
 	}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
+	ctx, cancelCtx := context.WithCancel(lifetimeCtx)
 	initialCols, initialRows = NormalizeTerminalDimensions(initialCols, initialRows)
 
 	cm := &ConnManager{
@@ -185,8 +195,8 @@ func createConnManager(
 	} else {
 		cm.log.V(1).Info("Terminal connection manager is listening", "SocketPath", socketPath)
 	}
-
 	context.AfterFunc(lifetimeCtx, cm.shutdownOnce)
+
 	return cm, nil
 }
 
@@ -221,10 +231,18 @@ func (cm *ConnManager) AttachProcess(ptp *PseudoTerminalProcess) error {
 	return nil
 }
 
-// SocketPath returns the filesystem path of the Unix domain socket the
-// manager is (or was) listening on.
+// SocketPath returns the filesystem path of the Unix domain socket the manager
+// is (or was) listening on (or, in connect mode, dialing). When listen mode was
+// given an empty path at construction, this returns the path DCP generated.
 func (cm *ConnManager) SocketPath() string {
 	return cm.socketPath
+}
+
+// Shutdown deterministically tears down the manager: it terminates any active
+// Serve loop or pending dial and, in listen mode, removes the socket file and
+// closes the listener. It is idempotent and safe to call from any goroutine.
+func (cm *ConnManager) Shutdown() {
+	cm.shutdownOnce()
 }
 
 // Done returns a channel that is closed once the manager has fully
@@ -254,8 +272,6 @@ func (cm *ConnManager) watchProcessExit() {
 // process to be supplied via AttachProcess, then serves the warmed connection and
 // continues into the normal connection-serving loop.
 func (cm *ConnManager) prepareAndServe() {
-	defer close(cm.done)
-
 	conn, err := cm.nextConn()
 	if err != nil {
 		// Shutting down before any client connection could be established.
@@ -456,16 +472,13 @@ func (cm *ConnManager) serveConnection(conn net.Conn) {
 	wg.Wait()
 }
 
-// shutdown() is the manager's idempotent shutdown sequence. It cancels the
-// internal context (which terminates any in-progress Serve loop or pending
-// dial, and the underlying Hmp1Server's PTY reader worker) and, in listen mode,
-// closes the listener (which unblocks Accept). The socket file at socketPath is
-// intentionally left in place — in listen mode the caller owns its lifecycle,
-// and in connect mode the peer owns it.
-// Note: cm.done is closed when connLoop() exits.
+// shutdown() is the manager's shutdown sequence.
+// Idempotency is guaranteed via wrapping the method in a sync.Once.
 func (cm *ConnManager) shutdown() {
-	cm.log.V(1).Info("Shutting down terminal connection manager", "SocketPath", cm.socketPath)
+	cm.log.V(1).Info("Shutting down terminal connection manager...", "SocketPath", cm.socketPath)
+	defer close(cm.done)
 
+	// Cancels HMP1 server and any data exchange with the client.
 	cm.cancelCtx()
 
 	if cm.listener != nil {

--- a/internal/termpty/conn_manager_test.go
+++ b/internal/termpty/conn_manager_test.go
@@ -56,8 +56,7 @@ func newConnMgrFixture(t *testing.T) (context.Context, *PseudoTerminalProcess, *
 
 	ptp := &PseudoTerminalProcess{
 		PTY:              pty,
-		PID:              process.Pid_t(12345),
-		IdentityTime:     time.Now(),
+		Handle:           process.NewHandle(process.Pid_t(12345), time.Now()),
 		StartWaitForExit: func() {},
 		ExitHandler:      process.NewConcurrentProcessExitHandler(),
 	}
@@ -277,7 +276,7 @@ func TestConnManager_ListenMode_RemovesSocketFileOnProcessExit(t *testing.T) {
 	_, statErr := os.Stat(socketPath)
 	require.NoError(t, statErr, "listen mode should create the socket file")
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -362,7 +361,7 @@ func TestConnManager_ListenMode_GeneratesSocketPathWhenEmpty(t *testing.T) {
 	hello := drainHelloAndStateSync(t, ctx, conn)
 	require.Equal(t, 1, hello.Version)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -408,7 +407,7 @@ func TestConnManager_AcceptsAndServesClient(t *testing.T) {
 	require.Equal(t, "hello-client", string(payload))
 
 	// Tear down by simulating process exit; manager should shut down.
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -430,7 +429,7 @@ func TestConnManager_HelloAdvertisesConfiguredInitialSize(t *testing.T) {
 	require.Equal(t, uint16(132), hello.Width)
 	require.Equal(t, uint16(50), hello.Height)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -467,7 +466,7 @@ func TestConnManager_ReusableAcrossSequentialConnections(t *testing.T) {
 	runSession("third")
 
 	// Shut down by cancelling lifetime via process exit.
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -531,7 +530,7 @@ func TestConnManager_ProcessExitShutsDownManager(t *testing.T) {
 	require.NoError(t, err)
 
 	// Process exits BEFORE any client connects.
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 7, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 7, nil)
 
 	select {
 	case <-cm.Done():
@@ -588,7 +587,7 @@ func TestConnManager_ExitCodePropagatedToClient(t *testing.T) {
 	// PTY-read pump unblocks with EOF (mimicking what the OS does when the
 	// child closes the slave fd). This triggers the exit-frame send path.
 	const wantExit int32 = 99
-	ptp.ExitHandler.OnProcessExited(ptp.PID, wantExit, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, wantExit, nil)
 	_ = pty.Close()
 
 	payload := drainUntilExit(t, ctx, conn)
@@ -695,7 +694,7 @@ func TestConnManager_ConnectModeDialsPeerAndServes(t *testing.T) {
 	require.Equal(t, "hello-client", string(payload))
 
 	// Tear down by simulating process exit; manager should shut down.
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -722,7 +721,7 @@ func TestConnManager_ConnectModeStartsWithoutPeerThenDials(t *testing.T) {
 	conn := acceptPeer(t, ctx, peer)
 	drainHelloAndStateSync(t, ctx, conn)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -760,7 +759,7 @@ func TestConnManager_ConnectModeReconnectsAfterSessionEnds(t *testing.T) {
 	runSession("second")
 	runSession("third")
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -798,7 +797,7 @@ func TestConnManager_ConnectModeProcessExitWhileDialingShutsDown(t *testing.T) {
 	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeConnect, 0, 0, log)
 	require.NoError(t, err)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 7, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 7, nil)
 
 	select {
 	case <-cm.Done():
@@ -867,7 +866,7 @@ func TestConnManager_ConnectModeAcceptThenCloseDoesNotHotLoop(t *testing.T) {
 		"connect mode hot-looped: %d accepts in %s (max expected %d)", got, window, maxExpected)
 
 	// Shut down cleanly.
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -938,7 +937,7 @@ func TestConnManager_AttachProcessListenMode_WarmsThenServesAfterAttach(t *testi
 	require.Equal(t, Hmp1FrameOutput, ft)
 	require.Equal(t, "hello-client", string(payload))
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -973,7 +972,7 @@ func TestConnManager_AttachProcessConnectMode_WarmsThenServesAfterAttach(t *test
 		t.Fatal("timed out waiting for client input to reach PTY")
 	}
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -1005,7 +1004,7 @@ func TestConnManager_AttachProcessMode_AttachBeforeClientConnects(t *testing.T) 
 		t.Fatal("timed out waiting for client input to reach PTY")
 	}
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -1046,7 +1045,7 @@ func TestConnManager_AttachProcessMode_ReconnectsAfterFirstSession(t *testing.T)
 		t.Fatal("timed out waiting for second session input")
 	}
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -1069,7 +1068,7 @@ func TestConnManager_AttachProcessMode_HelloAdvertisesConfiguredSize(t *testing.
 	require.Equal(t, uint16(132), hello.Width)
 	require.Equal(t, uint16(50), hello.Height)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -1152,7 +1151,7 @@ func TestConnManager_AttachProcessMode_ClientDisconnectsBeforeAttachThenRecovers
 		t.Fatal("timed out waiting for fresh client input after recovery")
 	}
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():
@@ -1263,7 +1262,7 @@ func TestConnManager_AttachProcessConnectMode_RedialThrottledAfterImmediateClose
 	require.LessOrEqualf(t, got, maxExpected,
 		"attach-process connect mode hot-looped: %d accepts in %s (max expected %d)", got, window, maxExpected)
 
-	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	ptp.ExitHandler.OnProcessExited(ptp.Handle.Pid, 0, nil)
 	select {
 	case <-cm.Done():
 	case <-ctx.Done():

--- a/internal/termpty/conn_manager_test.go
+++ b/internal/termpty/conn_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	internal_testutil "github.com/microsoft/dcp/internal/testutil"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/process"
 	usvc_random "github.com/microsoft/dcp/pkg/randdata"
 	"github.com/microsoft/dcp/pkg/testutil"
@@ -154,8 +156,9 @@ func TestNewConnManager_RejectsInvalidArgs(t *testing.T) {
 	ctx, ptp, _, socketPath := newConnMgrFixture(t)
 	log := testutil.NewLogForTesting(t.Name())
 
-	t.Run("empty socket path", func(t *testing.T) {
-		_, err := NewConnManager(ctx, ptp, "", SocketModeListen, 0, 0, log)
+	t.Run("empty socket path in connect mode", func(t *testing.T) {
+		// In listen mode an empty path is allowed (DCP generates one); connect mode still requires it.
+		_, err := NewConnManager(ctx, ptp, "", SocketModeConnect, 0, 0, log)
 		require.Error(t, err)
 	})
 
@@ -186,6 +189,187 @@ func TestNewConnManager_FailsWhenSocketPathInUse(t *testing.T) {
 	second, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
 	require.Error(t, err, "expected error creating second manager on same socket")
 	require.Nil(t, second)
+}
+
+// --- Listen-mode socket file ownership ---
+
+// makeStaleSocketFile binds and immediately closes a Unix listener at path
+// (opting out of unlink-on-close), leaving a leftover socket file behind with no
+// live listener, as a crashed process would.
+func makeStaleSocketFile(t *testing.T, path string) {
+	t.Helper()
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	require.NoErrorf(t, err, "create stale socket at %s", path)
+	l.SetUnlinkOnClose(false)
+	require.NoError(t, l.Close())
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "stale socket file should remain after listener close")
+}
+
+// requireFileRemoved asserts that nothing exists at path.
+func requireFileRemoved(t *testing.T, path string) {
+	t.Helper()
+	_, statErr := os.Stat(path)
+	require.Truef(t, errors.Is(statErr, os.ErrNotExist), "expected %s to be removed, stat error was %v", path, statErr)
+}
+
+// TestConnManager_ListenMode_RefusesExistingSocketFile verifies that listen mode
+// refuses to bind when a leftover socket file is already present at the path and
+// leaves the existing file intact.
+func TestConnManager_ListenMode_RefusesExistingSocketFile(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	makeStaleSocketFile(t, socketPath)
+
+	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.Error(t, err, "listen mode must refuse an existing socket file")
+	require.Nil(t, cm)
+
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "existing socket file must not be removed")
+}
+func TestConnManager_ListenMode_DoesNotClobberActiveListener(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	// A live listener owns the path; it must survive a failed construction.
+	startPeerListener(t, socketPath)
+
+	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.Error(t, err, "listen mode must not bind over an active listener")
+	require.Nil(t, cm)
+
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "active listener socket file must not be removed")
+}
+
+// TestConnManager_ListenMode_RefusesDirectoryPath verifies that listen mode
+// never removes a directory that happens to sit at the socket path.
+func TestConnManager_ListenMode_RefusesDirectoryPath(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	require.NoError(t, os.Mkdir(socketPath, 0o700))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.Error(t, err, "listen mode must refuse a directory at the socket path")
+	require.Nil(t, cm)
+
+	info, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "directory must not be removed")
+	require.True(t, info.IsDir())
+}
+
+// TestConnManager_ListenMode_RemovesSocketFileOnProcessExit verifies that the
+// owned socket file is removed when the underlying process exits.
+func TestConnManager_ListenMode_RemovesSocketFileOnProcessExit(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.NoError(t, err)
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "listen mode should create the socket file")
+
+	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	select {
+	case <-cm.Done():
+	case <-ctx.Done():
+		t.Fatal("ConnManager did not become dormant after process exit")
+	}
+
+	requireFileRemoved(t, socketPath)
+}
+
+// TestConnManager_ListenMode_RemovesSocketFileOnLifetimeCancel verifies that the
+// owned socket file is removed when the lifetime context is cancelled.
+func TestConnManager_ListenMode_RemovesSocketFileOnLifetimeCancel(t *testing.T) {
+	t.Parallel()
+	parentCtx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	lifetimeCtx, lifetimeCancel := context.WithCancel(parentCtx)
+	defer lifetimeCancel()
+
+	cm, err := NewConnManager(lifetimeCtx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.NoError(t, err)
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr)
+
+	lifetimeCancel()
+	select {
+	case <-cm.Done():
+	case <-parentCtx.Done():
+		t.Fatal("ConnManager did not become dormant after lifetime cancel")
+	}
+
+	requireFileRemoved(t, socketPath)
+}
+
+// TestConnManager_ListenMode_ShutdownRemovesSocketFile verifies that the public
+// Shutdown() method removes the owned socket file and is idempotent.
+func TestConnManager_ListenMode_ShutdownRemovesSocketFile(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, socketPath := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	cm, err := NewConnManager(ctx, ptp, socketPath, SocketModeListen, 0, 0, log)
+	require.NoError(t, err)
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr)
+
+	cm.Shutdown()
+	select {
+	case <-cm.Done():
+	case <-ctx.Done():
+		t.Fatal("ConnManager did not become dormant after Shutdown")
+	}
+
+	requireFileRemoved(t, socketPath)
+
+	require.NotPanics(t, func() { cm.Shutdown() }, "Shutdown must be idempotent")
+}
+
+// TestConnManager_ListenMode_GeneratesSocketPathWhenEmpty verifies that an empty
+// socket path in listen mode causes DCP to generate a unique path under the DCP
+// temp dir, report it via SocketPath(), serve on it, and remove it on shutdown.
+func TestConnManager_ListenMode_GeneratesSocketPathWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ctx, ptp, _, _ := newConnMgrFixture(t)
+	log := testutil.NewLogForTesting(t.Name())
+
+	cm, err := NewConnManager(ctx, ptp, "", SocketModeListen, 0, 0, log)
+	require.NoError(t, err, "listen mode must generate a socket path when none is supplied")
+
+	generatedPath := cm.SocketPath()
+	require.NotEmpty(t, generatedPath, "generated socket path must be reported via SocketPath()")
+	t.Cleanup(func() { _ = os.Remove(generatedPath) })
+
+	require.Truef(t, strings.HasPrefix(generatedPath, usvc_io.DcpTempDir()),
+		"generated socket path %q should live under the DCP temp dir %q", generatedPath, usvc_io.DcpTempDir())
+
+	_, statErr := os.Stat(generatedPath)
+	require.NoError(t, statErr, "generated socket file should exist while running")
+
+	// It must serve a client like any other listen-mode socket.
+	conn := dialConnMgr(t, ctx, generatedPath)
+	hello := drainHelloAndStateSync(t, ctx, conn)
+	require.Equal(t, 1, hello.Version)
+
+	ptp.ExitHandler.OnProcessExited(ptp.PID, 0, nil)
+	select {
+	case <-cm.Done():
+	case <-ctx.Done():
+		t.Fatal("ConnManager did not become dormant after process exit")
+	}
+
+	requireFileRemoved(t, generatedPath)
 }
 
 // --- Normal serve ---

--- a/internal/termpty/conpty_windows.go
+++ b/internal/termpty/conpty_windows.go
@@ -127,7 +127,7 @@ func startProcessWithTerminal(ctx context.Context, pe process.Executor, spec *Co
 	}
 
 	exitHandler := process.NewConcurrentProcessExitHandler()
-	pid, startTime, startWait, startErr := pe.StartProcess(
+	handle, startWait, startErr := pe.StartProcess(
 		ctx,
 		spec.Cmd,
 		exitHandler,
@@ -149,8 +149,7 @@ func startProcessWithTerminal(ctx context.Context, pe process.Executor, spec *Co
 			otherHandles: []windows.Handle{inputRead, outputWrite},
 			lock:         &sync.Mutex{},
 		},
-		PID:              pid,
-		IdentityTime:     startTime,
+		Handle:           handle,
 		StartWaitForExit: startWait,
 		ExitHandler:      exitHandler,
 		Executor:         pe,

--- a/internal/termpty/pty.go
+++ b/internal/termpty/pty.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"math"
 	"os/exec"
-	"time"
 
 	"github.com/microsoft/dcp/pkg/process"
 )
@@ -44,11 +43,8 @@ type PseudoTerminalProcess struct {
 	// The pseudo-terminal for the process.
 	PTY PTY
 
-	// The PID of the process.
-	PID process.Pid_t
-
-	// Identity time for identifying the process.
-	IdentityTime time.Time
+	// Handle identifies the process.
+	Handle process.ProcessHandle
 
 	// StartWaitForExit is a function that starts waiting for the process to exit.
 	StartWaitForExit func()
@@ -65,7 +61,7 @@ func (ptp *PseudoTerminalProcess) Stop(options ...process.ProcessStopOption) err
 	if ptp.Executor == nil {
 		return errors.New("process executor is not available, cannot stop process") // Should never happen
 	}
-	return ptp.Executor.StopProcess(ptp.PID, ptp.IdentityTime, options...)
+	return ptp.Executor.StopProcess(ptp.Handle, options...)
 }
 
 // CommandSpec captures data needed to spawn a command attached to a freshly allocated pseudo-terminal.

--- a/internal/termpty/pty_unix.go
+++ b/internal/termpty/pty_unix.go
@@ -169,7 +169,7 @@ func startProcessWithTerminal(ctx context.Context, pe process.Executor, spec *Co
 	}
 
 	exitHandler := process.NewConcurrentProcessExitHandler()
-	pid, startTime, startWait, startErr := pe.StartProcess(ctx, cmd, exitHandler, spec.CreationFlags, nil)
+	handle, startWait, startErr := pe.StartProcess(ctx, cmd, exitHandler, spec.CreationFlags, nil)
 	if startErr != nil {
 		_ = pty.Close() // best effort
 		return nil, fmt.Errorf("failed to start process: %w", startErr)
@@ -185,8 +185,7 @@ func startProcessWithTerminal(ctx context.Context, pe process.Executor, spec *Co
 
 	ptp := PseudoTerminalProcess{
 		PTY:              pty,
-		PID:              pid,
-		IdentityTime:     startTime,
+		Handle:           handle,
 		StartWaitForExit: startWait,
 		ExitHandler:      exitHandler,
 		Executor:         pe,

--- a/internal/testutil/ctrlutil/apiserver_start.go
+++ b/internal/testutil/ctrlutil/apiserver_start.go
@@ -242,14 +242,14 @@ func StartApiServer(
 		info.ApiServerExited.SetAndFreeze()
 	})
 
-	apiServerPID, _, startWaitForProcessExit, dcpStartErr := pe.StartProcess(testRunCtx, cmd, apiserverExitHandler, process.CreationFlagsNone, nil)
+	apiServerHandle, startWaitForProcessExit, dcpStartErr := pe.StartProcess(testRunCtx, cmd, apiserverExitHandler, process.CreationFlagsNone, nil)
 	if dcpStartErr != nil {
 		info.ApiServerExited.SetAndFreeze()
 		cleanup()
 		return nil, fmt.Errorf("failed to start the API server process: %w", dcpStartErr)
 	}
 	startWaitForProcessExit()
-	info.ApiServerPID = apiServerPID
+	info.ApiServerPID = apiServerHandle.Pid
 
 	// Using generous timeout because AzDO pipeline machines can be very slow at times.
 	const configCreationTimeout = 70 * time.Second

--- a/internal/testutil/ctrlutil/test_container_attach_dispatcher.go
+++ b/internal/testutil/ctrlutil/test_container_attach_dispatcher.go
@@ -106,7 +106,7 @@ func (d *ContainerAttachFactoryDispatcher) InstallHandler(
 		}
 		if tp, ok := result.PTY.(*testutil.TestPty); ok {
 			select {
-			case ch <- &AttachedTerminalInfo{TestPty: tp, Pid: result.PID}:
+			case ch <- &AttachedTerminalInfo{TestPty: tp, Pid: result.Handle.Pid}:
 			default:
 				// Channel buffer full — the caller is only expected to read once.
 			}
@@ -158,7 +158,7 @@ func NewTestPtyContainerAttachFactory(pe process.Executor) ContainerAttachFactor
 		testPty := testutil.NewTestPty()
 		exitHandler := process.NewConcurrentProcessExitHandler()
 
-		pid, startTime, startWait, startErr := pe.StartProcess(
+		handle, startWait, startErr := pe.StartProcess(
 			ctx,
 			placeholderAttachCommand(containerName),
 			exitHandler,
@@ -172,8 +172,7 @@ func NewTestPtyContainerAttachFactory(pe process.Executor) ContainerAttachFactor
 
 		return &termpty.PseudoTerminalProcess{
 			PTY:              testPty,
-			PID:              pid,
-			IdentityTime:     startTime,
+			Handle:           handle,
 			StartWaitForExit: startWait,
 			ExitHandler:      exitHandler,
 			Executor:         pe,

--- a/internal/testutil/ctrlutil/test_container_orchestrator.go
+++ b/internal/testutil/ctrlutil/test_container_orchestrator.go
@@ -1726,7 +1726,7 @@ func (to *TestContainerOrchestrator) fireAttachExitHandlers(container *testConta
 			// Already fired by another path (e.g. TestProcessExecutor.StopProcess).
 			continue
 		default:
-			tproc.ExitHandler.OnProcessExited(tproc.PID, exitCode, nil)
+			tproc.ExitHandler.OnProcessExited(tproc.Handle.Pid, exitCode, nil)
 		}
 	}
 }

--- a/internal/testutil/ctrlutil/test_process_executable_runner.go
+++ b/internal/testutil/ctrlutil/test_process_executable_runner.go
@@ -167,13 +167,13 @@ func (r *TestProcessExecutableRunner) StopPersistentProcess(ctx context.Context,
 	return persistentRunner.StopPersistentProcess(ctx, exe, record, log)
 }
 
-func (r *TestProcessExecutableRunner) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
+func (r *TestProcessExecutableRunner) CheckProcessRunning(handle process.ProcessHandle) error {
 	persistentRunner, ok := r.inner.(controllers.PersistentExecutableRunner)
 	if !ok {
 		return fmt.Errorf("inner test process runner does not support persistent process liveness checks")
 	}
 
-	return persistentRunner.CheckProcessRunning(pid, processStartTime)
+	return persistentRunner.CheckProcessRunning(handle)
 }
 
 var _ controllers.ExecutableRunner = (*TestProcessExecutableRunner)(nil)

--- a/internal/testutil/ctrlutil/test_terminal_dispatcher.go
+++ b/internal/testutil/ctrlutil/test_terminal_dispatcher.go
@@ -122,7 +122,7 @@ func NewTestPtyTerminalFactory() termpty.TerminalProcessFactory {
 		testPty := testutil.NewTestPty()
 		exitHandler := process.NewConcurrentProcessExitHandler()
 
-		pid, startTime, startWait, startErr := pe.StartProcess(ctx, spec.Cmd, exitHandler, spec.CreationFlags, nil)
+		handle, startWait, startErr := pe.StartProcess(ctx, spec.Cmd, exitHandler, spec.CreationFlags, nil)
 		if startErr != nil {
 			_ = testPty.Close()
 			return nil, startErr
@@ -130,8 +130,7 @@ func NewTestPtyTerminalFactory() termpty.TerminalProcessFactory {
 
 		return &termpty.PseudoTerminalProcess{
 			PTY:              testPty,
-			PID:              pid,
-			IdentityTime:     startTime,
+			Handle:           handle,
 			StartWaitForExit: startWait,
 			ExitHandler:      exitHandler,
 			Executor:         pe,

--- a/internal/testutil/process.go
+++ b/internal/testutil/process.go
@@ -21,7 +21,7 @@ import (
 	"github.com/microsoft/dcp/pkg/slices"
 )
 
-func EnsureProcessTree(t *testing.T, rootP process.ProcessTreeItem, expectedSize int, timeout time.Duration) {
+func EnsureProcessTree(t *testing.T, rootP process.ProcessHandle, expectedSize int, timeout time.Duration) {
 	processesStartedCtx, processesStartedCancelFn := context.WithTimeout(context.Background(), timeout)
 	defer processesStartedCancelFn()
 

--- a/internal/testutil/test_process_executor.go
+++ b/internal/testutil/test_process_executor.go
@@ -80,11 +80,11 @@ func (e *TestProcessExecutor) StartProcess(
 	handler process.ProcessExitHandler,
 	_ process.ProcessCreationFlag,
 	_ process.SysCreateProcessFunc,
-) (process.Pid_t, time.Time, func(), error) {
+) (process.ProcessHandle, func(), error) {
 	pid64 := atomic.AddInt64(&e.nextPID, 1)
 	pid, err := process.Int64_ToPidT(pid64)
 	if err != nil {
-		return process.UnknownPID, time.Time{}, nil, err
+		return process.ProcessHandle{Pid: process.UnknownPID}, nil, err
 	}
 
 	e.m.Lock()
@@ -131,17 +131,17 @@ func (e *TestProcessExecutor) StartProcess(
 	}
 
 	if autoExecutionErr := e.maybeAutoExecute(&pe); autoExecutionErr != nil {
-		return process.UnknownPID, time.Time{}, nil, autoExecutionErr
+		return process.ProcessHandle{Pid: process.UnknownPID}, nil, autoExecutionErr
 	}
 
-	return pid, startTimestamp, startWaitingForExit, nil
+	return process.NewHandle(pid, startTimestamp), startWaitingForExit, nil
 }
 
-func (e *TestProcessExecutor) StartAndForget(cmd *exec.Cmd, _ process.ProcessCreationFlag) (process.Pid_t, time.Time, error) {
+func (e *TestProcessExecutor) StartAndForget(cmd *exec.Cmd, _ process.ProcessCreationFlag) (process.ProcessHandle, error) {
 	pid64 := atomic.AddInt64(&e.nextPID, 1)
 	pid, err := process.Int64_ToPidT(pid64)
 	if err != nil {
-		return process.UnknownPID, time.Time{}, err
+		return process.ProcessHandle{Pid: process.UnknownPID}, err
 	}
 
 	e.m.Lock()
@@ -167,10 +167,10 @@ func (e *TestProcessExecutor) StartAndForget(cmd *exec.Cmd, _ process.ProcessCre
 	e.Executions = append(e.Executions, &pe)
 
 	if autoExecutionErr := e.maybeAutoExecute(&pe); autoExecutionErr != nil {
-		return process.UnknownPID, time.Time{}, autoExecutionErr
+		return process.ProcessHandle{Pid: process.UnknownPID}, autoExecutionErr
 	}
 
-	return pid, startTimestamp, nil
+	return process.NewHandle(pid, startTimestamp), nil
 }
 
 func (e *TestProcessExecutor) maybeAutoExecute(pe *ProcessExecution) error {
@@ -193,7 +193,7 @@ func (e *TestProcessExecutor) maybeAutoExecute(pe *ProcessExecution) error {
 						if !stopInitiated {
 							// RunCommand() "ended on its own" (as opposed to being triggered by StopProcess() or SimulateProcessExit()),
 							// so we need to do the resource cleanup.
-							stopProcessErr := e.stopProcessImpl(pe.PID, pe.StartedAt, exitCode)
+							stopProcessErr := e.stopProcessImpl(process.NewHandle(pe.PID, pe.StartedAt), exitCode)
 							if stopProcessErr != nil && ae.StopError == nil {
 								panic(fmt.Errorf("we should have an execution with PID=%d: %w", pe.PID, stopProcessErr))
 							}
@@ -209,29 +209,29 @@ func (e *TestProcessExecutor) maybeAutoExecute(pe *ProcessExecution) error {
 }
 
 // Called by the controller (via Executor interface)
-func (e *TestProcessExecutor) StopProcess(pid process.Pid_t, processStartTime time.Time, _ ...process.ProcessStopOption) error {
-	return e.stopProcessImpl(pid, processStartTime, KilledProcessExitCode)
+func (e *TestProcessExecutor) StopProcess(handle process.ProcessHandle, _ ...process.ProcessStopOption) error {
+	return e.stopProcessImpl(handle, KilledProcessExitCode)
 }
 
-func (e *TestProcessExecutor) CheckProcessRunning(pid process.Pid_t, processStartTime time.Time) error {
+func (e *TestProcessExecutor) CheckProcessRunning(handle process.ProcessHandle) error {
 	e.m.RLock()
 	defer e.m.RUnlock()
 
-	i := e.findByPid(pid)
+	i := e.findByPid(handle.Pid)
 	if i == NotFound {
-		return fmt.Errorf("no process with PID %d found", pid)
+		return fmt.Errorf("no process with PID %d found", handle.Pid)
 	}
 
 	execution := e.Executions[i]
-	if !processStartTime.IsZero() && !osutil.Within(processStartTime, execution.StartedAt, process.ProcessIdentityTimeMaximumDifference) {
+	if !handle.IdentityTime.IsZero() && !osutil.Within(handle.IdentityTime, execution.StartedAt, process.ProcessIdentityTimeMaximumDifference) {
 		return fmt.Errorf("process start time mismatch for PID %d: expected %s, actual %s",
-			pid,
-			processStartTime.Format(osutil.RFC3339MiliTimestampFormat),
+			handle.Pid,
+			handle.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
 			execution.StartedAt.Format(osutil.RFC3339MiliTimestampFormat),
 		)
 	}
 	if execution.Finished() {
-		return fmt.Errorf("process with PID %d is not running", pid)
+		return fmt.Errorf("process with PID %d is not running", handle.Pid)
 	}
 
 	return nil
@@ -239,7 +239,7 @@ func (e *TestProcessExecutor) CheckProcessRunning(pid process.Pid_t, processStar
 
 // Called by tests to simulate a process exit with specific exit code.
 func (e *TestProcessExecutor) SimulateProcessExit(t *testing.T, pid process.Pid_t, exitCode int32) {
-	err := e.stopProcessImpl(pid, time.Time{}, exitCode)
+	err := e.stopProcessImpl(process.NewHandle(pid, time.Time{}), exitCode)
 	if err != nil {
 		require.Failf(t, "invalid PID (test issue)", err.Error())
 	}
@@ -328,21 +328,21 @@ func (e *TestProcessExecutor) findByPid(pid process.Pid_t) int {
 	return NotFound
 }
 
-func (e *TestProcessExecutor) stopProcessImpl(pid process.Pid_t, processStartTime time.Time, exitCode int32) error {
+func (e *TestProcessExecutor) stopProcessImpl(handle process.ProcessHandle, exitCode int32) error {
 	e.m.Lock()
 
-	i := e.findByPid(pid)
+	i := e.findByPid(handle.Pid)
 	if i == NotFound {
 		e.m.Unlock()
-		return fmt.Errorf("no process with PID %d found", pid)
+		return fmt.Errorf("no process with PID %d found", handle.Pid)
 	}
 
-	if !processStartTime.IsZero() {
-		if !osutil.Within(processStartTime, e.Executions[i].StartedAt, process.ProcessIdentityTimeMaximumDifference) {
+	if !handle.IdentityTime.IsZero() {
+		if !osutil.Within(handle.IdentityTime, e.Executions[i].StartedAt, process.ProcessIdentityTimeMaximumDifference) {
 			e.m.Unlock()
 			return fmt.Errorf("process start time mismatch for PID %d: expected %s, actual %s",
-				pid,
-				processStartTime.Format(osutil.RFC3339MiliTimestampFormat),
+				handle.Pid,
+				handle.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
 				e.Executions[i].StartedAt.Format(osutil.RFC3339MiliTimestampFormat),
 			)
 		}
@@ -391,7 +391,7 @@ func (e *TestProcessExecutor) stopProcessImpl(pid process.Pid_t, processStartTim
 			case <-e.lifetimeCtx.Done():
 				return
 			case <-pe.startWaitingChan:
-				pe.ExitHandler.OnProcessExited(pid, exitCode, nil)
+				pe.ExitHandler.OnProcessExited(handle.Pid, exitCode, nil)
 			}
 		}()
 	}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1961,6 +1961,13 @@ func schema_microsoft_dcp_api_v1_ContainerStatus(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"terminalSocketPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The filesystem path of the terminal HMP v1 Unix domain socket, when the Container is configured with a terminal. In \"listen\" mode this is the socket DCP owns (and is the DCP-generated path when the spec left UDSPath empty); in \"connect\" mode it is the peer-owned socket DCP dials.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"exitCode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Exit code of the Container. Default is -1, meaning the exit code is not known, or the container is still running.",
@@ -3094,6 +3101,13 @@ func schema_microsoft_dcp_api_v1_ExecutableStatus(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"terminalSocketPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The filesystem path of the terminal HMP v1 Unix domain socket, when the Executable is configured with a terminal. In \"listen\" mode this is the socket DCP owns (and is the DCP-generated path when the spec left UDSPath empty); in \"connect\" mode it is the peer-owned socket DCP dials.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"effectiveEnv": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -3961,14 +3975,14 @@ func schema_microsoft_dcp_api_v1_TerminalSpec(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"udsPath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UDSPath is the Unix Domain Socket path used for the HMP v1 client connection. Required.",
+							Description: "Unix Domain Socket path used for the HMP v1 client connection. In \"listen\" mode UDSPath is optional: when empty, DCP chooses a unique socket path in the session/temp folder and reports the actual path in the resource Status. DCP owns the socket file in this mode (creates it and removes it on teardown); when UDSPath is provided it must not already exist, as DCP will not reuse or remove a pre-existing file. In \"connect\" mode UDSPath is required and refers to a socket the peer is listening on.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"socketMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SocketMode selects how DCP establishes the HMP v1 connection over UDSPath. \"listen\" (the default) means DCP listens on the socket and the client connects to it. \"connect\" means the client listens on the socket and DCP connects to it. The terminal data flow is identical in both modes; only connection establishment differs.",
+							Description: "SocketMode selects how DCP establishes the HMP v1 connection over UDSPath. \"listen\" (the default) means DCP listens on the socket and the client connects to it; DCP owns the socket file (creating and removing it). \"connect\" means the client listens on the socket (which it owns) and DCP connects to it. The terminal data flow is identical in both modes; only connection establishment differs.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/osutil/osutil_unix.go
+++ b/pkg/osutil/osutil_unix.go
@@ -11,6 +11,11 @@ import (
 	"os"
 )
 
+// MaxUnixSocketPathLen is a conservative upper bound on the length of a Unix
+// domain socket path. The kernel sun_path buffer is 108 bytes on Linux and 104
+// on macOS/BSD; we use the smaller limit minus one for the null terminator.
+const MaxUnixSocketPathLen = 103
+
 func IsAdmin() (bool, error) {
 	if os.Getuid() == 0 {
 		return true, nil

--- a/pkg/osutil/osutil_windows.go
+++ b/pkg/osutil/osutil_windows.go
@@ -11,6 +11,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// MaxUnixSocketPathLen is a conservative upper bound on the length of a Unix
+// domain socket path. The Windows UNIX_PATH_MAX is 108; we reserve one byte for
+// the null terminator.
+const MaxUnixSocketPathLen = 107
+
 func IsAdmin() (bool, error) {
 	// Get the actual token for the process
 	var processToken windows.Token

--- a/pkg/osutil/socket.go
+++ b/pkg/osutil/socket.go
@@ -1,0 +1,227 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package osutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/microsoft/dcp/pkg/concurrency"
+	"github.com/microsoft/dcp/pkg/randdata"
+)
+
+const (
+	socketPathRandomSuffixLength       = 8
+	randomSocketListenerCreateAttempts = 16
+)
+
+var errUnixSocketPathExists = errors.New("unix socket path already exists")
+
+// UnixSocketListener owns a Unix domain socket listener and its socket file.
+type UnixSocketListener struct {
+	listener        *net.UnixListener
+	socketPath      string
+	lock            *sync.Mutex
+	closed          bool
+	closeErrPromise *concurrency.ValuePromise[error]
+}
+
+var _ net.Listener = (*UnixSocketListener)(nil)
+
+// CreateRandomSocketPath builds a unique Unix domain socket path under a
+// per-program subfolder, creating that subfolder (private to the current user)
+// as necessary. The returned path is not bound; the caller is responsible for
+// creating and removing the socket file.
+//
+// If rootDir is empty, the user's cache directory is used. The subfolder name
+// is derived from the running executable's name with its extension stripped
+// (so both "dcp" and "dcp.exe" map to "dcp"). socketNamePrefix is prepended to
+// a random suffix to form the socket file name.
+//
+// The function fails if the resulting path would exceed MaxUnixSocketPathLen,
+// since such a path cannot be used for an AF_UNIX socket.
+func CreateRandomSocketPath(rootDir string, socketNamePrefix string) (string, error) {
+	socketDir, socketDirErr := prepareSocketDir(rootDir)
+	if socketDirErr != nil {
+		return "", socketDirErr
+	}
+
+	return randomSocketPath(socketDir, socketNamePrefix)
+}
+
+// CreateRandomUnixSocketListener creates and binds a Unix domain socket listener
+// at a unique path under a private per-program subfolder. The returned listener
+// owns the socket file and removes it when closed.
+func CreateRandomUnixSocketListener(rootDir string, socketNamePrefix string) (*UnixSocketListener, error) {
+	socketDir, socketDirErr := prepareSocketDir(rootDir)
+	if socketDirErr != nil {
+		return nil, socketDirErr
+	}
+
+	var lastErr error
+	for range randomSocketListenerCreateAttempts {
+		socketPath, pathErr := randomSocketPath(socketDir, socketNamePrefix)
+		if pathErr != nil {
+			return nil, pathErr
+		}
+
+		listener, listenerErr := CreateUnixSocketListener(socketPath)
+		if listenerErr == nil {
+			return listener, nil
+		}
+		if !errors.Is(listenerErr, errUnixSocketPathExists) {
+			return nil, listenerErr
+		}
+		lastErr = listenerErr
+	}
+
+	return nil, fmt.Errorf("failed to create a unique Unix socket listener after %d attempts: %w", randomSocketListenerCreateAttempts, lastErr)
+}
+
+// CreateUnixSocketListener creates and binds a Unix domain socket listener at
+// socketPath. The path must not already exist. The returned listener owns the
+// socket file and removes it when closed.
+func CreateUnixSocketListener(socketPath string) (*UnixSocketListener, error) {
+	if socketPath == "" {
+		return nil, errors.New("socket path must not be empty")
+	}
+	if len(socketPath) > MaxUnixSocketPathLen {
+		return nil, fmt.Errorf("socket path %s is %d characters long, which exceeds the maximum of %d for a Unix domain socket", socketPath, len(socketPath), MaxUnixSocketPathLen)
+	}
+
+	_, lstatErr := os.Lstat(socketPath)
+	if lstatErr == nil {
+		return nil, fmt.Errorf("%w: %s", errUnixSocketPathExists, socketPath)
+	}
+	if !errors.Is(lstatErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to inspect Unix socket path %s: %w", socketPath, lstatErr)
+	}
+
+	boundListener, listenErr := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if listenErr != nil {
+		if errors.Is(listenErr, syscall.EADDRINUSE) || errors.Is(listenErr, syscall.EEXIST) || errors.Is(listenErr, os.ErrExist) {
+			return nil, fmt.Errorf("%w: %s: %w", errUnixSocketPathExists, socketPath, listenErr)
+		}
+		return nil, fmt.Errorf("failed to create Unix socket listener at %s: %w", socketPath, listenErr)
+	}
+
+	boundListener.SetUnlinkOnClose(false)
+
+	return &UnixSocketListener{
+		listener:        boundListener,
+		socketPath:      socketPath,
+		lock:            &sync.Mutex{},
+		closeErrPromise: concurrency.NewValuePromise[error](),
+	}, nil
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (l *UnixSocketListener) Accept() (net.Conn, error) {
+	return l.listener.Accept()
+}
+
+// AcceptUnix waits for and returns the next Unix domain connection to the listener.
+func (l *UnixSocketListener) AcceptUnix() (*net.UnixConn, error) {
+	return l.listener.AcceptUnix()
+}
+
+// Close closes the listener and removes the owned socket file. Close is idempotent.
+func (l *UnixSocketListener) Close() error {
+	l.lock.Lock()
+
+	if l.closed {
+		l.lock.Unlock()
+		return l.closeErrPromise.Get()
+	}
+
+	l.closed = true
+	l.lock.Unlock()
+
+	closeErr := l.listener.Close()
+
+	removeErr := os.Remove(l.socketPath)
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+
+	closeErr = errors.Join(closeErr, removeErr)
+	l.closeErrPromise.Set(closeErr)
+	return closeErr
+}
+
+// Addr returns the listener's network address.
+func (l *UnixSocketListener) Addr() net.Addr {
+	return l.listener.Addr()
+}
+
+// SocketPath returns the filesystem path of the Unix domain socket.
+func (l *UnixSocketListener) SocketPath() string {
+	return l.socketPath
+}
+
+func prepareSocketDir(rootDir string) (string, error) {
+	if rootDir == "" {
+		cacheDir, cacheDirErr := os.UserCacheDir()
+		if cacheDirErr != nil {
+			return "", fmt.Errorf("failed to get user cache directory when creating a Unix socket: %w", cacheDirErr)
+		}
+		rootDir = cacheDir
+	}
+
+	exePath, exePathErr := os.Executable()
+	if exePathErr != nil {
+		return "", fmt.Errorf("failed to determine the current executable when creating a Unix socket: %w", exePathErr)
+	}
+
+	socketDir := filepath.Join(rootDir, programSubfolderName(exePath))
+	if err := os.MkdirAll(socketDir, PermissionOnlyOwnerReadWriteTraverse); err != nil {
+		return "", fmt.Errorf("failed to create directory for socket: %w", err)
+	}
+
+	// On Windows the user cache directory always exists and is always private to the user,
+	// but on Unix-like systems, we need to ensure the directory is private.
+	if !IsWindows() {
+		info, infoErr := os.Stat(socketDir)
+		if infoErr != nil {
+			return "", fmt.Errorf("failed to check permissions on the socket directory: %w", infoErr)
+		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("socket path %s is not a directory", socketDir)
+		}
+		if info.Mode().Perm() != PermissionOnlyOwnerReadWriteTraverse {
+			return "", fmt.Errorf("socket directory %s is not private to the user", socketDir)
+		}
+	}
+
+	return socketDir, nil
+}
+
+func randomSocketPath(socketDir string, socketNamePrefix string) (string, error) {
+	suffix, suffixErr := randdata.MakeRandomString(socketPathRandomSuffixLength)
+	if suffixErr != nil {
+		return "", fmt.Errorf("failed to create random string for socket path suffix: %w", suffixErr)
+	}
+
+	socketPath := filepath.Join(socketDir, socketNamePrefix+string(suffix))
+	if len(socketPath) > MaxUnixSocketPathLen {
+		return "", fmt.Errorf("socket path %s is %d characters long, which exceeds the maximum of %d for a Unix domain socket", socketPath, len(socketPath), MaxUnixSocketPathLen)
+	}
+
+	return socketPath, nil
+}
+
+// programSubfolderName returns the base name of the executable at exePath with
+// any file extension removed (e.g. "dcp.exe" and "/usr/bin/dcp" both yield "dcp").
+func programSubfolderName(exePath string) string {
+	base := filepath.Base(exePath)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/pkg/osutil/socket_test.go
+++ b/pkg/osutil/socket_test.go
@@ -1,0 +1,229 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package osutil
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// shortTempDir creates a temp directory with a short path (independent of the
+// test name) so that generated socket paths stay within MaxUnixSocketPathLen,
+// which matters on Windows where t.TempDir() embeds the long test name.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(os.TempDir(), "st")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestProgramSubfolderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		exePath  string
+		expected string
+	}{
+		{"bare name", "dcp", "dcp"},
+		{"name with exe extension", "dcp.exe", "dcp"},
+		{"unix-style path", filepath.Join(string(filepath.Separator), "usr", "bin", "dcp"), "dcp"},
+		{"path with exe extension", filepath.Join("some", "dir", "dcp.exe"), "dcp"},
+		{"multiple dots keeps all but last segment", "dcp.test.exe", "dcp.test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, programSubfolderName(tt.exePath))
+		})
+	}
+}
+
+func TestCreateRandomSocketPath_CreatesDirAndUniquePaths(t *testing.T) {
+	t.Parallel()
+
+	rootDir := shortTempDir(t)
+	const prefix = "sock-"
+
+	exe, exeErr := os.Executable()
+	require.NoError(t, exeErr)
+	expectedDir := filepath.Join(rootDir, programSubfolderName(exe))
+
+	first, firstErr := CreateRandomSocketPath(rootDir, prefix)
+	require.NoError(t, firstErr)
+	require.Equal(t, expectedDir, filepath.Dir(first), "socket should live under <rootDir>/<programName>")
+	require.True(t, strings.HasPrefix(filepath.Base(first), prefix), "socket name %q should start with prefix %q", filepath.Base(first), prefix)
+
+	info, statErr := os.Stat(expectedDir)
+	require.NoError(t, statErr, "the program subfolder should have been created")
+	require.True(t, info.IsDir())
+
+	second, secondErr := CreateRandomSocketPath(rootDir, prefix)
+	require.NoError(t, secondErr)
+	require.NotEqual(t, first, second, "successive calls must yield distinct paths")
+}
+
+func TestCreateRandomSocketPath_EmptyRootResolvesToUserCacheDir(t *testing.T) {
+	t.Parallel()
+
+	cacheDir, cacheErr := os.UserCacheDir()
+	require.NoError(t, cacheErr)
+
+	socketPath, err := CreateRandomSocketPath("", "sock-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	require.Truef(t, strings.HasPrefix(socketPath, cacheDir),
+		"expected %q to be rooted under the user cache dir %q", socketPath, cacheDir)
+}
+
+func TestCreateRandomSocketPath_FailsWhenPathTooLong(t *testing.T) {
+	t.Parallel()
+
+	// A long root dir pushes the resulting socket path beyond MaxUnixSocketPathLen, while staying
+	// short enough that the directory itself can still be created.
+	rootDir := filepath.Join(t.TempDir(), strings.Repeat("a", 80))
+
+	_, err := CreateRandomSocketPath(rootDir, "sock-")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds the maximum")
+}
+
+func TestCreateRandomSocketPath_DirIsPrivateOnUnix(t *testing.T) {
+	t.Parallel()
+
+	if IsWindows() {
+		t.Skip("directory permissions are not enforced on Windows")
+	}
+
+	rootDir := shortTempDir(t)
+	socketPath, err := CreateRandomSocketPath(rootDir, "sock-")
+	require.NoError(t, err)
+
+	info, statErr := os.Stat(filepath.Dir(socketPath))
+	require.NoError(t, statErr)
+	require.Equal(t, PermissionOnlyOwnerReadWriteTraverse, info.Mode().Perm())
+}
+
+func TestCreateUnixSocketListener_CreatesAndRemovesSocketFile(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(shortTempDir(t), "explicit.sock")
+
+	listener, err := CreateUnixSocketListener(socketPath)
+	require.NoError(t, err)
+
+	require.Equal(t, socketPath, listener.SocketPath())
+	require.Equal(t, "unix", listener.Addr().Network())
+	_, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "socket file should exist while the listener is open")
+
+	require.NoError(t, listener.Close())
+	require.NoError(t, listener.Close(), "Close should be idempotent")
+
+	_, statErr = os.Stat(socketPath)
+	require.Truef(t, errors.Is(statErr, os.ErrNotExist), "expected %s to be removed, stat error was %v", socketPath, statErr)
+}
+
+func TestCreateUnixSocketListener_AcceptsConnections(t *testing.T) {
+	t.Parallel()
+
+	listener, err := CreateUnixSocketListener(filepath.Join(shortTempDir(t), "accept.sock"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+
+	acceptedConns := make(chan *net.UnixConn, 1)
+	acceptErrs := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr != nil {
+			acceptErrs <- acceptErr
+			return
+		}
+		acceptedConns <- conn
+	}()
+
+	clientConn, dialErr := net.Dial("unix", listener.SocketPath())
+	require.NoError(t, dialErr)
+	t.Cleanup(func() { require.NoError(t, clientConn.Close()) })
+
+	var serverConn *net.UnixConn
+	select {
+	case serverConn = <-acceptedConns:
+	case acceptErr := <-acceptErrs:
+		require.NoError(t, acceptErr)
+	}
+	t.Cleanup(func() { require.NoError(t, serverConn.Close()) })
+
+	_, writeErr := clientConn.Write([]byte("hello"))
+	require.NoError(t, writeErr)
+
+	buf := make([]byte, 5)
+	n, readErr := serverConn.Read(buf)
+	require.NoError(t, readErr)
+	require.Equal(t, "hello", string(buf[:n]))
+}
+
+func TestCreateUnixSocketListener_RefusesExistingPath(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(shortTempDir(t), "existing")
+	require.NoError(t, os.Mkdir(socketPath, PermissionOnlyOwnerReadWriteTraverse))
+
+	listener, err := CreateUnixSocketListener(socketPath)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errUnixSocketPathExists)
+	require.Nil(t, listener)
+
+	info, statErr := os.Stat(socketPath)
+	require.NoError(t, statErr, "existing path should not be removed")
+	require.True(t, info.IsDir())
+}
+
+func TestCreateRandomUnixSocketListener_CreatesDirAndUniqueListeners(t *testing.T) {
+	t.Parallel()
+
+	rootDir := shortTempDir(t)
+	const prefix = "sock-"
+
+	exe, exeErr := os.Executable()
+	require.NoError(t, exeErr)
+	expectedDir := filepath.Join(rootDir, programSubfolderName(exe))
+
+	first, firstErr := CreateRandomUnixSocketListener(rootDir, prefix)
+	require.NoError(t, firstErr)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+
+	require.Equal(t, expectedDir, filepath.Dir(first.SocketPath()), "socket should live under <rootDir>/<programName>")
+	require.True(t, strings.HasPrefix(filepath.Base(first.SocketPath()), prefix), "socket name %q should start with prefix %q", filepath.Base(first.SocketPath()), prefix)
+	_, statErr := os.Stat(first.SocketPath())
+	require.NoError(t, statErr, "socket file should exist while the listener is open")
+
+	second, secondErr := CreateRandomUnixSocketListener(rootDir, prefix)
+	require.NoError(t, secondErr)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+
+	require.NotEqual(t, first.SocketPath(), second.SocketPath(), "successive calls must yield distinct listener paths")
+}
+
+func TestCreateRandomUnixSocketListener_FailsWhenPathTooLong(t *testing.T) {
+	t.Parallel()
+
+	rootDir := filepath.Join(t.TempDir(), strings.Repeat("a", 80))
+
+	listener, err := CreateRandomUnixSocketListener(rootDir, "sock-")
+	require.Error(t, err)
+	require.Nil(t, listener)
+	require.Contains(t, err.Error(), "exceeds the maximum")
+}

--- a/pkg/process/console_unix.go
+++ b/pkg/process/console_unix.go
@@ -7,14 +7,10 @@
 
 package process
 
-import (
-	"time"
-
-	"github.com/go-logr/logr"
-)
+import "github.com/go-logr/logr"
 
 // StopViaConsole stops the process. Console attachment is Windows-specific, so this is a
 // regular StopProcess call on non-Windows platforms.
-func StopViaConsole(_ logr.Logger, executor Executor, pid Pid_t, startTime time.Time, options ...ProcessStopOption) error {
-	return executor.StopProcess(pid, startTime, options...)
+func StopViaConsole(_ logr.Logger, executor Executor, handle ProcessHandle, options ...ProcessStopOption) error {
+	return executor.StopProcess(handle, options...)
 }

--- a/pkg/process/console_windows.go
+++ b/pkg/process/console_windows.go
@@ -10,7 +10,6 @@ package process
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sys/windows"
@@ -27,11 +26,11 @@ var (
 // If attachment succeeds, it sends CTRL_C_EVENT to the entire console group and protects
 // the caller from its own signal.
 // If the target has no console or has already exited, it falls back to a regular StopProcess call.
-func StopViaConsole(log logr.Logger, executor Executor, pid Pid_t, startTime time.Time, options ...ProcessStopOption) error {
-	attached, attachErr := attachToTargetProcessConsole(log, pid)
+func StopViaConsole(log logr.Logger, executor Executor, handle ProcessHandle, options ...ProcessStopOption) error {
+	attached, attachErr := attachToTargetProcessConsole(log, handle.Pid)
 	if attachErr != nil {
 		// Error already logged in attachToTargetProcessConsole. Fall back to direct stop.
-		stopErr := executor.StopProcess(pid, startTime, options...)
+		stopErr := executor.StopProcess(handle, options...)
 		if stopErr != nil {
 			return errors.Join(attachErr, stopErr)
 		}
@@ -39,7 +38,7 @@ func StopViaConsole(log logr.Logger, executor Executor, pid Pid_t, startTime tim
 	}
 
 	if !attached {
-		return executor.StopProcess(pid, startTime, options...)
+		return executor.StopProcess(handle, options...)
 	}
 	defer restoreParentConsole(log)
 
@@ -53,7 +52,7 @@ func StopViaConsole(log logr.Logger, executor Executor, pid Pid_t, startTime tim
 	consoleOptions := make([]ProcessStopOption, 0, len(options)+1)
 	consoleOptions = append(consoleOptions, options...)
 	consoleOptions = append(consoleOptions, stopConsoleGroup())
-	return executor.StopProcess(pid, startTime, consoleOptions...)
+	return executor.StopProcess(handle, consoleOptions...)
 }
 
 func stopConsoleGroup() ProcessStopOption {

--- a/pkg/process/os_executor.go
+++ b/pkg/process/os_executor.go
@@ -47,33 +47,30 @@ type waitState struct {
 	reason      waitReason    // The reason why are waiting on the process
 }
 
-type WaitKey struct {
-	Pid       Pid_t
-	StartedAt time.Time
-}
-
 func (e *OSExecutor) StartProcess(
 	ctx context.Context,
 	cmd *exec.Cmd,
 	handler ProcessExitHandler,
 	flags ProcessCreationFlag,
 	sysCreateProcess SysCreateProcessFunc,
-) (Pid_t, time.Time, func(), error) {
+) (ProcessHandle, func(), error) {
 	e.acquireLock()
 	if e.disposed {
 		e.releaseLock()
-		return UnknownPID, time.Time{}, nil, ErrDisposed
+		return ProcessHandle{Pid: UnknownPID}, nil, ErrDisposed
 	}
 	e.releaseLock()
 
-	pid, processIdentityTime, waitable, err := e.startProcess(cmd, flags, sysCreateProcess)
-	if err != nil {
-		return UnknownPID, time.Time{}, nil, err
+	handle, waitable, startProcessErr := e.startProcess(cmd, flags, sysCreateProcess)
+	if startProcessErr != nil {
+		return ProcessHandle{Pid: UnknownPID}, nil, startProcessErr
 	}
+
+	pid := handle.Pid
 
 	// Get the wait result channel, but do not actually start waiting
 	// This also has the effect of tying the wait for this process to the command that started it.
-	ws, _ := e.tryStartWaiting(pid, processIdentityTime, waitable, waitReasonNone)
+	ws, _ := e.tryStartWaiting(handle, waitable, waitReasonNone)
 
 	// Start the goroutine that waits for the context to expire.
 	go func() {
@@ -88,7 +85,7 @@ func (e *OSExecutor) StartProcess(
 			}
 
 		case <-ctx.Done():
-			_, shouldStopProcess := e.tryStartWaiting(pid, processIdentityTime, waitable, waitReasonStopping)
+			_, shouldStopProcess := e.tryStartWaiting(handle, waitable, waitReasonStopping)
 			var stopProcessErr error = nil
 
 			if shouldStopProcess {
@@ -99,7 +96,7 @@ func (e *OSExecutor) StartProcess(
 					"Args", cmd.Args[1:],
 				)
 				log.Info("Context expired, stopping process...")
-				stopProcessErr = e.stopProcessInternal(pid, processIdentityTime, optIsResponsibleForStopping)
+				stopProcessErr = e.stopProcessInternal(handle, optIsResponsibleForStopping)
 				if stopProcessErr != nil {
 					log.Error(stopProcessErr, "Could not stop process upon context expiration")
 					if handler != nil {
@@ -122,23 +119,23 @@ func (e *OSExecutor) StartProcess(
 	}()
 
 	startWaitingForProcessExit := func() {
-		_, _ = e.tryStartWaiting(pid, processIdentityTime, waitable, waitReasonMonitoring)
+		_, _ = e.tryStartWaiting(handle, waitable, waitReasonMonitoring)
 	}
 
-	return pid, processIdentityTime, startWaitingForProcessExit, nil
+	return handle, startWaitingForProcessExit, nil
 }
 
-func (e *OSExecutor) StartAndForget(cmd *exec.Cmd, flags ProcessCreationFlag) (Pid_t, time.Time, error) {
+func (e *OSExecutor) StartAndForget(cmd *exec.Cmd, flags ProcessCreationFlag) (ProcessHandle, error) {
 	e.acquireLock()
 	if e.disposed {
 		e.releaseLock()
-		return UnknownPID, time.Time{}, ErrDisposed
+		return ProcessHandle{Pid: UnknownPID}, ErrDisposed
 	}
 	e.releaseLock()
 
-	pid, processStartTime, waitable, err := e.startProcess(cmd, flags, nil)
-	if err != nil {
-		return UnknownPID, time.Time{}, err
+	handle, waitable, startProcessErr := e.startProcess(cmd, flags, nil)
+	if startProcessErr != nil {
+		return ProcessHandle{Pid: UnknownPID}, startProcessErr
 	}
 
 	// We have to wait (not cmd.Process.Release()) because if we don't, then if the child process exits
@@ -149,10 +146,10 @@ func (e *OSExecutor) StartAndForget(cmd *exec.Cmd, flags ProcessCreationFlag) (P
 		}()
 	}
 
-	return pid, processStartTime, nil
+	return handle, nil
 }
 
-func (e *OSExecutor) StopProcess(pid Pid_t, processStartTime time.Time, options ...ProcessStopOption) error {
+func (e *OSExecutor) StopProcess(handle ProcessHandle, options ...ProcessStopOption) error {
 	e.acquireLock()
 	if e.disposed {
 		e.releaseLock()
@@ -161,35 +158,37 @@ func (e *OSExecutor) StopProcess(pid Pid_t, processStartTime time.Time, options 
 	e.releaseLock()
 
 	stopOptions := newProcessStopOptions(options)
-	return e.stopProcessInternal(pid, processStartTime, stopOptions.opts)
+	return e.stopProcessInternal(handle, stopOptions.opts)
 }
 
-// Returns the PID, process identity time (to distinguish between process instances with the same PID), and error.
+// Returns the process handle, waitable process, and error.
 func (e *OSExecutor) startProcess(
 	cmd *exec.Cmd,
 	flags ProcessCreationFlag,
 	sysCreateProcess SysCreateProcessFunc,
-) (Pid_t, time.Time, Waitable, error) {
+) (ProcessHandle, Waitable, error) {
 	e.prepareProcessStart(cmd, flags)
 
 	var pid Pid_t
+	var handle ProcessHandle
 	var waitable Waitable
 
 	if sysCreateProcess != nil {
 		var sysCreateErr error
 		pid, waitable, sysCreateErr = sysCreateProcess(cmd)
 		if sysCreateErr != nil {
-			return UnknownPID, time.Time{}, nil, sysCreateErr
+			return ProcessHandle{Pid: UnknownPID}, nil, sysCreateErr
 		}
 		if waitable == nil {
-			return UnknownPID, time.Time{}, nil, fmt.Errorf("sysCreateProcess returned nil waitable")
+			return ProcessHandle{Pid: UnknownPID}, nil, fmt.Errorf("sysCreateProcess returned nil waitable")
 		}
+		handle = NewHandle(pid, ProcessIdentityTime(pid))
 	} else {
 		if err := cmd.Start(); err != nil {
-			return UnknownPID, time.Time{}, nil, err
+			return ProcessHandle{Pid: UnknownPID}, nil, err
 		}
-		osPid := cmd.Process.Pid
-		pid = Uint32_ToPidT(uint32(osPid))
+		handle = ProcessHandleFromCmd(cmd)
+		pid = handle.Pid
 		waitable = &waitableCmd{cmd, flags}
 	}
 
@@ -200,23 +199,21 @@ func (e *OSExecutor) startProcess(
 		"CreationFlags", flags,
 	)
 
-	processIdentityTime := ProcessIdentityTime(pid)
-
-	startCompletionErr := e.completeProcessStart(pid, processIdentityTime, flags)
+	startCompletionErr := e.completeProcessStart(handle, flags)
 	if startCompletionErr != nil {
 		startLog.Error(startCompletionErr, "Could not complete process start")
 
 		// If we could not complete the process start, we need to stop the process.
 		// Do not try graceful stop (no optTrySignal), just kill it immediately.
-		if stopErr := e.stopProcessInternal(pid, processIdentityTime, optIsResponsibleForStopping); stopErr != nil {
+		if stopErr := e.stopProcessInternal(handle, optIsResponsibleForStopping); stopErr != nil {
 			startLog.Error(stopErr, "Could not stop process after failed start")
 		}
 
-		return UnknownPID, time.Time{}, nil, fmt.Errorf("could not complete process start: %w", startCompletionErr)
+		return ProcessHandle{Pid: UnknownPID}, nil, fmt.Errorf("could not complete process start: %w", startCompletionErr)
 	}
 
 	startLog.V(1).Info("Process started successfully", "PID", pid)
-	return pid, processIdentityTime, waitable, nil
+	return handle, waitable, nil
 }
 
 // Atomically starts waiting on the passed waitable if noting is already waiting in association with the process
@@ -225,11 +222,11 @@ func (e *OSExecutor) startProcess(
 // Returns the waitState object associated with the process, and a boolean indicating whether the caller
 // is the first one to indicate that the reason for the wait is "stopping the process",
 // and thus IT is the caller that must stop the process.
-func (e *OSExecutor) tryStartWaiting(pid Pid_t, startTime time.Time, waitable Waitable, reason waitReason) (*waitState, bool) {
+func (e *OSExecutor) tryStartWaiting(handle ProcessHandle, waitable Waitable, reason waitReason) (*waitState, bool) {
 	e.acquireLock()
 	defer e.releaseLock()
 
-	ws, found := e.procsWaiting[WaitKey{pid, startTime}]
+	ws, found := e.procsWaiting[handle]
 	callerShouldStopProcess := false
 
 	if found {
@@ -250,7 +247,7 @@ func (e *OSExecutor) tryStartWaiting(pid Pid_t, startTime time.Time, waitable Wa
 			if effectiveWaitable == nil {
 				effectiveWaitable = waitable
 			}
-			go e.doWait(ws, effectiveWaitable, pid)
+			go e.doWait(ws, effectiveWaitable, handle.Pid)
 		}
 	} else {
 		callerShouldStopProcess = (reason & waitReasonStopping) != 0
@@ -259,9 +256,9 @@ func (e *OSExecutor) tryStartWaiting(pid Pid_t, startTime time.Time, waitable Wa
 			waitEndedCh: make(chan struct{}),
 			reason:      reason,
 		}
-		e.procsWaiting[WaitKey{pid, startTime}] = ws
+		e.procsWaiting[handle] = ws
 		if reason != waitReasonNone {
-			go e.doWait(ws, waitable, pid)
+			go e.doWait(ws, waitable, handle.Pid)
 		}
 	}
 
@@ -311,7 +308,7 @@ func (e *OSExecutor) acquireLock() {
 	}
 
 	// Only keep wait states that correspond to processes that are still running, or the ones that completed recently
-	e.procsWaiting = maps.Select(e.procsWaiting, func(_ WaitKey, ws *waitState) bool {
+	e.procsWaiting = maps.Select(e.procsWaiting, func(_ ProcessHandle, ws *waitState) bool {
 		return ws.waitEnded.IsZero() || time.Since(ws.waitEnded) < maxCompletedDuration
 	})
 }
@@ -320,11 +317,11 @@ func (e *OSExecutor) releaseLock() {
 	e.lock.Unlock()
 }
 
-func (e *OSExecutor) stopProcessInternal(pid Pid_t, processStartTime time.Time, opts processStoppingOpts) error {
-	procTreeLog := e.log.WithValues("Root", pid)
+func (e *OSExecutor) stopProcessInternal(handle ProcessHandle, opts processStoppingOpts) error {
+	procTreeLog := e.log.WithValues("Root", handle.Pid)
 
 	stopRootProcess := func() (<-chan struct{}, error, error) {
-		procEndedCh, stopErr := e.stopSingleProcess(pid, processStartTime, opts|optNotFoundIsError|optTrySignal|optWaitForStdio)
+		procEndedCh, stopErr := e.stopSingleProcess(handle, opts|optNotFoundIsError|optTrySignal|optWaitForStdio)
 		if stopErr != nil && !errors.Is(stopErr, ErrTimedOutWaitingForProcessToStop) {
 			// If the root process cannot be stopped (and it is not just a timeout error), don't bother with the rest of the tree.
 			procTreeLog.Error(stopErr, "Could not stop root process")
@@ -363,12 +360,12 @@ func (e *OSExecutor) stopProcessInternal(pid Pid_t, processStartTime time.Time, 
 		return waitForRootProcessToEnd(procEndedCh, stopErr)
 	}
 
-	tree, err := GetProcessTree(ProcessTreeItem{pid, processStartTime})
-	if err != nil {
-		return fmt.Errorf("could not get process tree for process %d: %w", pid, err)
+	tree, treeErr := GetProcessTree(handle)
+	if treeErr != nil {
+		return fmt.Errorf("could not get process tree for process %d: %w", handle.Pid, treeErr)
 	}
 
-	procTreeLog.V(1).Info("Stopping process tree...", "Root", pid, "Tree", getIDs(tree))
+	procTreeLog.V(1).Info("Stopping process tree...", "Root", handle.Pid, "Tree", getIDs(tree))
 
 	procEndedCh, stopErr, rootStopErr := stopRootProcess()
 	if rootStopErr != nil {
@@ -382,7 +379,7 @@ func (e *OSExecutor) stopProcessInternal(pid Pid_t, processStartTime time.Time, 
 	}
 
 	procTreeLog.V(1).Info("Make sure children of the root processes are gone...")
-	childStoppingErrors := slices.MapConcurrent[error](tree, func(p ProcessTreeItem) error {
+	childStoppingErrors := slices.MapConcurrent[error](tree, func(p ProcessHandle) error {
 		// Retry stopping the child process as we occasionally see transient "Access Denied" errors.
 		const childStopTimeout = 2 * time.Second
 		childLog := procTreeLog.WithValues("Child", p.Pid)
@@ -390,7 +387,7 @@ func (e *OSExecutor) stopProcessInternal(pid Pid_t, processStartTime time.Time, 
 		retryErr := resiliency.RetryExponentialWithTimeout(context.Background(), childStopTimeout, func() error {
 			childLog.V(1).Info("Stopping child process...")
 
-			_, childStopErr := e.stopSingleProcess(p.Pid, p.IdentityTime, opts&^optNotFoundIsError)
+			_, childStopErr := e.stopSingleProcess(p, opts&^optNotFoundIsError)
 			if childStopErr != nil {
 				childLog.V(1).Info("Error stopping child process", "Error", childStopErr.Error())
 			} else {
@@ -401,7 +398,7 @@ func (e *OSExecutor) stopProcessInternal(pid Pid_t, processStartTime time.Time, 
 		})
 
 		if retryErr != nil {
-			childLog.Error(err, "Could not stop child process")
+			childLog.Error(retryErr, "Could not stop child process")
 		}
 		return retryErr
 
@@ -452,7 +449,7 @@ func (e *OSExecutor) Dispose() {
 	wg.Add(len(currentProcs))
 	sem := concurrency.NewSemaphoreWithCount(uint(maxConcurrentProcessStops))
 
-	for wk, ws := range currentProcs {
+	for handle, ws := range currentProcs {
 		<-sem.Wait().Chan
 
 		go func() {
@@ -472,14 +469,14 @@ func (e *OSExecutor) Dispose() {
 
 			if flags&CreationFlagEnsureKillOnDispose == CreationFlagEnsureKillOnDispose {
 				// Best effort to stop the process.
-				e.log.V(1).Info("Stopping process during executor disposal...", "PID", wk.Pid, "Command", waitable.Info())
-				stopErr := e.stopProcessInternal(wk.Pid, wk.StartedAt, optIsResponsibleForStopping|optTrySignal)
+				e.log.V(1).Info("Stopping process during executor disposal...", "PID", handle.Pid, "Command", waitable.Info())
+				stopErr := e.stopProcessInternal(handle, optIsResponsibleForStopping|optTrySignal)
 				if stopErr != nil {
-					e.log.Error(stopErr, "Could not stop process during executor disposal", "PID", wk.Pid, "Command", waitable.Info())
+					e.log.Error(stopErr, "Could not stop process during executor disposal", "PID", handle.Pid, "Command", waitable.Info())
 				}
 			} else {
 				// Just make sure we called wait() so the process does not become a zombie.
-				_, _ = e.tryStartWaiting(wk.Pid, wk.StartedAt, waitable, waitReasonMonitoring)
+				_, _ = e.tryStartWaiting(handle, waitable, waitReasonMonitoring)
 			}
 		}()
 	}
@@ -490,13 +487,13 @@ func (e *OSExecutor) Dispose() {
 	e.log.V(1).Info("Process executor disposed")
 }
 
-func (e *OSExecutor) CheckProcessRunning(pid Pid_t, processStartTime time.Time) error {
-	proc, err := FindProcess(pid, processStartTime)
+func (e *OSExecutor) CheckProcessRunning(handle ProcessHandle) error {
+	proc, err := FindProcess(handle)
 	if err != nil {
 		return err
 	}
 	if releaseErr := proc.Release(); releaseErr != nil {
-		e.log.Error(releaseErr, "Failed to release process handle", "PID", pid)
+		e.log.Error(releaseErr, "Failed to release process handle", "PID", handle.Pid)
 	}
 	return nil
 }

--- a/pkg/process/os_executor_unix.go
+++ b/pkg/process/os_executor_unix.go
@@ -25,7 +25,7 @@ const (
 )
 
 type OSExecutor struct {
-	procsWaiting map[WaitKey]*waitState
+	procsWaiting map[ProcessHandle]*waitState
 	disposed     bool
 	lock         sync.Locker
 	log          logr.Logger
@@ -33,36 +33,36 @@ type OSExecutor struct {
 
 func NewOSExecutor(log logr.Logger) Executor {
 	return &OSExecutor{
-		procsWaiting: make(map[WaitKey]*waitState),
+		procsWaiting: make(map[ProcessHandle]*waitState),
 		disposed:     false,
 		lock:         &sync.Mutex{},
 		log:          log.WithName("os-executor"),
 	}
 }
 
-func (e *OSExecutor) stopSingleProcess(pid Pid_t, processStartTime time.Time, opts processStoppingOpts) (<-chan struct{}, error) {
+func (e *OSExecutor) stopSingleProcess(handle ProcessHandle, opts processStoppingOpts) (<-chan struct{}, error) {
 	// Console group signaling is Windows-specific; keep the shared option as an explicit no-op on Unix.
 	opts &^= optSignalConsoleGroup
 
-	proc, err := FindProcess(pid, processStartTime)
+	proc, err := FindProcess(handle)
 	if err != nil {
 		e.acquireLock()
 		alreadyEnded := false
-		ws, found := e.procsWaiting[WaitKey{pid, processStartTime}]
+		ws, found := e.procsWaiting[handle]
 		if found {
 			alreadyEnded = !ws.waitEnded.IsZero()
 		}
 		e.releaseLock()
 
 		if (opts&optNotFoundIsError) != 0 && !alreadyEnded {
-			return nil, &ErrProcessNotFound{Pid: pid, Inner: err}
+			return nil, &ErrProcessNotFound{Pid: handle.Pid, Inner: err}
 		} else {
 			return makeClosedChan(), nil
 		}
 	}
 
-	waitable := makeProcessWaitable(pid, proc)
-	ws, shouldStopProcess := e.tryStartWaiting(pid, processStartTime, waitable, waitReasonStopping)
+	waitable := makeProcessWaitable(handle.Pid, proc)
+	ws, shouldStopProcess := e.tryStartWaiting(handle, waitable, waitReasonStopping)
 
 	waitEndedCh := ws.waitEndedCh
 	if opts&optWaitForStdio == 0 {
@@ -80,22 +80,22 @@ func (e *OSExecutor) stopSingleProcess(pid Pid_t, processStartTime time.Time, op
 		err = e.signalAndWaitForExit(proc, syscall.SIGTERM, ws)
 		switch {
 		case err == nil:
-			e.log.V(1).Info("Process stopped by SIGTERM", "PID", pid)
+			e.log.V(1).Info("Process stopped by SIGTERM", "PID", handle.Pid)
 			return waitEndedCh, nil
 		case !errors.Is(err, ErrTimedOutWaitingForProcessToStop):
 			return nil, err
 		default:
-			e.log.V(1).Info("Process did not stop upon SIGTERM", "PID", pid)
+			e.log.V(1).Info("Process did not stop upon SIGTERM", "PID", handle.Pid)
 		}
 	}
 
-	e.log.V(1).Info("Sending SIGKILL to process...", "PID", pid)
+	e.log.V(1).Info("Sending SIGKILL to process...", "PID", handle.Pid)
 	err = e.signalAndWaitForExit(proc, syscall.SIGKILL, ws)
 	if err != nil {
 		return nil, err
 	}
 
-	e.log.V(1).Info("Process stopped by SIGKILL", "PID", pid)
+	e.log.V(1).Info("Process stopped by SIGKILL", "PID", handle.Pid)
 	return waitEndedCh, nil
 }
 
@@ -133,7 +133,7 @@ func (e *OSExecutor) prepareProcessStart(_ *exec.Cmd, _ ProcessCreationFlag) {
 	// No additional preparation needed for Unix-like systems.
 }
 
-func (e *OSExecutor) completeProcessStart(_ Pid_t, _ time.Time, _ ProcessCreationFlag) error {
+func (e *OSExecutor) completeProcessStart(_ ProcessHandle, _ ProcessCreationFlag) error {
 	// No additional actions needed on process start for Unix-like systems.
 	return nil
 }

--- a/pkg/process/os_executor_windows.go
+++ b/pkg/process/os_executor_windows.go
@@ -40,7 +40,7 @@ var (
 )
 
 type OSExecutor struct {
-	procsWaiting      map[WaitKey]*waitState
+	procsWaiting      map[ProcessHandle]*waitState
 	lock              sync.Locker
 	disposed          bool
 	log               logr.Logger
@@ -49,7 +49,7 @@ type OSExecutor struct {
 
 func NewOSExecutor(log logr.Logger) Executor {
 	e := &OSExecutor{
-		procsWaiting: make(map[WaitKey]*waitState),
+		procsWaiting: make(map[ProcessHandle]*waitState),
 		lock:         &sync.Mutex{},
 		disposed:     false,
 		log:          log.WithName("os-executor"),
@@ -58,26 +58,26 @@ func NewOSExecutor(log logr.Logger) Executor {
 	return e
 }
 
-func (e *OSExecutor) stopSingleProcess(pid Pid_t, processStartTime time.Time, opts processStoppingOpts) (<-chan struct{}, error) {
-	proc, err := FindProcess(pid, processStartTime)
+func (e *OSExecutor) stopSingleProcess(handle ProcessHandle, opts processStoppingOpts) (<-chan struct{}, error) {
+	proc, err := FindProcess(handle)
 	if err != nil {
 		e.acquireLock()
 		alreadyEnded := false
-		ws, found := e.procsWaiting[WaitKey{pid, processStartTime}]
+		ws, found := e.procsWaiting[handle]
 		if found {
 			alreadyEnded = !ws.waitEnded.IsZero()
 		}
 		e.releaseLock()
 
 		if (opts&optNotFoundIsError) != 0 && !alreadyEnded {
-			return nil, &ErrProcessNotFound{Pid: pid, Inner: err}
+			return nil, &ErrProcessNotFound{Pid: handle.Pid, Inner: err}
 		} else {
 			return makeClosedChan(), nil
 		}
 	}
 
-	waitable := makeProcessWaitable(pid, proc)
-	ws, shouldStopProcess := e.tryStartWaiting(pid, processStartTime, waitable, waitReasonStopping)
+	waitable := makeProcessWaitable(handle.Pid, proc)
+	ws, shouldStopProcess := e.tryStartWaiting(handle, waitable, waitReasonStopping)
 
 	waitEndedCh := ws.waitEndedCh
 	if opts&optWaitForStdio == 0 {
@@ -108,31 +108,31 @@ func (e *OSExecutor) stopSingleProcess(pid Pid_t, processStartTime time.Time, op
 
 		err = e.signalAndWaitForExit(proc, sig, processGroupID, ws)
 		if err == nil {
-			e.log.V(1).Info("Process stopped by signal", "PID", pid, "Signal", sig)
+			e.log.V(1).Info("Process stopped by signal", "PID", handle.Pid, "Signal", sig)
 			return waitEndedCh, nil
 		}
 
-		e.log.V(1).Info("Process did not stop upon signal; falling back to SIGKILL", "PID", pid, "Signal", sig, "Error", err)
+		e.log.V(1).Info("Process did not stop upon signal; falling back to SIGKILL", "PID", handle.Pid, "Signal", sig, "Error", err)
 	} else if (opts & optSignalConsoleGroup) != 0 {
 		// The process was not signaled directly here, but a CTRL_C_EVENT was already
 		// broadcast to the entire console group (for the root process). Give this process
 		// time to exit from that broadcast before force-killing it.
 		select {
 		case <-ws.waitEndedCh:
-			e.log.V(1).Info("Process exited after console group signal", "PID", pid)
+			e.log.V(1).Info("Process exited after console group signal", "PID", handle.Pid)
 			return waitEndedCh, nil
 		case <-time.After(signalAndWaitTimeout):
-			e.log.V(1).Info("Process did not exit after console group signal, force-killing", "PID", pid)
+			e.log.V(1).Info("Process did not exit after console group signal, force-killing", "PID", handle.Pid)
 		}
 	}
 
-	e.log.V(1).Info("Sending SIGKILL to process...", "PID", pid)
+	e.log.V(1).Info("Sending SIGKILL to process...", "PID", handle.Pid)
 	err = proc.Kill()
 	if err != nil && !errors.Is(err, os.ErrProcessDone) {
 		return nil, err
 	}
 
-	e.log.V(1).Info("Process stopped by SIGKILL", "PID", pid)
+	e.log.V(1).Info("Process stopped by SIGKILL", "PID", handle.Pid)
 	return waitEndedCh, nil
 }
 
@@ -191,7 +191,7 @@ func (e *OSExecutor) prepareProcessStart(cmd *exec.Cmd, flags ProcessCreationFla
 	}
 }
 
-func (e *OSExecutor) completeProcessStart(pid Pid_t, _ time.Time, flags ProcessCreationFlag) error {
+func (e *OSExecutor) completeProcessStart(handle ProcessHandle, flags ProcessCreationFlag) error {
 	if cleanupJobDisabled() || (flags&CreationFlagEnsureKillOnDispose) == 0 {
 		return nil
 	}
@@ -209,9 +209,9 @@ func (e *OSExecutor) completeProcessStart(pid Pid_t, _ time.Time, flags ProcessC
 		// The AssignProcessToJobObject docs say PROCESS_TERMINATE and PROCESS_SET_QUOTA are sufficient to assign a process to a job object,
 		// but in practice we need PROCESS_ALL_ACCESS to make it work.
 		const access = windows.PROCESS_ALL_ACCESS
-		processHandle, processHandleErr := windows.OpenProcess(access, false, uint32(pid))
+		processHandle, processHandleErr := windows.OpenProcess(access, false, uint32(handle.Pid))
 		if processHandleErr != nil {
-			e.log.V(1).Info("Could not open new process handle", "PID", pid, "Error", processHandleErr)
+			e.log.V(1).Info("Could not open new process handle", "PID", handle.Pid, "Error", processHandleErr)
 		} else {
 			defer tryCloseHandle(processHandle)
 
@@ -221,15 +221,15 @@ func (e *OSExecutor) completeProcessStart(pid Pid_t, _ time.Time, flags ProcessC
 
 			jobAssignmentErr := windows.AssignProcessToJobObject(pcj, processHandle)
 			if jobAssignmentErr != nil {
-				e.log.V(1).Info("Could not assign process to job object", "PID", pid, "Error", jobAssignmentErr)
+				e.log.V(1).Info("Could not assign process to job object", "PID", handle.Pid, "Error", jobAssignmentErr)
 			}
 		}
 	}
 
-	resumptionErr := resumeNewSuspendedProcess(uint32(pid))
+	resumptionErr := resumeNewSuspendedProcess(uint32(handle.Pid))
 	if resumptionErr != nil {
-		e.log.Error(resumptionErr, "Could not resume new suspended process", "PID", pid)
-		return fmt.Errorf("could not resume new suspended process with pid %d: %w", pid, resumptionErr)
+		e.log.Error(resumptionErr, "Could not resume new suspended process", "PID", handle.Pid)
+		return fmt.Errorf("could not resume new suspended process with pid %d: %w", handle.Pid, resumptionErr)
 	}
 
 	return nil

--- a/pkg/process/process_handle.go
+++ b/pkg/process/process_handle.go
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"time"
+)
+
+// ProcessHandle identifies a process instance by PID and identity time.
+//
+// IdentityTime may not be a valid wall-clock time on all platforms. On Linux it
+// is expressed as milliseconds since boot to avoid issues with system clock changes.
+//
+// ProcessHandle is comparable and can be used as a map key for handles created
+// from the same identity time source.
+type ProcessHandle struct {
+	Pid          Pid_t
+	IdentityTime time.Time
+}
+
+// NewHandle creates a ProcessHandle from a PID and identity time.
+func NewHandle(pid Pid_t, identityTime time.Time) ProcessHandle {
+	return ProcessHandle{
+		Pid:          pid,
+		IdentityTime: identityTime,
+	}
+}
+
+// ProcessHandleFromCmd creates a ProcessHandle from a started exec.Cmd.
+func ProcessHandleFromCmd(cmd *exec.Cmd) ProcessHandle {
+	if cmd.Process == nil {
+		return ProcessHandle{Pid: UnknownPID}
+	}
+
+	pid := Uint32_ToPidT(uint32(cmd.Process.Pid))
+	return ProcessHandle{
+		Pid:          pid,
+		IdentityTime: ProcessIdentityTime(pid),
+	}
+}
+
+// ProcessHandleFromProcess creates a ProcessHandle from a running os.Process.
+func ProcessHandleFromProcess(p *os.Process) ProcessHandle {
+	if p == nil {
+		return ProcessHandle{Pid: UnknownPID}
+	}
+
+	pid := Uint32_ToPidT(uint32(p.Pid))
+	return ProcessHandle{
+		Pid:          pid,
+		IdentityTime: ProcessIdentityTime(pid),
+	}
+}

--- a/pkg/process/process_handle_test.go
+++ b/pkg/process/process_handle_test.go
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package process
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessHandle_Comparable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h1 := NewHandle(Uint32_ToPidT(100), now)
+	h2 := NewHandle(Uint32_ToPidT(100), now)
+	h3 := NewHandle(Uint32_ToPidT(200), now)
+
+	assert.Equal(t, h1, h2)
+	assert.NotEqual(t, h1, h3)
+
+	zeroHandle := ProcessHandle{Pid: UnknownPID}
+	assert.NotEqual(t, zeroHandle, h1)
+
+	m := map[ProcessHandle]string{
+		h1: "first",
+		h3: "second",
+	}
+	assert.Equal(t, "first", m[h2])
+	assert.Equal(t, "second", m[h3])
+}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -199,7 +199,7 @@ func TestRunCancelled(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	go func() {
-		_, _, startWaitForExit, processStartErr := executor.StartProcess(ctx, cmd, onProcessExited, process.CreationFlagsNone, nil)
+		_, startWaitForExit, processStartErr := executor.StartProcess(ctx, cmd, onProcessExited, process.CreationFlagsNone, nil)
 		startupNotification := process.NewProcessExitInfo()
 		if processStartErr != nil {
 			startupNotification.Err = processStartErr
@@ -234,32 +234,29 @@ func TestRunCancelled(t *testing.T) {
 func TestChildrenTerminated(t *testing.T) {
 	type testcase struct {
 		description    string
-		processStartFn func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessTreeItem
+		processStartFn func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessHandle
 	}
 
 	testcases := []testcase{
-		{"external start", func(t *testing.T, cmd *exec.Cmd, _ process.Executor) process.ProcessTreeItem {
+		{"external start", func(t *testing.T, cmd *exec.Cmd, _ process.Executor) process.ProcessHandle {
 			err := cmd.Start()
 			require.NoError(t, err, "could not start the 'delay' test program")
-			pid := process.Uint32_ToPidT(uint32(cmd.Process.Pid))
-			identityTime := process.ProcessIdentityTime(pid)
-			require.False(t, identityTime.IsZero(), "process identity time should not be zero")
-			return process.ProcessTreeItem{pid, identityTime}
+			handle := process.ProcessHandleFromCmd(cmd)
+			require.False(t, handle.IdentityTime.IsZero(), "process identity time should not be zero")
+			return handle
 		}},
-		{"executor start, no wait", func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessTreeItem {
-			pid, _, _, err := e.StartProcess(context.Background(), cmd, nil, process.CreationFlagsNone, nil)
+		{"executor start, no wait", func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessHandle {
+			handle, _, err := e.StartProcess(context.Background(), cmd, nil, process.CreationFlagsNone, nil)
 			require.NoError(t, err, "could not start the 'delay' test program")
-			identityTime := process.ProcessIdentityTime(pid)
-			require.False(t, identityTime.IsZero(), "process identity time should not be zero")
-			return process.ProcessTreeItem{pid, identityTime}
+			require.False(t, handle.IdentityTime.IsZero(), "process identity time should not be zero")
+			return handle
 		}},
-		{"executor start with wait", func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessTreeItem {
-			pid, _, startWaitForProcessExit, err := e.StartProcess(context.Background(), cmd, nil, process.CreationFlagsNone, nil)
+		{"executor start with wait", func(t *testing.T, cmd *exec.Cmd, e process.Executor) process.ProcessHandle {
+			handle, startWaitForProcessExit, err := e.StartProcess(context.Background(), cmd, nil, process.CreationFlagsNone, nil)
 			require.NoError(t, err, "could not start the 'delay' test program")
 			startWaitForProcessExit()
-			identityTime := process.ProcessIdentityTime(pid)
-			require.False(t, identityTime.IsZero(), "process identity time should not be zero")
-			return process.ProcessTreeItem{pid, identityTime}
+			require.False(t, handle.IdentityTime.IsZero(), "process identity time should not be zero")
+			return handle
 		}},
 	}
 
@@ -291,7 +288,7 @@ func TestChildrenTerminated(t *testing.T) {
 			processTree, err := process.GetProcessTree(rootP)
 			require.NoError(t, err)
 
-			err = executor.StopProcess(rootP.Pid, rootP.IdentityTime)
+			err = executor.StopProcess(rootP)
 			require.NoError(t, err)
 
 			// Wait up to 10 seconds for all processes to exit. This guarantees that the test will only pass if StopProcess()
@@ -315,7 +312,7 @@ func TestChildrenTerminatedOnDispose(t *testing.T) {
 	cmd.Dir = delayToolDir
 	processExited := make(chan struct{})
 
-	_, _, startWaitForProcessExit, startErr := executor.StartProcess(
+	_, startWaitForProcessExit, startErr := executor.StartProcess(
 		context.Background(),
 		cmd,
 		process.ProcessExitHandlerFunc(func(_ process.Pid_t, _ int32, err error) {
@@ -356,7 +353,7 @@ func TestWatchCatchesProcessExit(t *testing.T) {
 	require.NoError(t, err)
 
 	pid := process.Uint32_ToPidT(uint32(cmd.Process.Pid))
-	delayProc, err := process.FindWaitableProcess(pid, time.Time{})
+	delayProc, err := process.FindWaitableProcess(process.NewHandle(pid, time.Time{}))
 	require.NoError(t, err)
 
 	err = delayProc.Wait(ctx)
@@ -383,7 +380,7 @@ func TestContextCancelsWatch(t *testing.T) {
 	require.NoError(t, err, "command should start without error")
 
 	pid := process.Uint32_ToPidT(uint32(cmd.Process.Pid))
-	delayProc, err := process.FindWaitableProcess(pid, time.Time{})
+	delayProc, err := process.FindWaitableProcess(process.NewHandle(pid, time.Time{}))
 	require.NoError(t, err, "find process should succeed without error")
 
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -439,7 +436,7 @@ func TestSysCreateProcess(t *testing.T) {
 			captureDoneCh: make(chan struct{}),
 		}
 		capturedWaitable = w
-		return process.Uint32_ToPidT(uint32(proc.Pid)), w, nil
+		return process.ProcessHandleFromProcess(proc).Pid, w, nil
 	})
 
 	exitInfoChan := make(chan process.ProcessExitInfo, 1)
@@ -447,7 +444,7 @@ func TestSysCreateProcess(t *testing.T) {
 		exitInfoChan <- process.ProcessExitInfo{PID: pid, ExitCode: exitCode, Err: exitErr}
 	})
 
-	_, _, startWaitForExit, startErr := executor.StartProcess(
+	_, startWaitForExit, startErr := executor.StartProcess(
 		testCtx, cmd, handler, process.CreationFlagsNone, sysCreate,
 	)
 	require.NoError(t, startErr, "StartProcess should succeed")

--- a/pkg/process/process_types.go
+++ b/pkg/process/process_types.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"time"
 )
 
 const (
@@ -93,28 +92,27 @@ type Executor interface {
 	// the sysCreateProcess function can be used to create the process using a different approach.
 	// In most circumstance the standard library's exec package is sufficient.
 	//
-	// StartProcess returns the process PID, process start time,
-	// and a function that enables process exit notifications delivered to the exit handler.
+	// StartProcess returns a ProcessHandle identifying the started process and a function that enables
+	// process exit notifications delivered to the exit handler.
 	StartProcess(
 		ctx context.Context,
 		cmd *exec.Cmd,
 		exitHandler ProcessExitHandler,
 		creationFlags ProcessCreationFlag,
 		sysCreateProcess SysCreateProcessFunc,
-	) (pid Pid_t, startTime time.Time, startWaitForProcessExit func(), err error)
+	) (handle ProcessHandle, startWaitForProcessExit func(), err error)
 
-	// Stops the process with a given PID.
-	// The processStartTime, if provided (time.IsZero() returns false), is used to further validate the process to be stopped.
+	// Stops the process identified by the given ProcessHandle.
+	// The handle's IdentityTime, if provided (time.IsZero() returns false), is used to further validate the process to be stopped
 	// (to protect against stopping a wrong process, if the PID was reused).
-	StopProcess(pid Pid_t, processStartTime time.Time, options ...ProcessStopOption) error
+	StopProcess(handle ProcessHandle, options ...ProcessStopOption) error
 
-	// Checks that the process with a given PID is running.
-	// The processStartTime, if provided (time.IsZero() returns false), is used to further validate the process.
-	CheckProcessRunning(pid Pid_t, processStartTime time.Time) error
+	// Checks that the process identified by the given ProcessHandle is running.
+	CheckProcessRunning(handle ProcessHandle) error
 
 	// Starts a process that does not need to be tracked (the caller is not interested in its exit code),
 	// minimizing resource usage. An error is returned if the process could not be started.
-	StartAndForget(cmd *exec.Cmd, creationFlags ProcessCreationFlag) (pid Pid_t, startTime time.Time, err error)
+	StartAndForget(cmd *exec.Cmd, creationFlags ProcessCreationFlag) (handle ProcessHandle, err error)
 
 	// Disposes the executor. Processes started with CreationFlagEnsureKillOnDispose will be terminated.
 	// Other processes will be waited on (so that they do not become zombies), but not terminated.

--- a/pkg/process/process_unix_test.go
+++ b/pkg/process/process_unix_test.go
@@ -44,17 +44,15 @@ func TestStopProcessIgnoreSigterm(t *testing.T) {
 		_ = cmd.Wait()
 	}()
 
-	pid := process.Uint32_ToPidT(uint32(cmd.Process.Pid))
-	identityTime := process.ProcessIdentityTime(pid)
-	require.False(t, identityTime.IsZero(), "process start time should not be zero")
-	rootP := process.ProcessTreeItem{pid, identityTime}
+	rootP := process.ProcessHandleFromCmd(cmd)
+	require.False(t, rootP.IdentityTime.IsZero(), "process start time should not be zero")
 
 	// Only one process should be running, so the "tree" size is 1.
 	int_testutil.EnsureProcessTree(t, rootP, 1, 5*time.Second)
 
 	executor := process.NewOSExecutor(log)
 	start := time.Now()
-	err = executor.StopProcess(pid, time.Time{})
+	err = executor.StopProcess(process.NewHandle(rootP.Pid, time.Time{}))
 	require.NoError(t, err)
 	elapsed := time.Since(start)
 	elapsedStr := osutil.FormatDuration(elapsed)
@@ -63,10 +61,10 @@ func TestStopProcessIgnoreSigterm(t *testing.T) {
 		// It should not take more than `signalAndWaitTimeout` though.
 		t.Fatal("Process was not terminated timely, elapsed time was ", elapsedStr)
 	}
-	ensureAllStopped(t, []process.ProcessTreeItem{rootP}, 5*time.Second)
+	ensureAllStopped(t, []process.ProcessHandle{rootP}, 5*time.Second)
 }
 
-func ensureAllStopped(t *testing.T, processes []process.ProcessTreeItem, timeout time.Duration) {
+func ensureAllStopped(t *testing.T, processes []process.ProcessHandle, timeout time.Duration) {
 	timeoutCtx, timeoutCtxCancelFn := context.WithTimeout(context.Background(), timeout)
 	defer timeoutCtxCancelFn()
 
@@ -83,7 +81,7 @@ func ensureAllStopped(t *testing.T, processes []process.ProcessTreeItem, timeout
 	require.NoError(t, err, "not all processes could be stopped")
 }
 
-func isStopped(pp process.ProcessTreeItem) bool {
+func isStopped(pp process.ProcessHandle) bool {
 	// On Unix-like systems FindProcess() always succeeds, so it is not a reliable way of checking
 	// if the process is still running.
 	osPid, err := process.PidT_ToInt(pp.Pid)

--- a/pkg/process/process_util.go
+++ b/pkg/process/process_util.go
@@ -24,11 +24,6 @@ import (
 	"github.com/microsoft/dcp/pkg/slices"
 )
 
-type ProcessTreeItem struct {
-	Pid          Pid_t
-	IdentityTime time.Time // Used to distinguish between different instances of processes with the same PID, may not be a valid wall-clock time.
-}
-
 func FormatIdentityTime(identityTime time.Time) string {
 	if identityTime.IsZero() {
 		return ""
@@ -37,7 +32,7 @@ func FormatIdentityTime(identityTime time.Time) string {
 }
 
 var (
-	This func() (ProcessTreeItem, error)
+	This func() (ProcessHandle, error)
 
 	// Essentially the same as ps.ErrorProcessNotRunning, but we do not want to
 	// expose the ps package outside of this package.
@@ -49,28 +44,28 @@ var (
 	ErrProcessIdentityMismatch = errors.New("process start time mismatch, pid might have been reused")
 )
 
-func getIDs(items []ProcessTreeItem) []Pid_t {
-	return slices.Map[Pid_t](items, func(item ProcessTreeItem) Pid_t {
+func getIDs(items []ProcessHandle) []Pid_t {
+	return slices.Map[Pid_t](items, func(item ProcessHandle) Pid_t {
 		return item.Pid
 	})
 }
 
 // Returns the list of ID for a given process and its children
 // The list is ordered starting with the root of the hierarchy, then the children, then the grandchildren etc.
-func GetProcessTree(rootP ProcessTreeItem) ([]ProcessTreeItem, error) {
-	root, err := findPsProcess(rootP.Pid, rootP.IdentityTime)
+func GetProcessTree(rootP ProcessHandle) ([]ProcessHandle, error) {
+	root, err := findPsProcess(rootP)
 	if err != nil {
 		return nil, err
 	}
 
-	tree := []ProcessTreeItem{}
+	tree := []ProcessHandle{}
 	next := []*ps.Process{root}
 
 	for len(next) > 0 {
 		current := next[0]
 		next = next[1:]
 		nextPid := Uint32_ToPidT(uint32(current.Pid))
-		tree = append(tree, ProcessTreeItem{nextPid, processIdentityTime(current)})
+		tree = append(tree, ProcessHandle{nextPid, processIdentityTime(current)})
 
 		children, childrenErr := current.Children()
 		if childrenErr != nil {
@@ -94,9 +89,9 @@ func RunToCompletion(ctx context.Context, executor Executor, cmd *exec.Cmd) (int
 	pic := make(chan ProcessExitInfo, 1)
 	peh := NewChannelProcessExitHandler(pic)
 
-	_, _, startWaitForProcessExit, err := executor.StartProcess(ctx, cmd, peh, CreationFlagsNone, nil)
-	if err != nil {
-		return UnknownExitCode, err
+	_, startWaitForProcessExit, startProcessErr := executor.StartProcess(ctx, cmd, peh, CreationFlagsNone, nil)
+	if startProcessErr != nil {
+		return UnknownExitCode, startProcessErr
 	}
 
 	startWaitForProcessExit()
@@ -170,8 +165,8 @@ func ProcessIdentityTime(pid Pid_t) time.Time {
 	return processIdentityTime(proc)
 }
 
-func findPsProcess(pid Pid_t, expectedIdentityTime time.Time) (*ps.Process, error) {
-	osPid, err := PidT_ToUint32(pid)
+func findPsProcess(handle ProcessHandle) (*ps.Process, error) {
+	osPid, err := PidT_ToUint32(handle.Pid)
 	if err != nil {
 		return nil, err
 	}
@@ -182,18 +177,18 @@ func findPsProcess(pid Pid_t, expectedIdentityTime time.Time) (*ps.Process, erro
 		if !errors.Is(procErr, ps.ErrorProcessNotRunning) {
 			return nil, procErr
 		} else {
-			return nil, fmt.Errorf("process with pid %d does not exist: %w", pid, ErrorProcessNotFound)
+			return nil, fmt.Errorf("process with pid %d does not exist: %w", handle.Pid, ErrorProcessNotFound)
 		}
 	}
 
-	if !HasExpectedIdentityTime(proc, expectedIdentityTime) {
+	if !HasExpectedIdentityTime(proc, handle.IdentityTime) {
 		actualIdentityTime := processIdentityTime(proc)
 
 		return nil, fmt.Errorf(
 			"%w: pid %d, expected start time %s, actual start time %s",
 			ErrProcessIdentityMismatch,
-			pid,
-			expectedIdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
+			handle.Pid,
+			handle.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
 			actualIdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
 		)
 	}
@@ -201,17 +196,17 @@ func findPsProcess(pid Pid_t, expectedIdentityTime time.Time) (*ps.Process, erro
 	return proc, nil
 }
 
-// Returns the process with the given PID. If the expectedStartTime is not zero,
-// the process start time is checked to match the expected start time.
-func FindProcess(pid Pid_t, expectedStartTime time.Time) (*os.Process, error) {
-	proc, err := findPsProcess(pid, expectedStartTime)
+// Returns the process with the given handle. If the handle's IdentityTime is not zero,
+// the process identity time is checked to match the expected identity time.
+func FindProcess(handle ProcessHandle) (*os.Process, error) {
+	proc, err := findPsProcess(handle)
 	if err != nil {
 		return nil, err
 	}
 
-	process, err := os.FindProcess(int(proc.Pid))
-	if err != nil {
-		return nil, err
+	process, findErr := os.FindProcess(int(proc.Pid))
+	if findErr != nil {
+		return nil, findErr
 	}
 
 	return process, nil
@@ -331,8 +326,8 @@ func makeProcessWaitable(pid Pid_t, proc *os.Process) Waitable {
 func init() {
 	ps.EnableBootTimeCache(true)
 
-	This = sync.OnceValues(func() (ProcessTreeItem, error) {
-		retval := ProcessTreeItem{
+	This = sync.OnceValues(func() (ProcessHandle, error) {
+		retval := ProcessHandle{
 			Pid:          UnknownPID,
 			IdentityTime: time.Time{},
 		}

--- a/pkg/process/process_windows_test.go
+++ b/pkg/process/process_windows_test.go
@@ -30,7 +30,7 @@ const (
 	STILL_ACTIVE = 259
 )
 
-func ensureAllStopped(t *testing.T, processes []process.ProcessTreeItem, timeout time.Duration) {
+func ensureAllStopped(t *testing.T, processes []process.ProcessHandle, timeout time.Duration) {
 	timeoutCtx, timeoutCtxCancelFn := context.WithTimeout(context.Background(), timeout)
 	defer timeoutCtxCancelFn()
 
@@ -47,7 +47,7 @@ func ensureAllStopped(t *testing.T, processes []process.ProcessTreeItem, timeout
 	require.NoError(t, err, "not all processes could be stopped")
 }
 
-func isStopped(pp process.ProcessTreeItem) bool {
+func isStopped(pp process.ProcessHandle) bool {
 	osPid, err := process.PidT_ToUint32(pp.Pid)
 	if err != nil {
 		// Invalid PID value, so there is no process with such ID

--- a/pkg/process/waitable_process.go
+++ b/pkg/process/waitable_process.go
@@ -27,8 +27,8 @@ type WaitableProcess struct {
 	waitLock         sync.Mutex
 }
 
-func FindWaitableProcess(pid Pid_t, processStartTime time.Time) (*WaitableProcess, error) {
-	foundProcess, err := FindProcess(pid, processStartTime)
+func FindWaitableProcess(handle ProcessHandle) (*WaitableProcess, error) {
+	foundProcess, err := FindProcess(handle)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func FindWaitableProcess(pid Pid_t, processStartTime time.Time) (*WaitableProces
 	dcpProcess := &WaitableProcess{
 		WaitPollInterval: defaultWaitPollInterval,
 		process:          foundProcess,
-		processStartTime: processStartTime,
+		processStartTime: handle.IdentityTime,
 		err:              nil,
 		waitLock:         sync.Mutex{},
 	}
@@ -78,7 +78,7 @@ func (p *WaitableProcess) pollingWait(ctx context.Context) {
 					case <-timer.C:
 						pid := Uint32_ToPidT(uint32(p.process.Pid))
 
-						_, pollErr := FindProcess(pid, p.processStartTime)
+						_, pollErr := FindProcess(ProcessHandle{Pid: pid, IdentityTime: p.processStartTime})
 						// We couldn't find the PID, so the process has exited
 						if pollErr != nil {
 							p.err = nil

--- a/test/integration/container_controller_terminal_test.go
+++ b/test/integration/container_controller_terminal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microsoft/dcp/internal/containers"
 	"github.com/microsoft/dcp/internal/termpty"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
 	usvc_random "github.com/microsoft/dcp/pkg/randdata"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
@@ -274,6 +275,12 @@ func TestContainerTerminalDeletionTearsDownPty(t *testing.T) {
 		t.Fatal("timed out waiting for TestPty from container attach factory")
 	}
 
+	// Status should report the configured terminal socket path.
+	running := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.TerminalSocketPath != "", nil
+	})
+	require.Equal(t, socketPath, running.Status.TerminalSocketPath, "Status should report the configured terminal socket path")
+
 	// Sanity check: the socket file exists before deletion.
 	_, statErr := os.Stat(socketPath)
 	require.NoError(t, statErr, "socket file should exist before deletion")
@@ -284,6 +291,72 @@ func TestContainerTerminalDeletionTearsDownPty(t *testing.T) {
 		return attached.TestPty.IsClosed(), nil
 	})
 	require.NoError(t, pollErr, "expected TestPty to be closed after Container deletion")
+
+	// DCP owns the listen-mode socket file, so it must be removed once the terminal is torn down.
+	removalErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		_, pollStatErr := os.Stat(socketPath)
+		return errors.Is(pollStatErr, os.ErrNotExist), nil
+	})
+	require.NoError(t, removalErr, "terminal socket file should be removed after Container deletion")
+}
+
+// TestContainerTerminalGeneratesSocketPathWhenUDSPathEmpty verifies that a terminal
+// Container created with an empty UDSPath reaches Running with a DCP-generated socket
+// path reported in Status, that the socket exists and serves while Running, and that the
+// generated file is removed once the Container is deleted.
+func TestContainerTerminalGeneratesSocketPathWhenUDSPathEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const ctrName = "test-ctr-term-autopath"
+	ctr := makeTerminalContainer(ctrName, "") // empty UDSPath: DCP generates the socket path.
+
+	infoCh := containerAttachFactoryDispatcher.InstallHandler(
+		t, ctr.Spec.ContainerName,
+		ctrl_testutil.NewTestPtyContainerAttachFactory(testProcessExecutor))
+
+	require.NoError(t, client.Create(ctx, ctr), "create Container")
+
+	_, _ = ensureContainerRunning(t, ctx, ctr)
+	var attached *ctrl_testutil.AttachedTerminalInfo
+	select {
+	case attached = <-infoCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for TestPty from container attach factory")
+	}
+
+	running := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(ctr), func(c *apiv1.Container) (bool, error) {
+		return c.Status.TerminalSocketPath != "", nil
+	})
+	generatedPath := running.Status.TerminalSocketPath
+	require.NotEmpty(t, generatedPath, "Status should report the DCP-generated terminal socket path")
+	require.Truef(t, strings.HasPrefix(generatedPath, usvc_io.DcpTempDir()),
+		"generated socket path %q should live under the DCP temp dir %q", generatedPath, usvc_io.DcpTempDir())
+	t.Cleanup(func() { _ = os.Remove(generatedPath) })
+
+	_, statErr := os.Stat(generatedPath)
+	require.NoError(t, statErr, "generated socket file should exist while Running")
+
+	// The generated socket must actually serve HMP v1 clients.
+	conn := dialTerminalSocketWhenReady(t, ctx, generatedPath)
+	hello := drainHelloAndStateSync(t, ctx, conn)
+	require.Equal(t, 1, hello.Version)
+	_ = conn.Close()
+
+	require.NoError(t, client.Delete(ctx, ctr), "delete Container")
+
+	pollErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		return attached.TestPty.IsClosed(), nil
+	})
+	require.NoError(t, pollErr, "expected TestPty to be closed after Container deletion")
+
+	removalErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		_, pollStatErr := os.Stat(generatedPath)
+		return errors.Is(pollStatErr, os.ErrNotExist), nil
+	})
+	require.NoError(t, removalErr, "generated terminal socket file should be removed after Container deletion")
 }
 
 // Verifies that when the container attach factory returns an error,

--- a/test/integration/container_network_tunnel_proxy_test.go
+++ b/test/integration/container_network_tunnel_proxy_test.go
@@ -1321,15 +1321,15 @@ func TestTunnelProxyWithRealOrchestrator(t *testing.T) {
 }
 
 func shutdownTestEnvironment(serverInfo *ctrl_testutil.ApiServerInfo, cancel context.CancelFunc) {
-	serverInfo.Dispose()
+	cancel()
 
-	// Wait for the API server cleanup to complete (with timeout)
+	// StartTestEnvironment closes its state store before disposing the API server. Wait
+	// for that full cleanup path before returning so t.TempDir cleanup does not race
+	// open SQLite file handles on Windows.
 	select {
 	case <-serverInfo.ApiServerDisposalComplete.Wait():
 	case <-time.After(20 * time.Second):
 	}
-
-	cancel()
 }
 
 func shutdownAdvancedTestEnvironment(

--- a/test/integration/controllers_common_test.go
+++ b/test/integration/controllers_common_test.go
@@ -53,7 +53,7 @@ var (
 	restClient                       *clientgorest.RESTClient
 	containerOrchestrator            *ctrl_testutil.TestContainerOrchestrator
 	testStateStore                   *statestore.Store
-	testResourceLeaseOwner           process.ProcessTreeItem
+	testResourceLeaseOwner           process.ProcessHandle
 )
 
 const pollImmediately = true // Don't wait before polling for the first time

--- a/test/integration/executable_controller_terminal_test.go
+++ b/test/integration/executable_controller_terminal_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/microsoft/dcp/internal/termpty"
 	internal_testutil "github.com/microsoft/dcp/internal/testutil"
 	ctrl_testutil "github.com/microsoft/dcp/internal/testutil/ctrlutil"
+	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/process"
 	usvc_random "github.com/microsoft/dcp/pkg/randdata"
 	"github.com/microsoft/dcp/pkg/testutil"
@@ -376,6 +377,12 @@ func TestExecutableTerminalDeletionTearsDownPty(t *testing.T) {
 		t.Fatal("timed out waiting for TestPty from terminal factory")
 	}
 
+	// Status should report the configured terminal socket path.
+	running := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.TerminalSocketPath != "", nil
+	})
+	require.Equal(t, socketPath, running.Status.TerminalSocketPath, "Status should report the configured terminal socket path")
+
 	// Sanity check: the socket file exists before deletion.
 	_, statErr := os.Stat(socketPath)
 	require.NoError(t, statErr, "socket file should exist before deletion")
@@ -386,6 +393,70 @@ func TestExecutableTerminalDeletionTearsDownPty(t *testing.T) {
 		return testPty.IsClosed(), nil
 	})
 	require.NoError(t, pollErr, "expected TestPty to be closed after Executable deletion")
+
+	// DCP owns the listen-mode socket file, so it must be removed once the terminal is torn down.
+	removalErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		_, pollStatErr := os.Stat(socketPath)
+		return errors.Is(pollStatErr, os.ErrNotExist), nil
+	})
+	require.NoError(t, removalErr, "terminal socket file should be removed after Executable deletion")
+}
+
+// TestExecutableTerminalGeneratesSocketPathWhenUDSPathEmpty verifies that a terminal
+// Executable created with an empty UDSPath reaches Running with a DCP-generated socket
+// path reported in Status, that the socket exists and serves while Running, and that the
+// generated file is removed once the Executable is deleted.
+func TestExecutableTerminalGeneratesSocketPathWhenUDSPathEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, defaultIntegrationTestTimeout)
+	defer cancel()
+
+	const exeName = "test-exe-term-autopath"
+	exe := makeTerminalExecutable(exeName, "") // empty UDSPath: DCP generates the socket path.
+
+	ptyCh := terminalProcessFactoryDispatcher.InstallHandler(t, exe.Spec.ExecutablePath, ctrl_testutil.NewTestPtyTerminalFactory())
+
+	require.NoError(t, client.Create(ctx, exe), "create Executable")
+
+	_ = ensureExeRunning(t, ctx, exe)
+	var testPty *internal_testutil.TestPty
+	select {
+	case testPty = <-ptyCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for TestPty from terminal factory")
+	}
+
+	running := waitObjectAssumesState(t, ctx, ctrl_client.ObjectKeyFromObject(exe), func(currentExe *apiv1.Executable) (bool, error) {
+		return currentExe.Status.TerminalSocketPath != "", nil
+	})
+	generatedPath := running.Status.TerminalSocketPath
+	require.NotEmpty(t, generatedPath, "Status should report the DCP-generated terminal socket path")
+	require.Truef(t, strings.HasPrefix(generatedPath, usvc_io.DcpTempDir()),
+		"generated socket path %q should live under the DCP temp dir %q", generatedPath, usvc_io.DcpTempDir())
+	t.Cleanup(func() { _ = os.Remove(generatedPath) })
+
+	_, statErr := os.Stat(generatedPath)
+	require.NoError(t, statErr, "generated socket file should exist while Running")
+
+	// The generated socket must actually serve HMP v1 clients.
+	conn := dialTerminalSocketWhenReady(t, ctx, generatedPath)
+	hello := drainHelloAndStateSync(t, ctx, conn)
+	require.Equal(t, 1, hello.Version)
+	_ = conn.Close()
+
+	require.NoError(t, client.Delete(ctx, exe), "delete Executable")
+
+	pollErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		return testPty.IsClosed(), nil
+	})
+	require.NoError(t, pollErr, "expected TestPty to be closed after Executable deletion")
+
+	removalErr := wait.PollUntilContextCancel(ctx, waitPollInterval, pollImmediately, func(_ context.Context) (bool, error) {
+		_, pollStatErr := os.Stat(generatedPath)
+		return errors.Is(pollStatErr, os.ErrNotExist), nil
+	})
+	require.NoError(t, removalErr, "generated terminal socket file should be removed after Executable deletion")
 }
 
 // Verifies that when the terminal process factory returns an error, the Executable

--- a/test/integration/executable_controller_test.go
+++ b/test/integration/executable_controller_test.go
@@ -392,11 +392,13 @@ func TestExecutableCleanupModeStopsExistingProcessOnDelete(t *testing.T) {
 	}
 
 	cmd := exec.Command(exe.Spec.ExecutablePath)
-	pid, identityTime, _, startProcessErr := teInfo.TestProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	handle, _, startProcessErr := teInfo.TestProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
 	require.NoError(t, startProcessErr, "could not seed process execution")
 	t.Cleanup(func() {
-		_ = teInfo.TestProcessExecutor.StopProcess(pid, identityTime)
+		_ = teInfo.TestProcessExecutor.StopProcess(handle)
 	})
+	pid := handle.Pid
+	identityTime := handle.IdentityTime
 
 	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
 	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
@@ -452,11 +454,13 @@ func TestExecutableCleanupModeDeletedBeforeAdoptionStopsExistingProcess(t *testi
 	}
 
 	cmd := exec.Command(exe.Spec.ExecutablePath)
-	pid, identityTime, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	handle, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
 	require.NoError(t, startProcessErr, "could not seed process execution")
 	t.Cleanup(func() {
-		_ = testProcessExecutor.StopProcess(pid, identityTime)
+		_ = testProcessExecutor.StopProcess(handle)
 	})
+	pid := handle.Pid
+	identityTime := handle.IdentityTime
 
 	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
 	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
@@ -473,7 +477,7 @@ func TestExecutableCleanupModeDeletedBeforeAdoptionStopsExistingProcess(t *testi
 	})
 	require.NoError(t, upsertErr, "could not seed persistent process record")
 
-	leaseOwner := process.ProcessTreeItem{Pid: process.Pid_t(1), IdentityTime: time.Now()}
+	leaseOwner := process.ProcessHandle{Pid: process.Pid_t(1), IdentityTime: time.Now()}
 	lease, leaseErr := testStateStore.AcquireResourceLease(ctx, &exe, leaseOwner, time.Minute)
 	require.NoError(t, leaseErr, "could not acquire persistent process lease")
 
@@ -588,11 +592,13 @@ func TestExecutableCleanupModeAdoptsProcessRecordCreatedAfterNotFound(t *testing
 	})
 
 	cmd := exec.Command(exe.Spec.ExecutablePath)
-	pid, identityTime, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
+	handle, _, startProcessErr := testProcessExecutor.StartProcess(ctx, cmd, nil, process.CreationFlagsNone, nil)
 	require.NoError(t, startProcessErr, "could not seed process execution")
 	t.Cleanup(func() {
-		_ = testProcessExecutor.StopProcess(pid, identityTime)
+		_ = testProcessExecutor.StopProcess(handle)
 	})
+	pid := handle.Pid
+	identityTime := handle.IdentityTime
 
 	lifecycleKey, _, lifecycleKeyErr := exe.GetLifecycleKey()
 	require.NoError(t, lifecycleKeyErr, "could not calculate lifecycle key")
@@ -3463,7 +3469,7 @@ func TestExecutableLogsRejectedWhenTerminalConfigured(t *testing.T) {
 		pe process.Executor,
 		spec *termpty.CommandSpec,
 	) (*termpty.PseudoTerminalProcess, error) {
-		_, _, _, startErr := pe.StartProcess(ctx, spec.Cmd, process.NewConcurrentProcessExitHandler(), spec.CreationFlags, nil)
+		_, _, startErr := pe.StartProcess(ctx, spec.Cmd, process.NewConcurrentProcessExitHandler(), spec.CreationFlags, nil)
 		return nil, startErr
 	})
 

--- a/test/integration/network_controller_test.go
+++ b/test/integration/network_controller_test.go
@@ -446,7 +446,7 @@ func ensureNetworkCreated(t *testing.T, ctx context.Context, network *apiv1.Cont
 	return updatedNet
 }
 
-func nonExistentProcess(t *testing.T) process.ProcessTreeItem {
+func nonExistentProcess(t *testing.T) process.ProcessHandle {
 	pps, ppsErr := ps.Processes()
 	require.NoError(t, ppsErr, "could not list processes")
 	pids := slices.Map[process.Pid_t](pps, func(pp *ps.Process) process.Pid_t {
@@ -463,7 +463,7 @@ func nonExistentProcess(t *testing.T) process.ProcessTreeItem {
 		require.NoError(t, candidateErr)
 
 		if !slices.Contains(pids, candidate) {
-			return process.ProcessTreeItem{
+			return process.ProcessHandle{
 				Pid:          candidate,
 				IdentityTime: time.Now().Add(-time.Minute),
 			}

--- a/test/integration/standard_test_env.go
+++ b/test/integration/standard_test_env.go
@@ -39,7 +39,7 @@ type TestEnvironmentInfo struct {
 	TerminalProcessFactoryDispatcher *ctrl_testutil.TerminalProcessFactoryDispatcher
 	ContainerAttachFactoryDispatcher *ctrl_testutil.ContainerAttachFactoryDispatcher
 	StateStore                       *statestore.Store
-	ResourceLeaseOwner               process.ProcessTreeItem
+	ResourceLeaseOwner               process.ProcessHandle
 	Log                              logr.Logger
 }
 


### PR DESCRIPTION
Backports the terminal socket ownership work from #185 and the ProcessHandle extraction from #196 to `release/0.25`. #185 is included first because #196 touches the same terminal lifecycle paths and depends on the newer listen-mode socket ownership behavior from `main`.

## Summary

- Backport #185: DCP owns listen-mode terminal socket files, can generate socket paths, reports resolved terminal socket paths, and adds socket lifecycle coverage.
- Backport #196: introduce `process.ProcessHandle` as the shared PID plus identity-time value and update process execution, monitoring, persistence, controller, and test call sites to pass handles instead of separate values.
- Preserve the same commit ordering as `main`: #185 first, then #196.

## Validation

- `make generate`
- `make test-prereqs`
- `make test` currently fails in `internal/termpty` at `TestConnManager_ExitCodePropagatedToClient`, where an exit-code/shutdown race can send `0` instead of the recorded code. Filed as #199 to fix on `main` separately rather than adding a release-only fix in this backport.