### PR TITLE
[release/0.25] Wait for cleanup resource leases

### DIFF
--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	workloadCleanupLeaseRevalidationInterval = 30 * time.Second
+	workloadCleanupLeaseRetryInterval        = 500 * time.Millisecond
 	workloadCleanupStopContainerTimeout      = 10
 	workloadCleanupResourceConcurrencyLimit  = uint16(8)
 )
@@ -465,7 +466,7 @@ func withCurrentPersistentContainerRecord(
 ) (string, bool, error) {
 	var resourceID string
 	found := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentContainer(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentContainerNotFound) {
 			return nil
@@ -497,7 +498,7 @@ func cleanupPersistentProcessRecord(
 ) (string, bool, error) {
 	var resourceID string
 	cleaned := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentProcess(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentProcessNotFound) {
 			return nil
@@ -580,7 +581,7 @@ func withCurrentPersistentNetworkRecord(
 ) (string, bool, error) {
 	var resourceID string
 	found := false
-	cleanupErr := stateStore.WithResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
+	cleanupErr := stateStore.WithResourceLeaseRetry(ctx, cleanupLeaseResource(record.ResourceKey), leaseOwner, workloadCleanupLeaseRevalidationInterval, workloadCleanupLeaseRetryInterval, func(ctx context.Context, _ *statestore.ResourceLease) error {
 		currentRecord, getErr := stateStore.GetPersistentNetwork(ctx, record.ResourceKey)
 		if errors.Is(getErr, statestore.ErrPersistentNetworkNotFound) {
 			return nil

--- a/internal/dcp/commands/cleanup_test.go
+++ b/internal/dcp/commands/cleanup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/microsoft/dcp/pkg/commonapi"
 	dcpio "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
 
@@ -575,6 +576,87 @@ func TestCleanupPersistentContainerRecordSkipsRecordThatChangedWorkload(t *testi
 	require.Equal(t, currentRecord.ContainerID, record.ContainerID)
 }
 
+func TestCleanupPersistentContainerRecordWaitsForHeldLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, 5*time.Second)
+	defer cancel()
+	stateStore := openCleanupTestStore(t, ctx)
+	heldLeaseOwner, heldLeaseOwnerErr := statestore.CurrentResourceLeaseOwner()
+	require.NoError(t, heldLeaseOwnerErr)
+	cleanupLeaseOwner := process.ProcessHandle{
+		Pid:          heldLeaseOwner.Pid,
+		IdentityTime: heldLeaseOwner.IdentityTime.Add(-time.Hour),
+	}
+	orchestrator, orchestratorErr := ctrlutil.NewTestContainerOrchestrator(ctx, logr.Discard(), ctrlutil.TcoOptionNone)
+	require.NoError(t, orchestratorErr)
+
+	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "api"})
+	require.NoError(t, createContainerErr)
+	record := statestore.PersistentContainerRecord{
+		ResourceKey:   "containers/api",
+		ContainerID:   containerID,
+		ContainerName: "api",
+		RuntimeName:   cleanupTestRuntimeName,
+		WorkloadID:    "workload-a",
+	}
+	require.NoError(t, stateStore.UpsertPersistentContainer(ctx, record))
+	_, leaseErr := stateStore.AcquireResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner, time.Minute)
+	require.NoError(t, leaseErr)
+
+	type cleanupResult struct {
+		resourceID string
+		cleaned    bool
+		err        error
+	}
+	resultCh := make(chan cleanupResult, 1)
+	// Start cleanup on a goroutine so it has to wait on the held resource lease.
+	go func() {
+		resourceID, cleaned, cleanupErr := cleanupPersistentContainerRecord(
+			ctx,
+			"workload-a",
+			stateStore,
+			cleanupLeaseOwner,
+			func(runtimeName string) (containers.ContainerOrchestrator, error) {
+				if runtimeName != cleanupTestRuntimeName {
+					return nil, errors.New("unexpected runtime name")
+				}
+				return orchestrator, nil
+			},
+			record,
+			logr.Discard(),
+		)
+		resultCh <- cleanupResult{resourceID: resourceID, cleaned: cleaned, err: cleanupErr}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "cleanup finished before the held lease was released", result.err)
+	default:
+	}
+
+	// Hold the lease long enough for at least one retry, then release it while cleanup is still waiting.
+	time.Sleep(2*workloadCleanupLeaseRetryInterval + 100*time.Millisecond)
+	require.NoError(t, stateStore.ReleaseResourceLease(ctx, cleanupLeaseResource(record.ResourceKey), heldLeaseOwner))
+
+	var result cleanupResult
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("cleanup did not finish after the held lease was released")
+		}
+	}))
+	require.NoError(t, result.err)
+	require.Equal(t, containerID, result.resourceID)
+	require.True(t, result.cleaned)
+	_, getErr := stateStore.GetPersistentContainer(ctx, record.ResourceKey)
+	require.ErrorIs(t, getErr, statestore.ErrPersistentContainerNotFound)
+	_, inspectErr := orchestrator.InspectContainers(ctx, containers.InspectContainersOptions{Containers: []string{containerID}})
+	require.ErrorIs(t, inspectErr, containers.ErrNotFound)
+}
+
 func TestCleanupWorkloadResourcesTreatsMissingProcessAsSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -943,23 +1025,24 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	ctx, cancel := testutil.GetTestContext(t, 30*time.Second)
 	defer cancel()
 	stateStore := openCleanupTestStore(t, ctx)
-	heldLeaseOwner, heldLeaseOwnerErr := statestore.CurrentResourceLeaseOwner()
-	require.NoError(t, heldLeaseOwnerErr)
-	cleanupLeaseOwner := process.ProcessHandle{
-		Pid:          heldLeaseOwner.Pid,
-		IdentityTime: heldLeaseOwner.IdentityTime.Add(-time.Hour),
-	}
+	leaseOwner, leaseOwnerErr := statestore.CurrentResourceLeaseOwner()
+	require.NoError(t, leaseOwnerErr)
 	processExecutor := process.NewOSExecutor(logr.Discard())
 	defer processExecutor.Dispose()
 	orchestrator, orchestratorErr := ctrlutil.NewTestContainerOrchestrator(ctx, logr.Discard(), ctrlutil.TcoOptionNone)
 	require.NoError(t, orchestratorErr)
+	removeContainerErr := errors.New("container removal failed")
+	wrappedOrchestrator := &failingCleanupContainerOrchestrator{
+		ContainerOrchestrator: orchestrator,
+		removeContainersErr:   removeContainerErr,
+	}
 
-	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "blocked"})
+	containerID, createContainerErr := orchestrator.CreateContainer(ctx, containers.CreateContainerOptions{Name: "invalid"})
 	require.NoError(t, createContainerErr)
 	require.NoError(t, stateStore.UpsertPersistentContainer(ctx, statestore.PersistentContainerRecord{
-		ResourceKey:   "containers/blocked",
+		ResourceKey:   "containers/invalid",
 		ContainerID:   containerID,
-		ContainerName: "blocked",
+		ContainerName: "invalid",
 		RuntimeName:   cleanupTestRuntimeName,
 		WorkloadID:    "workload-a",
 	}))
@@ -969,17 +1052,15 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 		RuntimeName: cleanupTestRuntimeName,
 		WorkloadID:  "workload-a",
 	}))
-	_, leaseErr := stateStore.AcquireResourceLease(ctx, cleanupLeaseResource("containers/blocked"), heldLeaseOwner, time.Minute)
-	require.NoError(t, leaseErr)
 
 	report, cleanupErr := cleanupWorkloadResources(
 		ctx,
 		"workload-a",
 		stateStore,
-		cleanupLeaseOwner,
+		leaseOwner,
 		func(runtimeName string) (containers.ContainerOrchestrator, error) {
 			require.Equal(t, cleanupTestRuntimeName, runtimeName)
-			return orchestrator, nil
+			return wrappedOrchestrator, nil
 		},
 		processExecutor,
 		logr.Discard(),
@@ -989,7 +1070,9 @@ func TestCleanupWorkloadResourcesReportsFailuresAndContinues(t *testing.T) {
 	require.Equal(t, cleanupStoppedCounts{Networks: 1}, report.Stopped)
 	require.Len(t, report.Failures, 1)
 	require.Equal(t, cleanupResourceName(cleanupResourceContainerGVR), report.Failures[0].Kind)
-	require.NotEmpty(t, report.Failures[0].Error)
+	require.Equal(t, "containers/invalid", report.Failures[0].ResourceKey)
+	require.Equal(t, containerID, report.Failures[0].ResourceID)
+	require.ErrorContains(t, errors.New(report.Failures[0].Error), removeContainerErr.Error())
 }
 
 func openCleanupTestStore(t *testing.T, ctx context.Context) *statestore.Store {
@@ -1096,4 +1179,14 @@ func (o *orderedCleanupContainerOrchestrator) RemoveNetworks(ctx context.Context
 	}
 
 	return o.ContainerOrchestrator.RemoveNetworks(ctx, options)
+}
+
+type failingCleanupContainerOrchestrator struct {
+	containers.ContainerOrchestrator
+
+	removeContainersErr error
+}
+
+func (o *failingCleanupContainerOrchestrator) RemoveContainers(context.Context, containers.RemoveContainersOptions) ([]string, error) {
+	return nil, o.removeContainersErr
 }

--- a/internal/statestore/leases.go
+++ b/internal/statestore/leases.go
@@ -13,7 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 )
 
 var (
@@ -248,6 +251,43 @@ func (s *Store) WithResourceLease(ctx context.Context, resource LeasableResource
 		return acquireErr
 	}
 
+	return withResourceLeaseCallback(ctx, lease, f)
+}
+
+// WithResourceLeaseRetry retries held leases until the lease is acquired or ctx is cancelled.
+func (s *Store) WithResourceLeaseRetry(
+	ctx context.Context,
+	resource LeasableResource,
+	ownerProcess process.ProcessHandle,
+	revalidationInterval time.Duration,
+	retryInterval time.Duration,
+	f func(context.Context, *ResourceLease) error,
+) error {
+	if f == nil {
+		return fmt.Errorf("%w: lease callback cannot be nil", ErrInvalidArgument)
+	}
+	if retryInterval <= 0 {
+		return fmt.Errorf("%w: lease retry interval must be positive", ErrInvalidArgument)
+	}
+
+	return resiliency.Retry(ctx, backoff.NewConstantBackOff(retryInterval), func() error {
+		lease, acquireErr := s.AcquireResourceLease(ctx, resource, ownerProcess, revalidationInterval)
+		if acquireErr == nil {
+			callbackErr := withResourceLeaseCallback(ctx, lease, f)
+			if callbackErr != nil {
+				return resiliency.Permanent(callbackErr)
+			}
+			return nil
+		}
+		if !errors.Is(acquireErr, ErrResourceLeaseHeld) {
+			return resiliency.Permanent(acquireErr)
+		}
+
+		return acquireErr
+	})
+}
+
+func withResourceLeaseCallback(ctx context.Context, lease *ResourceLease, f func(context.Context, *ResourceLease) error) error {
 	callbackErr := f(ctx, lease)
 	releaseErr := lease.Release(context.Background())
 	return errors.Join(callbackErr, releaseErr)

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -23,6 +23,7 @@ import (
 	usvc_io "github.com/microsoft/dcp/pkg/io"
 	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/resiliency"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
 
@@ -496,6 +497,119 @@ func TestWithResourceLeaseDoesNotRetryHeldLease(t *testing.T) {
 
 	require.ErrorIs(t, leaseErr, ErrResourceLeaseHeld)
 	require.False(t, callbackCalled)
+}
+
+func TestWithResourceLeaseRetryWaitsForHeldLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store1 := openTestStore(t, ctx, storePath)
+	store2 := openTestStore(t, ctx, storePath)
+
+	owner1, owner1Err := testResourceLeaseOwner(t, 0)
+	require.NoError(t, owner1Err)
+	owner2, owner2Err := testResourceLeaseOwner(t, -time.Hour)
+	require.NoError(t, owner2Err)
+
+	resource := testLeasableResource("container/test")
+	_, acquireErr := store1.AcquireResourceLease(ctx, resource, owner1, time.Minute)
+	require.NoError(t, acquireErr)
+
+	type leaseResult struct {
+		callbackCalled bool
+		err            error
+	}
+	resultCh := make(chan leaseResult, 1)
+	leaseRetryInterval := 500 * time.Millisecond
+	// Start acquisition on a goroutine so it has to wait on the held lease.
+	go func() {
+		callbackCalled := false
+		leaseErr := store2.WithResourceLeaseRetry(ctx, resource, owner2, time.Minute, leaseRetryInterval, func(context.Context, *ResourceLease) error {
+			callbackCalled = true
+			return nil
+		})
+		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "lease retry finished before the held lease was released", result.err)
+	default:
+	}
+
+	// Hold the lease long enough for at least one retry, then release it while the goroutine is still waiting.
+	time.Sleep(2*leaseRetryInterval + 100*time.Millisecond)
+	require.NoError(t, store1.ReleaseResourceLease(ctx, resource, owner1))
+
+	var result leaseResult
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("lease retry did not finish after the held lease was released")
+		}
+	}))
+	require.NoError(t, result.err)
+	require.True(t, result.callbackCalled)
+}
+
+func TestWithResourceLeaseRetryStopsWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store1 := openTestStore(t, ctx, storePath)
+	store2 := openTestStore(t, ctx, storePath)
+
+	owner1, owner1Err := testResourceLeaseOwner(t, 0)
+	require.NoError(t, owner1Err)
+	owner2, owner2Err := testResourceLeaseOwner(t, -time.Hour)
+	require.NoError(t, owner2Err)
+
+	resource := testLeasableResource("container/test")
+	_, acquireErr := store1.AcquireResourceLease(ctx, resource, owner1, time.Minute)
+	require.NoError(t, acquireErr)
+
+	waitCtx, cancelWait := context.WithCancel(ctx)
+	defer cancelWait()
+
+	type leaseResult struct {
+		callbackCalled bool
+		err            error
+	}
+	resultCh := make(chan leaseResult, 1)
+	go func() {
+		callbackCalled := false
+		leaseErr := store2.WithResourceLeaseRetry(waitCtx, resource, owner2, time.Minute, 10*time.Millisecond, func(context.Context, *ResourceLease) error {
+			callbackCalled = true
+			return nil
+		})
+		resultCh <- leaseResult{callbackCalled: callbackCalled, err: leaseErr}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "lease retry finished before the context was canceled", result.err)
+	default:
+	}
+
+	cancelWait()
+
+	var result leaseResult
+	require.NoError(t, resiliency.RetryExponential(ctx, func() error {
+		select {
+		case result = <-resultCh:
+			return nil
+		default:
+			return errors.New("lease retry did not finish after the context was canceled")
+		}
+	}))
+	require.ErrorIs(t, result.err, context.Canceled)
+	require.False(t, result.callbackCalled)
 }
 
 func TestDeleteInactiveResourceLeasesUsesOwnerProcessIdentity(t *testing.T) {


### PR DESCRIPTION
Backports #219 to release/0.25 so `dcp cleanup` waits for existing DCP ownership conflicts instead of failing immediately when a live instance still holds a persistent resource lease.

This cherry-picks the merged PR changes onto the release branch: cleanup uses retrying lease acquisition for persistent containers, executables, and networks; statestore exposes the retrying lease helper; and regression tests cover held leases, cancellation, and cleanup failure reporting.

Validation:
- `make test-prereqs && go test -count 1 -parallel 32 ./internal/statestore ./internal/dcp/commands`
- `make lint`