### PR TITLE
Order cleanup resources by dependencies

### DIFF
--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
 	cmds "github.com/microsoft/dcp/internal/commands"
@@ -47,12 +48,12 @@ type persistentProcessCleanupRunner interface {
 	StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error
 }
 
-type cleanupResourceKind string
+type cleanupResourceKind = schema.GroupVersionResource
 
-const (
-	cleanupResourceKindContainer  cleanupResourceKind = "container"
-	cleanupResourceKindExecutable cleanupResourceKind = "executable"
-	cleanupResourceKindNetwork    cleanupResourceKind = "network"
+var (
+	cleanupResourceKindContainer  = (&apiv1.Container{}).GetGroupVersionResource()
+	cleanupResourceKindExecutable = (&apiv1.Executable{}).GetGroupVersionResource()
+	cleanupResourceKindNetwork    = (&apiv1.ContainerNetwork{}).GetGroupVersionResource()
 )
 
 type cleanupResourceState uint
@@ -283,7 +284,7 @@ func runCleanupResourceGroups(report *cleanupReport, groups []cleanupResourceGro
 				resourceID = result.fallbackResourceID
 			}
 			report.Failures = append(report.Failures, cleanupFailureEntry{
-				Kind:        string(result.kind),
+				Kind:        cleanupResourceKindName(result.kind),
 				ResourceKey: result.resourceKey,
 				ResourceID:  resourceID,
 				Error:       result.err.Error(),
@@ -295,7 +296,7 @@ func runCleanupResourceGroups(report *cleanupReport, groups []cleanupResourceGro
 		}
 		countStopped, ok := cleanupStoppedCounters[result.kind]
 		if !ok {
-			return fmt.Errorf("unknown cleanup resource kind %q", result.kind)
+			return fmt.Errorf("unknown cleanup resource kind %q", cleanupResourceKindName(result.kind))
 		}
 		countStopped(&report.Stopped)
 	}
@@ -363,9 +364,9 @@ func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, 
 	if len(blockedGroups) > 0 {
 		blockedGroupDescriptions := slices.Map[string](blockedGroups, func(group cleanupResourceGroup) string {
 			dependencies := slices.Map[string](group.waitingFor, func(kind cleanupResourceKind) string {
-				return string(kind)
+				return cleanupResourceKindName(kind)
 			})
-			return fmt.Sprintf("%s waiting for %s", group.kind, strings.Join(dependencies, ", "))
+			return fmt.Sprintf("%s waiting for %s", cleanupResourceKindName(group.kind), strings.Join(dependencies, ", "))
 		})
 		return results, fmt.Errorf("could not resolve cleanup resource dependencies: %s", strings.Join(blockedGroupDescriptions, "; "))
 	}
@@ -381,6 +382,13 @@ func cleanupReadyGroupIndexes(groups []cleanupResourceGroup) []int {
 		}
 	}
 	return readyGroupIndexes
+}
+
+func cleanupResourceKindName(kind cleanupResourceKind) string {
+	if kind.Resource != "" {
+		return kind.Resource
+	}
+	return kind.String()
 }
 
 func cleanupWorkItems(workItems []cleanupWorkItem) []cleanupWorkResult {

--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	workloadCleanupLeaseRevalidationInterval = 30 * time.Second
-	workloadCleanupStopContainerTimeout      = 10
-	workloadCleanupConcurrency               = uint16(8)
+	workloadCleanupLeaseRevalidationInterval    = 30 * time.Second
+	workloadCleanupStopContainerTimeout         = 10
+	workloadCleanupResourceKindConcurrencyLimit = uint16(8)
 )
 
 type containerOrchestratorProvider func(runtimeName string) (containers.ContainerOrchestrator, error)
@@ -47,15 +47,40 @@ type persistentProcessCleanupRunner interface {
 	StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error
 }
 
+type cleanupResourceKind string
+
+const (
+	cleanupResourceKindContainer  cleanupResourceKind = "container"
+	cleanupResourceKindExecutable cleanupResourceKind = "executable"
+	cleanupResourceKindNetwork    cleanupResourceKind = "network"
+)
+
+type cleanupResourceState uint
+
+const (
+	cleanupResourceStateInitial cleanupResourceState = iota
+	cleanupResourceStateProcessing
+	cleanupResourceStateDone
+)
+
+type cleanupResourceGroup struct {
+	kind         cleanupResourceKind
+	cleanUpAfter []cleanupResourceKind
+	workItems    []cleanupWorkItem
+
+	state      cleanupResourceState
+	waitingFor []cleanupResourceKind
+}
+
 type cleanupWorkItem struct {
-	kind               string
+	kind               cleanupResourceKind
 	resourceKey        string
 	fallbackResourceID string
 	clean              func() (string, bool, error)
 }
 
 type cleanupWorkResult struct {
-	kind               string
+	kind               cleanupResourceKind
 	resourceKey        string
 	fallbackResourceID string
 	resourceID         string
@@ -63,10 +88,27 @@ type cleanupWorkResult struct {
 	err                error
 }
 
+type cleanupResourceGroupResult struct {
+	groupIndex int
+	results    []cleanupWorkResult
+}
+
 type cleanupLeaseResource string
 
 func (r cleanupLeaseResource) GetLeaseKey() string {
 	return string(r)
+}
+
+var cleanupStoppedCounters = map[cleanupResourceKind]func(*cleanupStoppedCounts){
+	cleanupResourceKindContainer: func(counts *cleanupStoppedCounts) {
+		counts.Containers++
+	},
+	cleanupResourceKindExecutable: func(counts *cleanupStoppedCounts) {
+		counts.Executables++
+	},
+	cleanupResourceKindNetwork: func(counts *cleanupStoppedCounts) {
+		counts.Networks++
+	},
 }
 
 type cleanupReport struct {
@@ -174,11 +216,11 @@ func cleanupWorkloadResources(
 	}
 
 	processRunner := exerunners.NewProcessExecutableRunner(processExecutor)
-	workItems := make([]cleanupWorkItem, 0, len(containerRecords)+len(processRecords)+len(networkRecords))
+	containerWorkItems := make([]cleanupWorkItem, 0, len(containerRecords))
 	for _, record := range containerRecords {
 		record := record
-		workItems = append(workItems, cleanupWorkItem{
-			kind:               "container",
+		containerWorkItems = append(containerWorkItems, cleanupWorkItem{
+			kind:               cleanupResourceKindContainer,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: record.ContainerID,
 			clean: func() (string, bool, error) {
@@ -186,10 +228,11 @@ func cleanupWorkloadResources(
 			},
 		})
 	}
+	processWorkItems := make([]cleanupWorkItem, 0, len(processRecords))
 	for _, record := range processRecords {
 		record := record
-		workItems = append(workItems, cleanupWorkItem{
-			kind:               "executable",
+		processWorkItems = append(processWorkItems, cleanupWorkItem{
+			kind:               cleanupResourceKindExecutable,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: fmt.Sprintf("%d", record.PID),
 			clean: func() (string, bool, error) {
@@ -197,10 +240,11 @@ func cleanupWorkloadResources(
 			},
 		})
 	}
+	networkWorkItems := make([]cleanupWorkItem, 0, len(networkRecords))
 	for _, record := range networkRecords {
 		record := record
-		workItems = append(workItems, cleanupWorkItem{
-			kind:               "network",
+		networkWorkItems = append(networkWorkItems, cleanupWorkItem{
+			kind:               cleanupResourceKindNetwork,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: record.NetworkID,
 			clean: func() (string, bool, error) {
@@ -209,17 +253,24 @@ func cleanupWorkloadResources(
 		})
 	}
 
-	results := slices.MapConcurrent[cleanupWorkResult](workItems, func(workItem cleanupWorkItem) cleanupWorkResult {
-		resourceID, cleaned, cleanupErr := workItem.clean()
-		return cleanupWorkResult{
-			kind:               workItem.kind,
-			resourceKey:        workItem.resourceKey,
-			fallbackResourceID: workItem.fallbackResourceID,
-			resourceID:         resourceID,
-			cleaned:            cleaned,
-			err:                cleanupErr,
-		}
-	}, workloadCleanupConcurrency)
+	results, runCleanupErr := cleanupResourceGroups([]cleanupResourceGroup{
+		{
+			kind:      cleanupResourceKindContainer,
+			workItems: containerWorkItems,
+		},
+		{
+			kind:      cleanupResourceKindExecutable,
+			workItems: processWorkItems,
+		},
+		{
+			kind:         cleanupResourceKindNetwork,
+			cleanUpAfter: []cleanupResourceKind{cleanupResourceKindContainer},
+			workItems:    networkWorkItems,
+		},
+	})
+	if runCleanupErr != nil {
+		return report, runCleanupErr
+	}
 
 	for _, result := range results {
 		if result.err != nil {
@@ -228,7 +279,7 @@ func cleanupWorkloadResources(
 				resourceID = result.fallbackResourceID
 			}
 			report.Failures = append(report.Failures, cleanupFailureEntry{
-				Kind:        result.kind,
+				Kind:        string(result.kind),
 				ResourceKey: result.resourceKey,
 				ResourceID:  resourceID,
 				Error:       result.err.Error(),
@@ -238,20 +289,100 @@ func cleanupWorkloadResources(
 		if !result.cleaned {
 			continue
 		}
-		switch result.kind {
-		case "container":
-			report.Stopped.Containers++
-		case "executable":
-			report.Stopped.Executables++
-		case "network":
-			report.Stopped.Networks++
+		countStopped, ok := cleanupStoppedCounters[result.kind]
+		if !ok {
+			return report, fmt.Errorf("unknown cleanup resource kind %q", result.kind)
 		}
+		countStopped(&report.Stopped)
 	}
 
 	if len(report.Failures) > 0 {
 		return report, fmt.Errorf("failed to clean up %d persistent resource(s)", len(report.Failures))
 	}
 	return report, nil
+}
+
+func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, error) {
+	totalWorkItems := 0
+	for i := range groups {
+		groups[i].state = cleanupResourceStateInitial
+		groups[i].waitingFor = append([]cleanupResourceKind(nil), groups[i].cleanUpAfter...)
+		totalWorkItems += len(groups[i].workItems)
+	}
+
+	results := make([]cleanupWorkResult, 0, totalWorkItems)
+	groupDone := make(chan cleanupResourceGroupResult)
+	inProgress := 0
+	startReadyGroups := func() {
+		readyGroupIndexes := cleanupReadyGroupIndexes(groups)
+		for _, groupIndex := range readyGroupIndexes {
+			groups[groupIndex].state = cleanupResourceStateProcessing
+			inProgress++
+			go func(groupIndex int, workItems []cleanupWorkItem) {
+				groupDone <- cleanupResourceGroupResult{
+					groupIndex: groupIndex,
+					results:    cleanupWorkItems(workItems),
+				}
+			}(groupIndex, groups[groupIndex].workItems)
+		}
+	}
+
+	startReadyGroups()
+	for inProgress > 0 {
+		groupResult := <-groupDone
+		inProgress--
+		results = append(results, groupResult.results...)
+		groups[groupResult.groupIndex].state = cleanupResourceStateDone
+		completedKind := groups[groupResult.groupIndex].kind
+		for groupIndex := range groups {
+			if groups[groupIndex].state == cleanupResourceStateDone {
+				continue
+			}
+			groups[groupIndex].waitingFor = slices.Select(groups[groupIndex].waitingFor, func(kind cleanupResourceKind) bool {
+				return kind != completedKind
+			})
+		}
+		startReadyGroups()
+	}
+
+	blockedGroups := slices.Select(groups, func(group cleanupResourceGroup) bool {
+		return group.state != cleanupResourceStateDone
+	})
+	if len(blockedGroups) > 0 {
+		blockedGroupDescriptions := slices.Map[string](blockedGroups, func(group cleanupResourceGroup) string {
+			dependencies := slices.Map[string](group.waitingFor, func(kind cleanupResourceKind) string {
+				return string(kind)
+			})
+			return fmt.Sprintf("%s waiting for %s", group.kind, strings.Join(dependencies, ", "))
+		})
+		return results, fmt.Errorf("could not resolve cleanup resource dependencies: %s", strings.Join(blockedGroupDescriptions, "; "))
+	}
+
+	return results, nil
+}
+
+func cleanupReadyGroupIndexes(groups []cleanupResourceGroup) []int {
+	readyGroupIndexes := make([]int, 0, len(groups))
+	for groupIndex, group := range groups {
+		if group.state == cleanupResourceStateInitial && len(group.waitingFor) == 0 {
+			readyGroupIndexes = append(readyGroupIndexes, groupIndex)
+		}
+	}
+	return readyGroupIndexes
+}
+
+func cleanupWorkItems(workItems []cleanupWorkItem) []cleanupWorkResult {
+	return slices.MapConcurrent[cleanupWorkResult](workItems, func(workItem cleanupWorkItem) cleanupWorkResult {
+		resourceID, cleaned, cleanupErr := workItem.clean()
+		return cleanupWorkResult{
+			kind:               workItem.kind,
+			resourceKey:        workItem.resourceKey,
+			fallbackResourceID: workItem.fallbackResourceID,
+			resourceID:         resourceID,
+			cleaned:            cleaned,
+			err:                cleanupErr,
+		}
+	}, workloadCleanupResourceKindConcurrencyLimit)
 }
 
 func cachedContainerOrchestratorProvider(getContainerOrchestrator containerOrchestratorProvider) containerOrchestratorProvider {

--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	workloadCleanupLeaseRevalidationInterval    = 30 * time.Second
-	workloadCleanupStopContainerTimeout         = 10
-	workloadCleanupResourceKindConcurrencyLimit = uint16(8)
+	workloadCleanupLeaseRevalidationInterval = 30 * time.Second
+	workloadCleanupStopContainerTimeout      = 10
+	workloadCleanupResourceConcurrencyLimit  = uint16(8)
 )
 
 type containerOrchestratorProvider func(runtimeName string) (containers.ContainerOrchestrator, error)
@@ -48,12 +48,10 @@ type persistentProcessCleanupRunner interface {
 	StopPersistentProcess(ctx context.Context, exe *apiv1.Executable, record *statestore.PersistentProcessRecord, log logr.Logger) error
 }
 
-type cleanupResourceKind = schema.GroupVersionResource
-
 var (
-	cleanupResourceKindContainer  = (&apiv1.Container{}).GetGroupVersionResource()
-	cleanupResourceKindExecutable = (&apiv1.Executable{}).GetGroupVersionResource()
-	cleanupResourceKindNetwork    = (&apiv1.ContainerNetwork{}).GetGroupVersionResource()
+	cleanupResourceContainerGVR  = (&apiv1.Container{}).GetGroupVersionResource()
+	cleanupResourceExecutableGVR = (&apiv1.Executable{}).GetGroupVersionResource()
+	cleanupResourceNetworkGVR    = (&apiv1.ContainerNetwork{}).GetGroupVersionResource()
 )
 
 type cleanupResourceState uint
@@ -65,23 +63,23 @@ const (
 )
 
 type cleanupResourceGroup struct {
-	kind         cleanupResourceKind
-	cleanUpAfter []cleanupResourceKind
+	gvr          schema.GroupVersionResource
+	cleanUpAfter []schema.GroupVersionResource
 	workItems    []cleanupWorkItem
 
 	state      cleanupResourceState
-	waitingFor []cleanupResourceKind
+	waitingFor []schema.GroupVersionResource
 }
 
 type cleanupWorkItem struct {
-	kind               cleanupResourceKind
+	gvr                schema.GroupVersionResource
 	resourceKey        string
 	fallbackResourceID string
 	clean              func() (string, bool, error)
 }
 
 type cleanupWorkResult struct {
-	kind               cleanupResourceKind
+	gvr                schema.GroupVersionResource
 	resourceKey        string
 	fallbackResourceID string
 	resourceID         string
@@ -100,14 +98,14 @@ func (r cleanupLeaseResource) GetLeaseKey() string {
 	return string(r)
 }
 
-var cleanupStoppedCounters = map[cleanupResourceKind]func(*cleanupStoppedCounts){
-	cleanupResourceKindContainer: func(counts *cleanupStoppedCounts) {
+var cleanupStoppedCounters = map[schema.GroupVersionResource]func(*cleanupStoppedCounts){
+	cleanupResourceContainerGVR: func(counts *cleanupStoppedCounts) {
 		counts.Containers++
 	},
-	cleanupResourceKindExecutable: func(counts *cleanupStoppedCounts) {
+	cleanupResourceExecutableGVR: func(counts *cleanupStoppedCounts) {
 		counts.Executables++
 	},
-	cleanupResourceKindNetwork: func(counts *cleanupStoppedCounts) {
+	cleanupResourceNetworkGVR: func(counts *cleanupStoppedCounts) {
 		counts.Networks++
 	},
 }
@@ -221,7 +219,7 @@ func cleanupWorkloadResources(
 	for _, record := range containerRecords {
 		record := record
 		containerWorkItems = append(containerWorkItems, cleanupWorkItem{
-			kind:               cleanupResourceKindContainer,
+			gvr:                cleanupResourceContainerGVR,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: record.ContainerID,
 			clean: func() (string, bool, error) {
@@ -233,7 +231,7 @@ func cleanupWorkloadResources(
 	for _, record := range processRecords {
 		record := record
 		processWorkItems = append(processWorkItems, cleanupWorkItem{
-			kind:               cleanupResourceKindExecutable,
+			gvr:                cleanupResourceExecutableGVR,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: fmt.Sprintf("%d", record.PID),
 			clean: func() (string, bool, error) {
@@ -245,7 +243,7 @@ func cleanupWorkloadResources(
 	for _, record := range networkRecords {
 		record := record
 		networkWorkItems = append(networkWorkItems, cleanupWorkItem{
-			kind:               cleanupResourceKindNetwork,
+			gvr:                cleanupResourceNetworkGVR,
 			resourceKey:        record.ResourceKey,
 			fallbackResourceID: record.NetworkID,
 			clean: func() (string, bool, error) {
@@ -256,16 +254,16 @@ func cleanupWorkloadResources(
 
 	runCleanupErr := runCleanupResourceGroups(&report, []cleanupResourceGroup{
 		{
-			kind:      cleanupResourceKindContainer,
+			gvr:       cleanupResourceContainerGVR,
 			workItems: containerWorkItems,
 		},
 		{
-			kind:      cleanupResourceKindExecutable,
+			gvr:       cleanupResourceExecutableGVR,
 			workItems: processWorkItems,
 		},
 		{
-			kind:         cleanupResourceKindNetwork,
-			cleanUpAfter: []cleanupResourceKind{cleanupResourceKindContainer},
+			gvr:          cleanupResourceNetworkGVR,
+			cleanUpAfter: []schema.GroupVersionResource{cleanupResourceContainerGVR},
 			workItems:    networkWorkItems,
 		},
 	})
@@ -284,7 +282,7 @@ func runCleanupResourceGroups(report *cleanupReport, groups []cleanupResourceGro
 				resourceID = result.fallbackResourceID
 			}
 			report.Failures = append(report.Failures, cleanupFailureEntry{
-				Kind:        cleanupResourceKindName(result.kind),
+				Kind:        cleanupResourceName(result.gvr),
 				ResourceKey: result.resourceKey,
 				ResourceID:  resourceID,
 				Error:       result.err.Error(),
@@ -294,9 +292,9 @@ func runCleanupResourceGroups(report *cleanupReport, groups []cleanupResourceGro
 		if !result.cleaned {
 			continue
 		}
-		countStopped, ok := cleanupStoppedCounters[result.kind]
+		countStopped, ok := cleanupStoppedCounters[result.gvr]
 		if !ok {
-			return fmt.Errorf("unknown cleanup resource kind %q", cleanupResourceKindName(result.kind))
+			return fmt.Errorf("unknown cleanup resource gvr %q", cleanupResourceName(result.gvr))
 		}
 		countStopped(&report.Stopped)
 	}
@@ -319,7 +317,7 @@ func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, 
 	totalWorkItems := 0
 	for i := range groups {
 		groups[i].state = cleanupResourceStateInitial
-		groups[i].waitingFor = append([]cleanupResourceKind(nil), groups[i].cleanUpAfter...)
+		groups[i].waitingFor = append([]schema.GroupVersionResource(nil), groups[i].cleanUpAfter...)
 		totalWorkItems += len(groups[i].workItems)
 	}
 
@@ -346,13 +344,13 @@ func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, 
 		inProgress--
 		results = append(results, groupResult.results...)
 		groups[groupResult.groupIndex].state = cleanupResourceStateDone
-		completedKind := groups[groupResult.groupIndex].kind
+		completedGVR := groups[groupResult.groupIndex].gvr
 		for groupIndex := range groups {
 			if groups[groupIndex].state == cleanupResourceStateDone {
 				continue
 			}
-			groups[groupIndex].waitingFor = slices.Select(groups[groupIndex].waitingFor, func(kind cleanupResourceKind) bool {
-				return kind != completedKind
+			groups[groupIndex].waitingFor = slices.Select(groups[groupIndex].waitingFor, func(gvr schema.GroupVersionResource) bool {
+				return gvr != completedGVR
 			})
 		}
 		startReadyGroups()
@@ -363,10 +361,10 @@ func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, 
 	})
 	if len(blockedGroups) > 0 {
 		blockedGroupDescriptions := slices.Map[string](blockedGroups, func(group cleanupResourceGroup) string {
-			dependencies := slices.Map[string](group.waitingFor, func(kind cleanupResourceKind) string {
-				return cleanupResourceKindName(kind)
+			dependencies := slices.Map[string](group.waitingFor, func(gvr schema.GroupVersionResource) string {
+				return cleanupResourceName(gvr)
 			})
-			return fmt.Sprintf("%s waiting for %s", cleanupResourceKindName(group.kind), strings.Join(dependencies, ", "))
+			return fmt.Sprintf("%s waiting for %s", cleanupResourceName(group.gvr), strings.Join(dependencies, ", "))
 		})
 		return results, fmt.Errorf("could not resolve cleanup resource dependencies: %s", strings.Join(blockedGroupDescriptions, "; "))
 	}
@@ -384,25 +382,25 @@ func cleanupReadyGroupIndexes(groups []cleanupResourceGroup) []int {
 	return readyGroupIndexes
 }
 
-func cleanupResourceKindName(kind cleanupResourceKind) string {
-	if kind.Resource != "" {
-		return kind.Resource
+func cleanupResourceName(gvr schema.GroupVersionResource) string {
+	if gvr.Resource != "" {
+		return gvr.Resource
 	}
-	return kind.String()
+	return gvr.String()
 }
 
 func cleanupWorkItems(workItems []cleanupWorkItem) []cleanupWorkResult {
 	return slices.MapConcurrent[cleanupWorkResult](workItems, func(workItem cleanupWorkItem) cleanupWorkResult {
 		resourceID, cleaned, cleanupErr := workItem.clean()
 		return cleanupWorkResult{
-			kind:               workItem.kind,
+			gvr:                workItem.gvr,
 			resourceKey:        workItem.resourceKey,
 			fallbackResourceID: workItem.fallbackResourceID,
 			resourceID:         resourceID,
 			cleaned:            cleaned,
 			err:                cleanupErr,
 		}
-	}, workloadCleanupResourceKindConcurrencyLimit)
+	}, workloadCleanupResourceConcurrencyLimit)
 }
 
 func cachedContainerOrchestratorProvider(getContainerOrchestrator containerOrchestratorProvider) containerOrchestratorProvider {

--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -253,7 +253,7 @@ func cleanupWorkloadResources(
 		})
 	}
 
-	results, runCleanupErr := cleanupResourceGroups([]cleanupResourceGroup{
+	runCleanupErr := runCleanupResourceGroups(&report, []cleanupResourceGroup{
 		{
 			kind:      cleanupResourceKindContainer,
 			workItems: containerWorkItems,
@@ -271,7 +271,11 @@ func cleanupWorkloadResources(
 	if runCleanupErr != nil {
 		return report, runCleanupErr
 	}
+	return report, nil
+}
 
+func runCleanupResourceGroups(report *cleanupReport, groups []cleanupResourceGroup) error {
+	results, runCleanupErr := cleanupResourceGroups(groups)
 	for _, result := range results {
 		if result.err != nil {
 			resourceID := result.resourceID
@@ -291,15 +295,23 @@ func cleanupWorkloadResources(
 		}
 		countStopped, ok := cleanupStoppedCounters[result.kind]
 		if !ok {
-			return report, fmt.Errorf("unknown cleanup resource kind %q", result.kind)
+			return fmt.Errorf("unknown cleanup resource kind %q", result.kind)
 		}
 		countStopped(&report.Stopped)
 	}
 
-	if len(report.Failures) > 0 {
-		return report, fmt.Errorf("failed to clean up %d persistent resource(s)", len(report.Failures))
+	failureErr := cleanupFailuresError(report.Failures)
+	if runCleanupErr != nil {
+		return errors.Join(runCleanupErr, failureErr)
 	}
-	return report, nil
+	return failureErr
+}
+
+func cleanupFailuresError(failures []cleanupFailureEntry) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	return fmt.Errorf("failed to clean up %d persistent resource(s)", len(failures))
 }
 
 func cleanupResourceGroups(groups []cleanupResourceGroup) ([]cleanupWorkResult, error) {

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apiv1 "github.com/microsoft/dcp/api/v1"
 	"github.com/microsoft/dcp/internal/containers"
@@ -383,10 +384,10 @@ func TestCleanupResourceGroupsUnblocksDependentsWhenOnlyTheirPrerequisitesFinish
 	go func() {
 		results, cleanupErr := cleanupResourceGroups([]cleanupResourceGroup{
 			{
-				kind: cleanupResourceKindContainer,
+				gvr: cleanupResourceContainerGVR,
 				workItems: []cleanupWorkItem{
 					{
-						kind: cleanupResourceKindContainer,
+						gvr: cleanupResourceContainerGVR,
 						clean: func() (string, bool, error) {
 							close(containerStarted)
 							select {
@@ -400,10 +401,10 @@ func TestCleanupResourceGroupsUnblocksDependentsWhenOnlyTheirPrerequisitesFinish
 				},
 			},
 			{
-				kind: cleanupResourceKindExecutable,
+				gvr: cleanupResourceExecutableGVR,
 				workItems: []cleanupWorkItem{
 					{
-						kind: cleanupResourceKindExecutable,
+						gvr: cleanupResourceExecutableGVR,
 						clean: func() (string, bool, error) {
 							close(executableStarted)
 							select {
@@ -417,11 +418,11 @@ func TestCleanupResourceGroupsUnblocksDependentsWhenOnlyTheirPrerequisitesFinish
 				},
 			},
 			{
-				kind:         cleanupResourceKindNetwork,
-				cleanUpAfter: []cleanupResourceKind{cleanupResourceKindContainer},
+				gvr:          cleanupResourceNetworkGVR,
+				cleanUpAfter: []schema.GroupVersionResource{cleanupResourceContainerGVR},
 				workItems: []cleanupWorkItem{
 					{
-						kind: cleanupResourceKindNetwork,
+						gvr: cleanupResourceNetworkGVR,
 						clean: func() (string, bool, error) {
 							close(networkStarted)
 							return "network-id", true, nil
@@ -468,10 +469,10 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 	cleanupItemErr := errors.New("cleanup item failed")
 	cleanupErr := runCleanupResourceGroups(&report, []cleanupResourceGroup{
 		{
-			kind: cleanupResourceKindContainer,
+			gvr: cleanupResourceContainerGVR,
 			workItems: []cleanupWorkItem{
 				{
-					kind: cleanupResourceKindContainer,
+					gvr: cleanupResourceContainerGVR,
 					clean: func() (string, bool, error) {
 						return "container-id", true, nil
 					},
@@ -479,10 +480,10 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 			},
 		},
 		{
-			kind: cleanupResourceKindExecutable,
+			gvr: cleanupResourceExecutableGVR,
 			workItems: []cleanupWorkItem{
 				{
-					kind:               cleanupResourceKindExecutable,
+					gvr:                cleanupResourceExecutableGVR,
 					resourceKey:        "executables/api",
 					fallbackResourceID: "123",
 					clean: func() (string, bool, error) {
@@ -492,11 +493,11 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 			},
 		},
 		{
-			kind:         cleanupResourceKindNetwork,
-			cleanUpAfter: []cleanupResourceKind{{Resource: "missing"}},
+			gvr:          cleanupResourceNetworkGVR,
+			cleanUpAfter: []schema.GroupVersionResource{{Resource: "missing"}},
 			workItems: []cleanupWorkItem{
 				{
-					kind: cleanupResourceKindNetwork,
+					gvr: cleanupResourceNetworkGVR,
 					clean: func() (string, bool, error) {
 						return "network-id", true, nil
 					},
@@ -510,7 +511,7 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 	require.ErrorContains(t, cleanupErr, "failed to clean up 1 persistent resource")
 	require.Equal(t, cleanupStoppedCounts{Containers: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
-	require.Equal(t, cleanupResourceKindName(cleanupResourceKindExecutable), report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceName(cleanupResourceExecutableGVR), report.Failures[0].Kind)
 	require.Equal(t, "executables/api", report.Failures[0].ResourceKey)
 	require.Equal(t, "123", report.Failures[0].ResourceID)
 	require.Equal(t, cleanupItemErr.Error(), report.Failures[0].Error)
@@ -713,11 +714,11 @@ func TestCleanupWorkloadResourcesRuntimeFailureDoesNotPreventExecutableCleanup(t
 	require.Equal(t, 1, runtimeRequests)
 	require.Equal(t, cleanupStoppedCounts{Executables: 1}, report.Stopped)
 	require.Len(t, report.Failures, 2)
-	require.Equal(t, cleanupResourceKindName(cleanupResourceKindContainer), report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceName(cleanupResourceContainerGVR), report.Failures[0].Kind)
 	require.Equal(t, "containers/api", report.Failures[0].ResourceKey)
 	require.Equal(t, "api-container", report.Failures[0].ResourceID)
 	require.ErrorContains(t, errors.New(report.Failures[0].Error), runtimeErr.Error())
-	require.Equal(t, cleanupResourceKindName(cleanupResourceKindNetwork), report.Failures[1].Kind)
+	require.Equal(t, cleanupResourceName(cleanupResourceNetworkGVR), report.Failures[1].Kind)
 	require.Equal(t, "containernetworks/api", report.Failures[1].ResourceKey)
 	require.Equal(t, "api-network", report.Failures[1].ResourceID)
 	require.ErrorContains(t, errors.New(report.Failures[1].Error), runtimeErr.Error())
@@ -987,7 +988,7 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	require.Error(t, cleanupErr)
 	require.Equal(t, cleanupStoppedCounts{Networks: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
-	require.Equal(t, cleanupResourceKindName(cleanupResourceKindContainer), report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceName(cleanupResourceContainerGVR), report.Failures[0].Kind)
 	require.NotEmpty(t, report.Failures[0].Error)
 }
 

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -139,6 +139,103 @@ func TestCleanupWorkloadResourcesRemovesContainersAndNetworks(t *testing.T) {
 	require.Empty(t, networkRecords)
 }
 
+func TestCleanupWorkloadResourcesRemovesContainersBeforeNetworks(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, 5*time.Second)
+	defer cancel()
+	stateStore := openCleanupTestStore(t, ctx)
+	leaseOwner, leaseOwnerErr := statestore.CurrentResourceLeaseOwner()
+	require.NoError(t, leaseOwnerErr)
+	processExecutor := process.NewOSExecutor(logr.Discard())
+	defer processExecutor.Dispose()
+	orchestrator, orchestratorErr := ctrlutil.NewTestContainerOrchestrator(ctx, logr.Discard(), ctrlutil.TcoOptionNone)
+	require.NoError(t, orchestratorErr)
+	wrappedOrchestrator := &orderedCleanupContainerOrchestrator{
+		ContainerOrchestrator:   orchestrator,
+		removeContainersEntered: make(chan struct{}),
+		allowRemoveContainers:   make(chan struct{}),
+		removeNetworksEntered:   make(chan struct{}),
+	}
+
+	networkID, createNetworkErr := orchestrator.CreateNetwork(ctx, containers.CreateNetworkOptions{Name: "app-network"})
+	require.NoError(t, createNetworkErr)
+	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{
+		Name: "api",
+		Networks: []containers.CreateContainerNetworkOptions{
+			{Name: "app-network"},
+		},
+	})
+	require.NoError(t, createContainerErr)
+	require.NoError(t, stateStore.UpsertPersistentContainer(ctx, statestore.PersistentContainerRecord{
+		ResourceKey:   "containers/api",
+		ContainerID:   containerID,
+		ContainerName: "api",
+		RuntimeName:   cleanupTestRuntimeName,
+		WorkloadID:    "workload-a",
+	}))
+	require.NoError(t, stateStore.UpsertPersistentNetwork(ctx, statestore.PersistentNetworkRecord{
+		ResourceKey: "containernetworks/app-network",
+		NetworkID:   networkID,
+		NetworkName: "app-network",
+		RuntimeName: cleanupTestRuntimeName,
+		WorkloadID:  "workload-a",
+	}))
+
+	type cleanupResult struct {
+		report cleanupReport
+		err    error
+	}
+	resultCh := make(chan cleanupResult, 1)
+	go func() {
+		report, cleanupErr := cleanupWorkloadResources(
+			ctx,
+			"workload-a",
+			stateStore,
+			leaseOwner,
+			func(runtimeName string) (containers.ContainerOrchestrator, error) {
+				if runtimeName != cleanupTestRuntimeName {
+					return nil, errors.New("unexpected runtime name")
+				}
+				return wrappedOrchestrator, nil
+			},
+			processExecutor,
+			logr.Discard(),
+		)
+		resultCh <- cleanupResult{report: report, err: cleanupErr}
+	}()
+
+	select {
+	case <-wrappedOrchestrator.removeContainersEntered:
+	case <-ctx.Done():
+		require.FailNow(t, "container cleanup did not start", ctx.Err())
+	}
+	networkStartedEarlyTimer := time.NewTimer(100 * time.Millisecond)
+	defer networkStartedEarlyTimer.Stop()
+	select {
+	case <-wrappedOrchestrator.removeNetworksEntered:
+		close(wrappedOrchestrator.allowRemoveContainers)
+		select {
+		case <-resultCh:
+		case <-ctx.Done():
+			require.FailNow(t, "cleanup did not finish", ctx.Err())
+		}
+		require.FailNow(t, "network cleanup started before container cleanup finished")
+	case <-networkStartedEarlyTimer.C:
+	}
+	close(wrappedOrchestrator.allowRemoveContainers)
+
+	var result cleanupResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		require.FailNow(t, "cleanup did not finish", ctx.Err())
+	}
+	require.NoError(t, result.err)
+	require.Equal(t, cleanupStoppedCounts{Containers: 1, Networks: 1}, result.report.Stopped)
+	require.Empty(t, result.report.Failures)
+}
+
 func TestCleanupWorkloadResourcesTreatsMissingRuntimeResourcesAsSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -265,6 +362,103 @@ func TestCleanupWorkloadResourcesRunsIndependentRecordsInParallel(t *testing.T) 
 	require.NoError(t, result.err)
 	require.Equal(t, cleanupStoppedCounts{Containers: 2}, result.report.Stopped)
 	require.Empty(t, result.report.Failures)
+}
+
+func TestCleanupResourceGroupsUnblocksDependentsWhenOnlyTheirPrerequisitesFinish(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, 5*time.Second)
+	defer cancel()
+	containerStarted := make(chan struct{})
+	releaseContainer := make(chan struct{})
+	executableStarted := make(chan struct{})
+	releaseExecutable := make(chan struct{})
+	networkStarted := make(chan struct{})
+
+	type cleanupResult struct {
+		results []cleanupWorkResult
+		err     error
+	}
+	resultCh := make(chan cleanupResult, 1)
+	go func() {
+		results, cleanupErr := cleanupResourceGroups([]cleanupResourceGroup{
+			{
+				kind: cleanupResourceKindContainer,
+				workItems: []cleanupWorkItem{
+					{
+						kind: cleanupResourceKindContainer,
+						clean: func() (string, bool, error) {
+							close(containerStarted)
+							select {
+							case <-releaseContainer:
+							case <-ctx.Done():
+								return "", false, ctx.Err()
+							}
+							return "container-id", true, nil
+						},
+					},
+				},
+			},
+			{
+				kind: cleanupResourceKindExecutable,
+				workItems: []cleanupWorkItem{
+					{
+						kind: cleanupResourceKindExecutable,
+						clean: func() (string, bool, error) {
+							close(executableStarted)
+							select {
+							case <-releaseExecutable:
+							case <-ctx.Done():
+								return "", false, ctx.Err()
+							}
+							return "executable-id", true, nil
+						},
+					},
+				},
+			},
+			{
+				kind:         cleanupResourceKindNetwork,
+				cleanUpAfter: []cleanupResourceKind{cleanupResourceKindContainer},
+				workItems: []cleanupWorkItem{
+					{
+						kind: cleanupResourceKindNetwork,
+						clean: func() (string, bool, error) {
+							close(networkStarted)
+							return "network-id", true, nil
+						},
+					},
+				},
+			},
+		})
+		resultCh <- cleanupResult{results: results, err: cleanupErr}
+	}()
+
+	select {
+	case <-containerStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "container cleanup did not start", ctx.Err())
+	}
+	select {
+	case <-executableStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "executable cleanup did not start", ctx.Err())
+	}
+	close(releaseContainer)
+	select {
+	case <-networkStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "network cleanup did not start after container cleanup finished", ctx.Err())
+	}
+	close(releaseExecutable)
+
+	var result cleanupResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		require.FailNow(t, "cleanup did not finish", ctx.Err())
+	}
+	require.NoError(t, result.err)
+	require.Len(t, result.results, 3)
 }
 
 func TestCleanupPersistentContainerRecordSkipsRecordThatChangedWorkload(t *testing.T) {
@@ -803,4 +997,47 @@ func (o *parallelCleanupContainerOrchestrator) RemoveContainers(ctx context.Cont
 	}
 
 	return o.ContainerOrchestrator.RemoveContainers(ctx, options)
+}
+
+type orderedCleanupContainerOrchestrator struct {
+	containers.ContainerOrchestrator
+
+	lock                    sync.Mutex
+	removeContainersDone    bool
+	removeContainersOnce    sync.Once
+	removeNetworksOnce      sync.Once
+	removeContainersEntered chan struct{}
+	allowRemoveContainers   chan struct{}
+	removeNetworksEntered   chan struct{}
+}
+
+func (o *orderedCleanupContainerOrchestrator) RemoveContainers(ctx context.Context, options containers.RemoveContainersOptions) ([]string, error) {
+	o.removeContainersOnce.Do(func() {
+		close(o.removeContainersEntered)
+	})
+	select {
+	case <-o.allowRemoveContainers:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	ids, removeErr := o.ContainerOrchestrator.RemoveContainers(ctx, options)
+	o.lock.Lock()
+	o.removeContainersDone = true
+	o.lock.Unlock()
+	return ids, removeErr
+}
+
+func (o *orderedCleanupContainerOrchestrator) RemoveNetworks(ctx context.Context, options containers.RemoveNetworksOptions) ([]string, error) {
+	o.removeNetworksOnce.Do(func() {
+		close(o.removeNetworksEntered)
+	})
+	o.lock.Lock()
+	removeContainersDone := o.removeContainersDone
+	o.lock.Unlock()
+	if !removeContainersDone {
+		return nil, errors.New("network cleanup started before container cleanup finished")
+	}
+
+	return o.ContainerOrchestrator.RemoveNetworks(ctx, options)
 }

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -493,7 +493,7 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 		},
 		{
 			kind:         cleanupResourceKindNetwork,
-			cleanUpAfter: []cleanupResourceKind{"missing"},
+			cleanUpAfter: []cleanupResourceKind{{Resource: "missing"}},
 			workItems: []cleanupWorkItem{
 				{
 					kind: cleanupResourceKindNetwork,
@@ -510,7 +510,7 @@ func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *te
 	require.ErrorContains(t, cleanupErr, "failed to clean up 1 persistent resource")
 	require.Equal(t, cleanupStoppedCounts{Containers: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
-	require.Equal(t, "executable", report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceKindName(cleanupResourceKindExecutable), report.Failures[0].Kind)
 	require.Equal(t, "executables/api", report.Failures[0].ResourceKey)
 	require.Equal(t, "123", report.Failures[0].ResourceID)
 	require.Equal(t, cleanupItemErr.Error(), report.Failures[0].Error)
@@ -713,11 +713,11 @@ func TestCleanupWorkloadResourcesRuntimeFailureDoesNotPreventExecutableCleanup(t
 	require.Equal(t, 1, runtimeRequests)
 	require.Equal(t, cleanupStoppedCounts{Executables: 1}, report.Stopped)
 	require.Len(t, report.Failures, 2)
-	require.Equal(t, "container", report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceKindName(cleanupResourceKindContainer), report.Failures[0].Kind)
 	require.Equal(t, "containers/api", report.Failures[0].ResourceKey)
 	require.Equal(t, "api-container", report.Failures[0].ResourceID)
 	require.ErrorContains(t, errors.New(report.Failures[0].Error), runtimeErr.Error())
-	require.Equal(t, "network", report.Failures[1].Kind)
+	require.Equal(t, cleanupResourceKindName(cleanupResourceKindNetwork), report.Failures[1].Kind)
 	require.Equal(t, "containernetworks/api", report.Failures[1].ResourceKey)
 	require.Equal(t, "api-network", report.Failures[1].ResourceID)
 	require.ErrorContains(t, errors.New(report.Failures[1].Error), runtimeErr.Error())
@@ -987,7 +987,7 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	require.Error(t, cleanupErr)
 	require.Equal(t, cleanupStoppedCounts{Networks: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
-	require.Equal(t, "container", report.Failures[0].Kind)
+	require.Equal(t, cleanupResourceKindName(cleanupResourceKindContainer), report.Failures[0].Kind)
 	require.NotEmpty(t, report.Failures[0].Error)
 }
 

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -461,6 +461,61 @@ func TestCleanupResourceGroupsUnblocksDependentsWhenOnlyTheirPrerequisitesFinish
 	require.Len(t, result.results, 3)
 }
 
+func TestRunCleanupResourceGroupsReportsCompletedWorkBeforeDependencyError(t *testing.T) {
+	t.Parallel()
+
+	report := cleanupReport{WorkloadID: "workload-a"}
+	cleanupItemErr := errors.New("cleanup item failed")
+	cleanupErr := runCleanupResourceGroups(&report, []cleanupResourceGroup{
+		{
+			kind: cleanupResourceKindContainer,
+			workItems: []cleanupWorkItem{
+				{
+					kind: cleanupResourceKindContainer,
+					clean: func() (string, bool, error) {
+						return "container-id", true, nil
+					},
+				},
+			},
+		},
+		{
+			kind: cleanupResourceKindExecutable,
+			workItems: []cleanupWorkItem{
+				{
+					kind:               cleanupResourceKindExecutable,
+					resourceKey:        "executables/api",
+					fallbackResourceID: "123",
+					clean: func() (string, bool, error) {
+						return "", false, cleanupItemErr
+					},
+				},
+			},
+		},
+		{
+			kind:         cleanupResourceKindNetwork,
+			cleanUpAfter: []cleanupResourceKind{"missing"},
+			workItems: []cleanupWorkItem{
+				{
+					kind: cleanupResourceKindNetwork,
+					clean: func() (string, bool, error) {
+						return "network-id", true, nil
+					},
+				},
+			},
+		},
+	})
+
+	require.Error(t, cleanupErr)
+	require.ErrorContains(t, cleanupErr, "could not resolve cleanup resource dependencies")
+	require.ErrorContains(t, cleanupErr, "failed to clean up 1 persistent resource")
+	require.Equal(t, cleanupStoppedCounts{Containers: 1}, report.Stopped)
+	require.Len(t, report.Failures, 1)
+	require.Equal(t, "executable", report.Failures[0].Kind)
+	require.Equal(t, "executables/api", report.Failures[0].ResourceKey)
+	require.Equal(t, "123", report.Failures[0].ResourceID)
+	require.Equal(t, cleanupItemErr.Error(), report.Failures[0].Error)
+}
+
 func TestCleanupPersistentContainerRecordSkipsRecordThatChangedWorkload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Persistent workload cleanup can fail when networks are removed while containers are still attached to them. Aspire cleanup hits this when container and network cleanup run in parallel.

## Summary

- Introduce command-local cleanup resource groups with explicit dependencies between resource kinds.
- Run container and executable cleanup groups independently, while delaying network cleanup until container cleanup has completed.
- Keep cleanup progress resilient by continuing to report item-level failures without blocking later cleanup groups.
- Add regression coverage for container-before-network ordering and for unblocking dependent work before unrelated resource kinds finish.

## Testing

- `go fmt ./internal/dcp/commands`
- `make test-prereqs`
- `go test -count 1 -parallel 32 ./internal/dcp/commands`
- `make test`