### PR TITLE
Wait for cleanup resource leases

### DIFF
--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	workloadCleanupLeaseRevalidationInterval = 30 * time.Second
+	workloadCleanupLeaseRetryInterval        = 500 * time.Millisecond
 	workloadCleanupStopContainerTimeout      = 10
 	workloadCleanupResourceConcurrencyLimit  = uint16(8)
 )
@@ -465,7 +466,7 @@ func withCurrentPersistentContainerRecord(
 ) (string, bool, error) {
 	var resourceID string
 	found := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentContainer(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentContainerNotFound) {
 			return nil
@@ -497,7 +498,7 @@ func cleanupPersistentProcessRecord(
 ) (string, bool, error) {
 	var resourceID string
 	cleaned := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentProcess(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentProcessNotFound) {
 			return nil
@@ -580,7 +581,7 @@ func withCurrentPersistentNetworkRecord(
 ) (string, bool, error) {
 	var resourceID string
 	found := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentNetwork(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentNetworkNotFound) {
 			return nil

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/microsoft/dcp/pkg/commonapi"
 	dcpio "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
 
@@ -627,22 +628,23 @@ func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
 		resultCh <- cleanupResult{resourceID: resourceID, cleaned: cleaned, err: cleanupErr}
 	}()
 
-	retryTimer := time.NewTimer(100 * time.Millisecond)
-	defer retryTimer.Stop()
 	select {
 	case result := <-resultCh:
 		require.FailNow(t, "cleanup finished before the held lease was released", result.err)
-	case <-retryTimer.C:
+	default:
 	}
 
 	require.NoError(t, stateStore.ReleaseResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner))
 
 	var result cleanupResult
-	select {
-	case result = <-resultCh:
-	case <-ctx.Done():
-		require.FailNow(t, "cleanup did not finish after the held lease was released", ctx.Err())
-	}
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("cleanup did not finish after the held lease was released")
+		}
+	}))
 	require.NoError(t, result.err)
 	require.Equal(t, containerID, result.resourceID)
 	require.True(t, result.cleaned)

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -635,8 +635,8 @@ func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
 	default:
 	}
 
-	// Hold the lease beyond one retry interval, then release it while cleanup is still waiting.
-	time.Sleep(workloadCleanupLeaseRetryInterval + 100*time.Millisecond)
+	// Hold the lease long enough for at least one retry, then release it while cleanup is still waiting.
+	time.Sleep(2*workloadCleanupLeaseRetryInterval + 100*time.Millisecond)
 	require.NoError(t, stateStore.ReleaseResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner))
 
 	var result cleanupResult

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -575,6 +575,83 @@ func TestCleanupPersistentContainerRecordSkipsRecordThatChangedWorkload(t *testi
 	require.Equal(t, currentRecord.ContainerID, record.ContainerID)
 }
 
+func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, 5*time.Second)
+	defer cancel()
+	stateStore := openCleanupTestStore(t, ctx)
+	heldLeaseOwner, heldLeaseOwnerErr := statestore.CurrentResourceLeaseOwner()
+	require.NoError(t, heldLeaseOwnerErr)
+	cleanupLeaseOwner := process.ProcessHandle{
+		Pid:          heldLeaseOwner.Pid,
+		IdentityTime: heldLeaseOwner.IdentityTime.Add(-time.Hour),
+	}
+	orchestrator, orchestratorErr := ctrlutil.NewTestContainerOrchestrator(ctx, logr.Discard(), ctrlutil.TcoOptionNone)
+	require.NoError(t, orchestratorErr)
+
+	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "api"})
+	require.NoError(t, createContainerErr)
+	record := statestore.PersistentContainerRecord{
+		ResourceKey:   "containers/api",
+		ContainerID:   containerID,
+		ContainerName: "api",
+		RuntimeName:   cleanupTestRuntimeName,
+		WorkloadID:    "workload-a",
+	}
+	require.NoError(t, stateStore.UpsertPersistentContainer(ctx, record))
+	_, leaseErr := stateStore.AcquireResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner, time.Minute)
+	require.NoError(t, leaseErr)
+
+	type cleanupResult struct {
+		resourceID string
+		cleaned    bool
+		err        error
+	}
+	resultCh := make(chan cleanupResult, 1)
+	go func() {
+		resourceID, cleaned, cleanupErr := cleanupPersistentContainerRecord(
+			ctx,
+			"workload-a",
+			stateStore,
+			cleanupLeaseOwner,
+			func(runtimeName string) (containers.ContainerOrchestrator, error) {
+				if runtimeName != cleanupTestRuntimeName {
+					return nil, errors.New("unexpected runtime name")
+				}
+				return orchestrator, nil
+			},
+			record,
+			logr.Discard(),
+		)
+		resultCh <- cleanupResult{resourceID: resourceID, cleaned: cleaned, err: cleanupErr}
+	}()
+
+	retryTimer := time.NewTimer(100 * time.Millisecond)
+	defer retryTimer.Stop()
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "cleanup finished before the held lease was released", result.err)
+	case <-retryTimer.C:
+	}
+
+	require.NoError(t, stateStore.ReleaseResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner))
+
+	var result cleanupResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		require.FailNow(t, "cleanup did not finish after the held lease was released", ctx.Err())
+	}
+	require.NoError(t, result.err)
+	require.Equal(t, containerID, result.resourceID)
+	require.True(t, result.cleaned)
+	_, getErr := stateStore.GetPersistentContainer(ctx, record.ResourceKey)
+	require.ErrorIs(t, getErr, statestore.ErrPersistentContainerNotFound)
+	_, inspectErr := orchestrator.InspectContainers(ctx, containers.InspectContainersOptions{Containers: []string{containerID}})
+	require.ErrorIs(t, inspectErr, containers.ErrNotFound)
+}
+
 func TestCleanupWorkloadResourcesTreatsMissingProcessAsSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -943,23 +1020,24 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, 30*time.Second)
 	defer cancel()
 	stateStore := openCleanupTestStore(t, ctx)
-	heldLeaseOwner, heldLeaseOwnerErr := statestore.CurrentResourceLeaseOwner()
-	require.NoError(t, heldLeaseOwnerErr)
-	cleanupLeaseOwner := process.ProcessHandle{
-		Pid:          heldLeaseOwner.Pid,
-		IdentityTime: heldLeaseOwner.IdentityTime.Add(-time.Hour),
-	}
+	leaseOwner, leaseOwnerErr := statestore.CurrentResourceLeaseOwner()
+	require.NoError(t, leaseOwnerErr)
 	processExecutor := process.NewOSExecutor(logr.Discard())
 	defer processExecutor.Dispose()
 	orchestrator, orchestratorErr := ctrlutil.NewTestContainerOrchestrator(ctx, logr.Discard(), ctrlutil.TcoOptionNone)
 	require.NoError(t, orchestratorErr)
+	removeContainerErr := errors.New("container removal failed")
+	wrappedOrchestrator := &failingCleanupContainerOrchestrator{
+		ContainerOrchestrator: orchestrator,
+		removeContainersErr:   removeContainerErr,
+	}
 
-	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "blocked"})
+	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "invalid"})
 	require.NoError(t, createContainerErr)
 	require.NoError(t, stateStore.UpsertPersistentContainer(ctx, statestore.PersistentContainerRecord{
-		ResourceKey:   "containers/blocked",
+		ResourceKey:   "containers/invalid",
 		ContainerID:   containerID,
-		ContainerName: "blocked",
+		ContainerName: "invalid",
 		RuntimeName:   cleanupTestRuntimeName,
 		WorkloadID:    "workload-a",
 	}))
@@ -969,17 +1047,15 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 		RuntimeName: cleanupTestRuntimeName,
 		WorkloadID:  "workload-a",
 	}))
-	_, leaseErr := stateStore.AcquireResourceLease(ctx, cleanupLeaseResource("containers/blocked"), heldLeaseOwner, time.Minute)
-	require.NoError(t, leaseErr)
 
 	report, cleanupErr := cleanupWorkloadResources(
 		ctx,
 		"workload-a",
 		stateStore,
-		cleanupLeaseOwner,
+		leaseOwner,
 		func(runtimeName string) (containers.ContainerOrchestrator, error) {
 			require.Equal(t, cleanupTestRuntimeName, runtimeName)
-			return orchestrator, nil
+			return wrappedOrchestrator, nil
 		},
 		processExecutor,
 		logr.Discard(),
@@ -989,7 +1065,9 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	require.Equal(t, cleanupStoppedCounts{Networks: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
 	require.Equal(t, cleanupResourceName(cleanupResourceContainerGVR), report.Failures[0].Kind)
-	require.NotEmpty(t, report.Failures[0].Error)
+	require.Equal(t, "containers/invalid", report.Failures[0].ResourceKey)
+	require.Equal(t, containerID, report.Failures[0].ResourceID)
+	require.ErrorContains(t, errors.New(report.Failures[0].Error), removeContainerErr.Error())
 }
 
 func openCleanupTestStore(t *testing.T, ctx context.Context) *statestore.Store {
@@ -1096,4 +1174,14 @@ func (o *orderedCleanupContainerOrchestrator) RemoveNetworks(ctx context.Context
 	}
 
 	return o.ContainerOrchestrator.RemoveNetworks(ctx, options)
+}
+
+type failingCleanupContainerOrchestrator struct {
+	containers.ContainerOrchestrator
+
+	removeContainersErr error
+}
+
+func (o *failingCleanupContainerOrchestrator) RemoveContainers(context.Context, containers.RemoveContainersOptions) ([]string, error) {
+	return nil, o.removeContainersErr
 }

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -610,6 +610,7 @@ func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
 		err        error
 	}
 	resultCh := make(chan cleanupResult, 1)
+	// Start cleanup on a goroutine so it has to wait on the held resource lease.
 	go func() {
 		resourceID, cleaned, cleanupErr := cleanupPersistentContainerRecord(
 			ctx,
@@ -634,6 +635,8 @@ func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
 	default:
 	}
 
+	// Hold the lease beyond one retry interval, then release it while cleanup is still waiting.
+	time.Sleep(workloadCleanupLeaseRetryInterval + 100*time.Millisecond)
 	require.NoError(t, stateStore.ReleaseResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner))
 
 	var result cleanupResult

--- a/internal/statestore/leases.go
+++ b/internal/statestore/leases.go
@@ -248,6 +248,50 @@ func (s *Store) WithResourceLease(ctx context.Context, resource LeasableResource
 		return acquireErr
 	}
 
+	return withResourceLeaseCallback(ctx, lease, f)
+}
+
+// WithResourceLeaseRetry retries held leases until the lease is acquired or ctx is cancelled.
+func (s *Store) WithResourceLeaseRetry(
+	ctx context.Context,
+	resource LeasableResource,
+	ownerProcess process.ProcessHandle,
+	revalidationInterval time.Duration,
+	retryInterval time.Duration,
+	f func(context.Context, *ResourceLease) error,
+) error {
+	if f == nil {
+		return fmt.Errorf("%w: lease callback cannot be nil", ErrInvalidArgument)
+	}
+	if retryInterval <= 0 {
+		return fmt.Errorf("%w: lease retry interval must be positive", ErrInvalidArgument)
+	}
+
+	for {
+		lease, acquireErr := s.AcquireResourceLease(ctx, resource, ownerProcess, revalidationInterval)
+		if acquireErr == nil {
+			return withResourceLeaseCallback(ctx, lease, f)
+		}
+		if !errors.Is(acquireErr, ErrResourceLeaseHeld) {
+			return acquireErr
+		}
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return errors.Join(acquireErr, ctx.Err())
+		}
+	}
+}
+
+func withResourceLeaseCallback(ctx context.Context, lease *ResourceLease, f func(context.Context, *ResourceLease) error) error {
 	callbackErr := f(ctx, lease)
 	releaseErr := lease.Release(context.Background())
 	return errors.Join(callbackErr, releaseErr)

--- a/internal/statestore/leases.go
+++ b/internal/statestore/leases.go
@@ -13,7 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 )
 
 var (
@@ -267,28 +270,21 @@ func (s *Store) WithResourceLeaseRetry(
 		return fmt.Errorf("%w: lease retry interval must be positive", ErrInvalidArgument)
 	}
 
-	for {
+	return resiliency.Retry(ctx, backoff.NewConstantBackOff(retryInterval), func() error {
 		lease, acquireErr := s.AcquireResourceLease(ctx, resource, ownerProcess, revalidationInterval)
 		if acquireErr == nil {
-			return withResourceLeaseCallback(ctx, lease, f)
+			callbackErr := withResourceLeaseCallback(ctx, lease, f)
+			if callbackErr != nil {
+				return resiliency.Permanent(callbackErr)
+			}
+			return nil
 		}
 		if !errors.Is(acquireErr, ErrResourceLeaseHeld) {
-			return acquireErr
+			return resiliency.Permanent(acquireErr)
 		}
 
-		timer := time.NewTimer(retryInterval)
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return errors.Join(acquireErr, ctx.Err())
-		}
-	}
+		return acquireErr
+	})
 }
 
 func withResourceLeaseCallback(ctx context.Context, lease *ResourceLease, f func(context.Context, *ResourceLease) error) error {

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -522,10 +522,11 @@ func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
 		err            error
 	}
 	resultCh := make(chan leaseResult, 1)
+	leaseRetryInterval := 500 * time.Millisecond
 	// Start acquisition on a goroutine so it has to wait on the held lease.
 	go func() {
 		callbackCalled := false
-		leaseErr := store2.WithResourceLeaseRetry(ctx, resource, owner2, time.Minute, 10*time.Millisecond, func(context.Context, *ResourceLease) error {
+		leaseErr := store2.WithResourceLeaseRetry(ctx, resource, owner2, time.Minute, leaseRetryInterval, func(context.Context, *ResourceLease) error {
 			callbackCalled = true
 			return nil
 		})
@@ -538,8 +539,8 @@ func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
 	default:
 	}
 
-	// Hold the lease beyond one retry interval, then release it while the goroutine is still waiting.
-	time.Sleep(25 * time.Millisecond)
+	// Hold the lease long enough for at least one retry, then release it while the goroutine is still waiting.
+	time.Sleep(2*leaseRetryInterval + 100*time.Millisecond)
 	require.NoError(t, store1.ReleaseResourceLease(ctx, resource, owner1))
 
 	var result leaseResult

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -522,6 +522,7 @@ func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
 		err            error
 	}
 	resultCh := make(chan leaseResult, 1)
+	// Start acquisition on a goroutine so it has to wait on the held lease.
 	go func() {
 		callbackCalled := false
 		leaseErr := store2.WithResourceLeaseRetry(ctx, resource, owner2, time.Minute, 10*time.Millisecond, func(context.Context, *ResourceLease) error {
@@ -537,6 +538,8 @@ func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
 	default:
 	}
 
+	// Hold the lease beyond one retry interval, then release it while the goroutine is still waiting.
+	time.Sleep(25 * time.Millisecond)
 	require.NoError(t, store1.ReleaseResourceLease(ctx, resource, owner1))
 
 	var result leaseResult

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -23,6 +23,7 @@ import (
 	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
 
@@ -530,22 +531,23 @@ func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
 		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
 	}()
 
-	retryTimer := time.NewTimer(50 * time.Millisecond)
-	defer retryTimer.Stop()
 	select {
 	case result := <-resultCh:
 		require.FailNow(t, "lease retry finished before the held lease was released", result.err)
-	case <-retryTimer.C:
+	default:
 	}
 
 	require.NoError(t, store1.ReleaseResourceLease(ctx, resource, owner1))
 
 	var result leaseResult
-	select {
-	case result = <-resultCh:
-	case <-ctx.Done():
-		require.FailNow(t, "lease retry did not finish after the held lease was released", ctx.Err())
-	}
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("lease retry did not finish after the held lease was released")
+		}
+	}))
 	require.NoError(t, result.err)
 	require.True(t, result.callbackCalled)
 }
@@ -585,22 +587,23 @@ func TestWithResourceLeaseRetryStopsWhenContextIsCanceled(t *testing.T) {
 		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
 	}()
 
-	retryTimer := time.NewTimer(50 * time.Millisecond)
-	defer retryTimer.Stop()
 	select {
 	case result := <-resultCh:
 		require.FailNow(t, "lease retry finished before the context was canceled", result.err)
-	case <-retryTimer.C:
+	default:
 	}
 
 	cancelWait()
 
 	var result leaseResult
-	select {
-	case result = <-resultCh:
-	case <-ctx.Done():
-		require.FailNow(t, "lease retry did not finish after the context was canceled", ctx.Err())
-	}
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("lease retry did not finish after the context was canceled")
+		}
+	}))
 	require.ErrorIs(t, result.err, context.Canceled)
 	require.False(t, result.callbackCalled)
 }

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -498,6 +498,113 @@ func TestWithResourceLeaseDoesNotRetryHeldLease(t *testing.T) {
 	require.False(t, callbackCalled)
 }
 
+func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store1 := openTestStore(t, ctx, storePath)
+	store2 := openTestStore(t, ctx, storePath)
+
+	owner1, owner1Err := testResourceLeaseOwner(t, 0)
+	require.NoError(t, owner1Err)
+	owner2, owner2Err := testResourceLeaseOwner(t, -time.Hour)
+	require.NoError(t, owner2Err)
+
+	resource := testLeasableResource("container/test")
+	_, acquireErr := store1.AcquireResourceLease(ctx, resource, owner1, time.Minute)
+	require.NoError(t, acquireErr)
+
+	type leaseResult struct {
+		callbackCalled bool
+		err            error
+	}
+	resultCh := make(chan leaseResult, 1)
+	go func() {
+		callbackCalled := false
+		leaseErr := store2.WithResourceLeaseRetry(ctx, resource, owner2, time.Minute, 10*time.Millisecond, func(context.Context, *ResourceLease) error {
+			callbackCalled = true
+			return nil
+		})
+		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
+	}()
+
+	retryTimer := time.NewTimer(50 * time.Millisecond)
+	defer retryTimer.Stop()
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "lease retry finished before the held lease was released", result.err)
+	case <-retryTimer.C:
+	}
+
+	require.NoError(t, store1.ReleaseResourceLease(ctx, resource, owner1))
+
+	var result leaseResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		require.FailNow(t, "lease retry did not finish after the held lease was released", ctx.Err())
+	}
+	require.NoError(t, result.err)
+	require.True(t, result.callbackCalled)
+}
+
+func TestWithResourceLeaseRetryStopsWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store1 := openTestStore(t, ctx, storePath)
+	store2 := openTestStore(t, ctx, storePath)
+
+	owner1, owner1Err := testResourceLeaseOwner(t, 0)
+	require.NoError(t, owner1Err)
+	owner2, owner2Err := testResourceLeaseOwner(t, -time.Hour)
+	require.NoError(t, owner2Err)
+
+	resource := testLeasableResource("container/test")
+	_, acquireErr := store1.AcquireResourceLease(ctx, resource, owner1, time.Minute)
+	require.NoError(t, acquireErr)
+
+	waitCtx, cancelWait := context.WithCancel(ctx)
+	defer cancelWait()
+
+	type leaseResult struct {
+		callbackCalled bool
+		err            error
+	}
+	resultCh := make(chan leaseResult, 1)
+	go func() {
+		callbackCalled := false
+		leaseErr := store2.WithResourceLeaseRetry(waitCtx, resource, owner2, time.Minute, 10*time.Millisecond, func(context.Context, *ResourceLease) error {
+			callbackCalled = true
+			return nil
+		})
+		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
+	}()
+
+	retryTimer := time.NewTimer(50 * time.Millisecond)
+	defer retryTimer.Stop()
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "lease retry finished before the context was canceled", result.err)
+	case <-retryTimer.C:
+	}
+
+	cancelWait()
+
+	var result leaseResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		require.FailNow(t, "lease retry did not finish after the context was canceled", ctx.Err())
+	}
+	require.ErrorIs(t, result.err, context.Canceled)
+	require.False(t, result.callbackCalled)
+}
+
 func TestDeleteInactiveResourceLeasesUsesOwnerProcessIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`dcp cleanup` can race with a still-running DCP instance that owns persistent resource leases during graceful shutdown, or with an active Aspire/DCP pair when cleanup is intentionally requested. Instead of treating a held lease as an immediate cleanup failure, cleanup now waits until it can acquire the resource lease or its context is canceled.

This adds a retrying statestore lease helper while preserving the existing one-shot `WithResourceLease` behavior for controllers and other callers. Cleanup uses the retrying helper for persistent containers, executables, and networks, with regression coverage for successful waiting, cancellation, and continued failure reporting when actual cleanup work fails.

Validation:
- `go test -count 1 -parallel 32 ./internal/statestore ./internal/dcp/commands`
- `make test`
- `make lint`
- Smoke-tested real `bin/dcp cleanup` against a live held resource lease in a local state store.