### PR TITLE
Monitor forked process exits

### DIFF
--- a/internal/commands/cmd_util.go
+++ b/internal/commands/cmd_util.go
@@ -6,12 +6,42 @@
 package commands
 
 import (
+	"errors"
 	"os"
 
 	"github.com/microsoft/dcp/pkg/logger"
 )
 
+type exitCodeError struct {
+	err      error
+	exitCode int
+}
+
+func NewExitCodeError(err error, exitCode int) error {
+	return &exitCodeError{
+		err:      err,
+		exitCode: exitCode,
+	}
+}
+
+func (e *exitCodeError) Error() string {
+	return e.err.Error()
+}
+
+func (e *exitCodeError) Unwrap() error {
+	return e.err
+}
+
+func (e *exitCodeError) ExitCode() int {
+	return e.exitCode
+}
+
 func ErrorExit(log *logger.Logger, err error, exitCode int) {
+	var exitErr *exitCodeError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+
 	log.Error(err, "the program finished with an error", "ExitCode", exitCode)
 	log.Flush()
 	os.Exit(exitCode)

--- a/internal/dcpproc/commands/fork_process.go
+++ b/internal/dcpproc/commands/fork_process.go
@@ -6,6 +6,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,20 +14,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
+	cmds "github.com/microsoft/dcp/internal/commands"
 	"github.com/microsoft/dcp/pkg/logger"
 	"github.com/microsoft/dcp/pkg/process"
 )
 
 func NewForkProcessCommand(log logr.Logger) (*cobra.Command, error) {
 	forkProcessCmd := &cobra.Command{
-		Use:                "fork-process command [args...]",
-		Short:              "Starts a detached child process and prints its PID.",
-		Long:               "Starts a child process outside of the parent process tree or process group and writes the child PID to stdout.",
-		RunE:               forkProcess(log),
-		SilenceUsage:       true,
-		Args:               validateForkProcessArgs,
-		DisableFlagParsing: true,
+		Use:   "fork-process [--monitor pid] [--monitor-identity-time time] -- command [args...]",
+		Short: "Starts a detached child process.",
+		Long:  "Starts a child process outside of the parent process tree or process group and writes the child PID to stdout. If a monitor process is provided, waits for either the child or monitor process to exit and exits with the child process exit code if the child exits first. If the monitor process exits first, fork-process exits and leaves the child process running.",
+		RunE:  forkProcess(log),
+		Args:  validateForkProcessArgs,
+
+		SilenceUsage: true,
 	}
+
+	cmds.AddMonitorFlags(forkProcessCmd)
 
 	return forkProcessCmd, nil
 }
@@ -43,29 +47,113 @@ func forkProcess(log logr.Logger) func(cmd *cobra.Command, args []string) error 
 	return func(cmd *cobra.Command, args []string) error {
 		args = trimForkProcessArgSeparator(args)
 
+		log = log.WithName("ForkProcess").WithValues(
+			"Command", args[0],
+			"Args", args[1:],
+		)
+
 		childCmd := exec.Command(args[0], args[1:]...)
 		childCmd.Env = os.Environ()
 		logger.WithSessionId(childCmd)
 		process.ForkFromParent(childCmd)
 
-		if startErr := childCmd.Start(); startErr != nil {
-			log.Error(startErr, "Failed to start forked process", "Command", args[0], "Args", args[1:])
-			return fmt.Errorf("could not start forked process: %w", startErr)
+		monitorEnabled := cmd.Flags().Changed("monitor")
+		var monitorCtx context.Context
+		var monitorCtxCancel context.CancelFunc
+		if monitorEnabled {
+			monitorCtx, monitorCtxCancel = cmds.GetMonitorContextFromFlags(cmd.Context(), log)
+			defer monitorCtxCancel()
+			select {
+			case <-monitorCtx.Done():
+				log.Info("Monitored process already exited; forked process will not be started")
+				return nil
+			default:
+			}
 		}
 
-		pid := childCmd.Process.Pid
-		if releaseErr := childCmd.Process.Release(); releaseErr != nil {
-			log.Error(releaseErr, "Failed to release forked process", "PID", pid)
-			return fmt.Errorf("could not release forked process %d: %w", pid, releaseErr)
+		pid, childExitInfoCh, disposeChildExecutor, startErr := startForkedProcess(cmd, childCmd, monitorEnabled, log)
+		if startErr != nil {
+			return startErr
+		}
+		defer disposeChildExecutor()
+
+		if !monitorEnabled {
+			return nil
 		}
 
-		if _, writeErr := fmt.Fprintln(cmd.OutOrStdout(), pid); writeErr != nil {
-			log.Error(writeErr, "Failed to write forked process PID", "PID", pid)
-			return fmt.Errorf("could not write forked process pid: %w", writeErr)
-		}
+		select {
+		case childExitInfo, ok := <-childExitInfoCh:
+			if !ok {
+				return fmt.Errorf("forked process exit channel closed without a result")
+			}
 
-		return nil
+			if childExitInfo.Err != nil {
+				log.Error(childExitInfo.Err, "Error waiting for forked process", "PID", pid)
+				return childExitInfo.Err
+			}
+
+			if childExitInfo.ExitCode != 0 {
+				exitCode := int(childExitInfo.ExitCode)
+				log.Info("Forked process exited with a non-zero exit code", "PID", pid, "ExitCode", exitCode)
+				return cmds.NewExitCodeError(fmt.Errorf("forked process exited with code %d", exitCode), exitCode)
+			}
+
+			log.V(1).Info("Forked process exited", "PID", pid)
+			return nil
+
+		case <-monitorCtx.Done():
+			if cmd.Context().Err() != nil {
+				return cmd.Context().Err()
+			}
+
+			log.Info("Monitored process exited; fork-process is exiting", "PID", pid)
+			return nil
+		}
 	}
+}
+
+func startForkedProcess(
+	cmd *cobra.Command,
+	childCmd *exec.Cmd,
+	observeExit bool,
+	log logr.Logger,
+) (process.Pid_t, <-chan process.ProcessExitInfo, func(), error) {
+	executor := process.NewOSExecutor(log.WithName("ProcessExecutor"))
+	dispose := executor.Dispose
+
+	var handle process.ProcessHandle
+	var childExitInfoCh chan process.ProcessExitInfo
+	var startErr error
+	if observeExit {
+		childExitInfoCh = make(chan process.ProcessExitInfo, 1)
+		childExitHandler := process.NewChannelProcessExitHandler(childExitInfoCh)
+		var startWaitForProcessExit func()
+		handle, startWaitForProcessExit, startErr = executor.StartProcess(context.Background(), childCmd, childExitHandler, process.CreationFlagsNone, nil)
+		if startErr == nil {
+			startWaitForProcessExit()
+		}
+	} else {
+		handle, startErr = executor.StartAndForget(childCmd, process.CreationFlagsNone)
+	}
+	if startErr != nil {
+		log.Error(startErr, "Failed to start forked process", "Command", childCmd.Path, "Args", childCmd.Args[1:])
+		executor.Dispose()
+		return process.UnknownPID, nil, nil, fmt.Errorf("could not start forked process: %w", startErr)
+	}
+
+	pid := handle.Pid
+	if _, writeErr := fmt.Fprintln(cmd.OutOrStdout(), pid); writeErr != nil {
+		log.Error(writeErr, "Failed to write forked process PID", "PID", pid)
+		executor.Dispose()
+		return process.UnknownPID, nil, nil, fmt.Errorf("could not write forked process pid: %w", writeErr)
+	}
+
+	if !observeExit {
+		executor.Dispose()
+		dispose = func() {}
+	}
+
+	return pid, childExitInfoCh, dispose, nil
 }
 
 func trimForkProcessArgSeparator(args []string) []string {

--- a/internal/dcpproc/fork_process_test.go
+++ b/internal/dcpproc/fork_process_test.go
@@ -6,8 +6,12 @@
 package dcpproc_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -17,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	int_testutil "github.com/microsoft/dcp/internal/testutil"
+	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/process"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
@@ -24,8 +29,8 @@ import (
 func TestForkProcessStartsDetachedCommand(t *testing.T) {
 	t.Parallel()
 
-	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer testCancel()
+	testCtx, testCancel := testutil.GetTestContext(t, 30*time.Second)
+	t.Cleanup(testCancel)
 
 	forkedProcess := startForkedDelay(t, testCtx)
 
@@ -33,6 +38,90 @@ func TestForkProcessStartsDetachedCommand(t *testing.T) {
 	checkExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
 	defer checkExecutor.Dispose()
 	require.NoError(t, checkExecutor.CheckProcessRunning(forkedProcess))
+}
+
+func TestForkProcessExitsWithChildExitCode(t *testing.T) {
+	t.Parallel()
+
+	testCtx, testCancel := testutil.GetTestContext(t, 30*time.Second)
+	defer testCancel()
+
+	dcpProc, dcpProcErr := getDcpProcExecutablePath()
+	require.NoError(t, dcpProcErr)
+
+	delayToolPath, toolPathErr := int_testutil.GetTestToolPath("delay")
+	require.NoError(t, toolPathErr)
+
+	cmdArgs := forkProcessArgsForCurrentProcess(t, delayToolPath, "--delay=100ms", "--exit-code=7")
+	dcpProcCmd := exec.CommandContext(testCtx, dcpProc, cmdArgs...)
+	var stdout, stderr bytes.Buffer
+	dcpProcCmd.Stdout = &stdout
+	dcpProcCmd.Stderr = &stderr
+
+	runErr := dcpProcCmd.Run()
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(runErr, &exitErr), "dcp fork-process should exit with the child exit code; stderr: %s", stderr.String())
+	require.Equal(t, 7, exitErr.ExitCode(), "dcp fork-process should exit with the child exit code; stderr: %s", stderr.String())
+
+	stdoutText := strings.TrimSpace(stdout.String())
+	_ = parseForkedPid(t, stdoutText)
+}
+
+func TestForkProcessExitsWhenMonitoredParentExits(t *testing.T) {
+	t.Parallel()
+
+	testCtx, testCancel := testutil.GetTestContext(t, 30*time.Second)
+	t.Cleanup(testCancel)
+
+	dcpProc, dcpProcErr := getDcpProcExecutablePath()
+	require.NoError(t, dcpProcErr)
+
+	delayToolPath, toolPathErr := int_testutil.GetTestToolPath("delay")
+	require.NoError(t, toolPathErr)
+
+	parentCmd := exec.CommandContext(testCtx, delayToolPath, "--delay=30s")
+	require.NoError(t, parentCmd.Start(), "parent command should start without error")
+	t.Cleanup(func() {
+		_ = parentCmd.Process.Kill()
+		_ = parentCmd.Wait()
+	})
+
+	parentHandle := process.ProcessHandleFromCmd(parentCmd)
+	require.False(t, parentHandle.IdentityTime.IsZero(), "parent process start time should not be zero")
+
+	dcpProcCmd := exec.CommandContext(testCtx, dcpProc,
+		"fork-process",
+		"--monitor", strconv.Itoa(parentCmd.Process.Pid),
+		"--monitor-identity-time", parentHandle.IdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
+		"--monitor-interval", "1",
+		"--",
+		delayToolPath,
+		"--delay=30s",
+	)
+	stdoutPipe, pipeErr := dcpProcCmd.StdoutPipe()
+	require.NoError(t, pipeErr)
+	var stderr bytes.Buffer
+	dcpProcCmd.Stderr = &stderr
+
+	require.NoError(t, dcpProcCmd.Start(), "dcp fork-process should start without error")
+
+	stdoutText, readErr := bufio.NewReader(stdoutPipe).ReadString('\n')
+	require.NoError(t, readErr, "dcp fork-process should print a child PID; stderr: %s", stderr.String())
+	childPid := parseForkedPid(t, stdoutText)
+	childIdentityTime := process.ProcessIdentityTime(childPid)
+	require.False(t, childIdentityTime.IsZero(), "forked process %d should be running", childPid)
+
+	cleanupExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
+	t.Cleanup(func() {
+		_ = cleanupExecutor.StopProcess(process.NewHandle(childPid, childIdentityTime))
+		cleanupExecutor.Dispose()
+	})
+
+	require.NoError(t, parentCmd.Process.Kill(), "parent command should stop without error")
+	_ = parentCmd.Wait()
+
+	require.NoError(t, dcpProcCmd.Wait(), "dcp fork-process should exit cleanly when the monitored parent exits; stderr: %s", stderr.String())
+	require.NoError(t, cleanupExecutor.CheckProcessRunning(process.NewHandle(childPid, childIdentityTime)), "fork-process should not stop the detached child")
 }
 
 func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessHandle {
@@ -44,7 +133,8 @@ func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessHand
 	delayToolPath, toolPathErr := int_testutil.GetTestToolPath("delay")
 	require.NoError(t, toolPathErr)
 
-	dcpProcCmd := exec.CommandContext(testCtx, dcpProc, "fork-process", delayToolPath, "--delay=30s")
+	cmdArgs := append([]string{"fork-process", "--", delayToolPath}, "--delay=30s")
+	dcpProcCmd := exec.CommandContext(testCtx, dcpProc, cmdArgs...)
 	var stdout, stderr bytes.Buffer
 	dcpProcCmd.Stdout = &stdout
 	dcpProcCmd.Stderr = &stderr
@@ -52,11 +142,7 @@ func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessHand
 	runErr := dcpProcCmd.Run()
 	require.NoError(t, runErr, "dcp fork-process should exit cleanly; stderr: %s", stderr.String())
 
-	stdoutText := strings.TrimSpace(stdout.String())
-	childPid, parseErr := strconv.ParseInt(stdoutText, 10, 64)
-	require.NoError(t, parseErr, "dcp fork-process should print only a child PID, got %q", stdoutText)
-
-	pid := process.Pid_t(childPid)
+	pid := parseForkedPid(t, stdout.String())
 	var identityTime time.Time
 	cleanupExecutor := process.NewOSExecutor(testutil.NewLogForTesting(t.Name()))
 	t.Cleanup(func() {
@@ -68,4 +154,30 @@ func startForkedDelay(t *testing.T, testCtx context.Context) process.ProcessHand
 	require.False(t, identityTime.IsZero(), "forked process %d should still be running", pid)
 
 	return process.NewHandle(pid, identityTime)
+}
+
+func forkProcessArgsForCurrentProcess(t *testing.T, childArgs ...string) []string {
+	t.Helper()
+
+	currentPid := process.Pid_t(os.Getpid())
+	currentIdentityTime := process.ProcessIdentityTime(currentPid)
+	require.False(t, currentIdentityTime.IsZero(), "current process start time should not be zero")
+
+	args := []string{
+		"fork-process",
+		"--monitor", fmt.Sprint(os.Getpid()),
+		"--monitor-identity-time", currentIdentityTime.Format(osutil.RFC3339MiliTimestampFormat),
+		"--",
+	}
+	args = append(args, childArgs...)
+	return args
+}
+
+func parseForkedPid(t *testing.T, stdoutText string) process.Pid_t {
+	t.Helper()
+
+	childPid, parseErr := strconv.ParseInt(strings.TrimSpace(stdoutText), 10, 64)
+	require.NoError(t, parseErr, "dcp fork-process should print only a child PID, got %q", stdoutText)
+
+	return process.Pid_t(childPid)
 }

--- a/internal/dcpproc/fork_process_test.go
+++ b/internal/dcpproc/fork_process_test.go
@@ -44,7 +44,7 @@ func TestForkProcessExitsWithChildExitCode(t *testing.T) {
 	t.Parallel()
 
 	testCtx, testCancel := testutil.GetTestContext(t, 30*time.Second)
-	defer testCancel()
+	t.Cleanup(testCancel)
 
 	dcpProc, dcpProcErr := getDcpProcExecutablePath()
 	require.NoError(t, dcpProcErr)

--- a/internal/dcpproc/fork_process_unix_test.go
+++ b/internal/dcpproc/fork_process_unix_test.go
@@ -8,7 +8,6 @@
 package dcpproc_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -16,13 +15,14 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/testutil"
 )
 
 func TestForkProcessStartsOutsideParentSession(t *testing.T) {
 	t.Parallel()
 
-	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer testCancel()
+	testCtx, testCancel := testutil.GetTestContext(t, 30*time.Second)
+	t.Cleanup(testCancel)
 
 	forkedProcess := startForkedDelay(t, testCtx)
 


### PR DESCRIPTION
Aspire needs `fork-process` to keep enough parent/child lifecycle information available to report early child failures, while still supporting the original detached fire-and-forget behavior when no monitor PID is provided.

This updates `fork-process` so monitor flags are optional. Without `--monitor`, it starts the detached child with `StartAndForget`, prints the PID, and exits as before. With `--monitor`, it starts the child through the process executor, prints the PID, waits for either the child or monitor process to exit, propagates the child exit code when the child exits first, and leaves the child running when the monitor exits first.

Also adds a narrow internal exit-code error path for command exit propagation and tests for detached startup, exit-code propagation, monitor exit behavior, and Unix session/process group separation.

Validation:
- `make lint`
- `make test`