### PR TITLE
[release/0.25] Repair interrupted state store migrations

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,7 +18,7 @@ required to debug changes to any libraries licensed under the GNU Lesser General
 ----------------------------------------------------------
 
 cel.dev/expr v0.25.1 - Apache-2.0
-https://github.com/google/cel-spec/blob/v0.25.1/LICENSE
+https://github.com/cel-expr/cel-spec/blob/v0.25.1/LICENSE
 
 
                                  Apache License

--- a/internal/dcp/bootstrap/dcp_run.go
+++ b/internal/dcp/bootstrap/dcp_run.go
@@ -104,12 +104,14 @@ func DcpRun(
 	})
 
 	hostedServices := []hosting.Service{}
+	builtInControllerServiceName := ""
 	if !serverOnly {
 		// Always run the built-in controllers
 		controllerService, controllerServiceErr := newRunControllersService(cwd, invocationFlags, log)
 		if controllerServiceErr != nil {
 			return fmt.Errorf("could not start built-in controllers: %w", controllerServiceErr)
 		}
+		builtInControllerServiceName = controllerService.Name()
 		hostedServices = append(hostedServices, controllerService)
 
 		// Also run any extension controllers
@@ -167,6 +169,9 @@ func DcpRun(
 	}
 
 	var err error
+	// controllerHostErr records a fatal failure of the built-in controller host so it can be
+	// reported after the regular shutdown sequence completes.
+	var controllerHostErr error
 	// Wait for the user to signal that they want to shut down.
 	for {
 		select {
@@ -186,20 +191,20 @@ func DcpRun(
 				err = shutdownHost()
 				if err != nil {
 					log.Error(err, "Failed to shut down hosted services")
-					return err
+					return errors.Join(controllerHostErr, err)
 				}
-				return nil
+				return controllerHostErr
 			}
 
 			err = appmgmt.CleanupAllResources(log)
 			err = errors.Join(err, shutdownHost())
 			if err != nil {
 				log.Error(err, "Failed to cleanup some resources. This may lead to resource leaks.")
-				return err
+				return errors.Join(controllerHostErr, err)
 			}
 
 			log.Info("Shutdown complete.")
-			return nil
+			return controllerHostErr
 
 		case <-apiServerShutdown:
 			err = fmt.Errorf("API server shut down unexpectedly. Graceful shutdown is not possible.")
@@ -214,7 +219,16 @@ func DcpRun(
 
 			if msg.Err != nil {
 				log.Error(msg.Err, fmt.Sprintf("Controller '%s' exited with an error. Application may not function correctly.", msg.ServiceName))
-				// Let the user decide whether to continue or not, do not break the loop yet.
+
+				// Nothing reconciles application resources without the built-in controllers, so keeping
+				// the API server alive would leave clients waiting indefinitely for resources that will
+				// never become ready. Shut down instead so the failure is visible. Resource cleanup also
+				// needs the controllers, so requesting it here would only delay the failure.
+				if msg.ServiceName == builtInControllerServiceName && controllerHostErr == nil {
+					controllerHostErr = fmt.Errorf("DCP cannot run without the built-in controllers: %w", msg.Err)
+					log.Error(controllerHostErr, "Terminating...")
+					runConfig.RequestShutdown(apiserver.ApiServerResourceCleanupNone)
+				}
 			}
 		}
 	}

--- a/internal/dcp/bootstrap/dcp_run.go
+++ b/internal/dcp/bootstrap/dcp_run.go
@@ -223,7 +223,8 @@ func DcpRun(
 				// Nothing reconciles application resources without the built-in controllers, so keeping
 				// the API server alive would leave clients waiting indefinitely for resources that will
 				// never become ready. Shut down instead so the failure is visible. Resource cleanup also
-				// needs the controllers, so requesting it here would only delay the failure.
+				// needs the controllers, so requesting it here (along with the cleanup notifications that
+				// go with it) would only delay the failure without releasing anything.
 				if msg.ServiceName == builtInControllerServiceName && controllerHostErr == nil {
 					controllerHostErr = fmt.Errorf("DCP cannot run without the built-in controllers: %w", msg.Err)
 					log.Error(controllerHostErr, "Terminating...")

--- a/internal/dcp/commands/cleanup.go
+++ b/internal/dcp/commands/cleanup.go
@@ -156,7 +156,7 @@ func cleanup(log logr.Logger) func(cmd *cobra.Command, args []string) error {
 			return workloadIDErr
 		}
 
-		stateStore, stateStoreErr := statestore.Open(cmd.Context(), statestore.Options{})
+		stateStore, stateStoreErr := statestore.Open(cmd.Context(), statestore.Options{Log: log})
 		if stateStoreErr != nil {
 			return fmt.Errorf("failed to initialize state store: %w", stateStoreErr)
 		}

--- a/internal/dcpctrl/commands/run_controllers.go
+++ b/internal/dcpctrl/commands/run_controllers.go
@@ -121,7 +121,7 @@ func runControllers(log logr.Logger) func(cmd *cobra.Command, _ []string) error 
 			return fmt.Errorf("cannot set up connection to the API server without kubeconfig file: %w", err)
 		}
 
-		stateStore, stateStoreErr := statestore.Open(ctrlCtx, statestore.Options{})
+		stateStore, stateStoreErr := statestore.Open(ctrlCtx, statestore.Options{Log: log})
 		if stateStoreErr != nil {
 			return fmt.Errorf("failed to initialize state store: %w", stateStoreErr)
 		}

--- a/internal/hosting/command_service.go
+++ b/internal/hosting/command_service.go
@@ -89,8 +89,7 @@ func (s *CommandService) Run(ctx context.Context) error {
 	if (s.options & CommandServiceRunOptionDontTerminate) != 0 {
 		select {
 		case exitInfo := <-pic:
-			s.exitCode = exitInfo.ExitCode
-			return exitInfo.Err
+			return s.recordExit(ctx, exitInfo)
 		case <-ctx.Done():
 			return nil
 		}
@@ -98,9 +97,21 @@ func (s *CommandService) Run(ctx context.Context) error {
 		// Context cancel will force the process to exit, so we only need to wait for the latter
 		// (and capture the result).
 		exitInfo := <-pic
-		s.exitCode = exitInfo.ExitCode
+		return s.recordExit(ctx, exitInfo)
+	}
+}
+
+// recordExit captures the process exit code and reports an unexpected exit as a service failure.
+// An exit that follows cancellation of the service context is expected and is not an error.
+func (s *CommandService) recordExit(ctx context.Context, exitInfo process.ProcessExitInfo) error {
+	s.exitCode = exitInfo.ExitCode
+	if exitInfo.Err != nil {
 		return exitInfo.Err
 	}
+	if exitInfo.ExitCode != 0 && ctx.Err() == nil {
+		return fmt.Errorf("%s exited unexpectedly with exit code %d", s.name, exitInfo.ExitCode)
+	}
+	return nil
 }
 
 var _ Service = (*CommandService)(nil)

--- a/internal/hosting/command_service_test.go
+++ b/internal/hosting/command_service_test.go
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package hosting
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/microsoft/dcp/internal/testutil"
+	"github.com/microsoft/dcp/pkg/process"
+)
+
+const (
+	commandServiceTestName = "test-service"
+
+	// The test executor hands out sequential PIDs starting at 1, and every test uses its own executor.
+	firstTestProcessPID process.Pid_t = 1
+)
+
+// newTestCommandService creates a CommandService backed by an executor that never runs a real process.
+func newTestCommandService(
+	t *testing.T,
+	executor process.Executor,
+	options CommandServiceRunOptions,
+) *CommandService {
+	t.Helper()
+
+	return NewCommandService(
+		commandServiceTestName,
+		exec.Command("dcp-command-service-test"),
+		executor,
+		options,
+		logr.Discard(),
+	)
+}
+
+// waitForTestProcessStart blocks until the service has started its process, so the test can
+// simulate an exit for it.
+func waitForTestProcessStart(t *testing.T, ctx context.Context, executor *testutil.TestProcessExecutor) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, found := executor.FindByPid(firstTestProcessPID); found {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			require.FailNow(t, "timed out waiting for the service process to start")
+		case <-ticker.C:
+		}
+	}
+}
+
+func runCommandServiceAsync(svc *CommandService, ctx context.Context) <-chan error {
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- svc.Run(ctx)
+	}()
+	return runResult
+}
+
+func Test_CommandService_CleanExitIsNotAnError(t *testing.T) {
+	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	defer cancelExecCtx()
+
+	executor := testutil.NewTestProcessExecutor(execCtx)
+	defer executor.Dispose()
+
+	svc := newTestCommandService(t, executor, 0)
+	runResult := runCommandServiceAsync(svc, execCtx)
+
+	waitForTestProcessStart(t, execCtx, executor)
+	executor.SimulateProcessExit(t, firstTestProcessPID, 0)
+
+	require.NoError(t, <-runResult)
+}
+
+// Test_CommandService_UnexpectedExitIsReported covers the failure that leaves DCP without the
+// component the service was hosting: the process exits on its own with a non-zero code while the
+// service is still supposed to be running.
+func Test_CommandService_UnexpectedExitIsReported(t *testing.T) {
+	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	defer cancelExecCtx()
+
+	executor := testutil.NewTestProcessExecutor(execCtx)
+	defer executor.Dispose()
+
+	svc := newTestCommandService(t, executor, 0)
+	runResult := runCommandServiceAsync(svc, execCtx)
+
+	waitForTestProcessStart(t, execCtx, executor)
+	executor.SimulateProcessExit(t, firstTestProcessPID, 1)
+
+	runErr := <-runResult
+	require.Error(t, runErr)
+	require.ErrorContains(t, runErr, commandServiceTestName)
+	require.ErrorContains(t, runErr, "exit code 1")
+}
+
+// Test_CommandService_ExitAfterCancellationIsNotAnError verifies that shutting DCP down does not
+// report a failure. Terminating a process yields a non-zero exit code on most platforms, and that
+// is the expected outcome once the service context is cancelled.
+func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
+	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	defer cancelExecCtx()
+
+	executor := testutil.NewTestProcessExecutor(execCtx)
+	defer executor.Dispose()
+
+	svcCtx, cancelSvcCtx := context.WithCancel(execCtx)
+	defer cancelSvcCtx()
+
+	svc := newTestCommandService(t, executor, 0)
+	runResult := runCommandServiceAsync(svc, svcCtx)
+
+	waitForTestProcessStart(t, execCtx, executor)
+	cancelSvcCtx()
+	executor.SimulateProcessExit(t, firstTestProcessPID, testutil.KilledProcessExitCode)
+
+	require.NoError(t, <-runResult)
+}
+
+// Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated covers the same unexpected exit for
+// services that outlive their context (CommandServiceRunOptionDontTerminate), which take a
+// different path out of Run.
+func Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated(t *testing.T) {
+	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	defer cancelExecCtx()
+
+	executor := testutil.NewTestProcessExecutor(execCtx)
+	defer executor.Dispose()
+
+	svc := newTestCommandService(t, executor, CommandServiceRunOptionDontTerminate)
+	runResult := runCommandServiceAsync(svc, execCtx)
+
+	waitForTestProcessStart(t, execCtx, executor)
+	executor.SimulateProcessExit(t, firstTestProcessPID, 3)
+
+	runErr := <-runResult
+	require.Error(t, runErr)
+	require.ErrorContains(t, runErr, "exit code 3")
+}
+
+// Test_CommandService_ProcessTrackingErrorIsReported verifies that a failure to observe the process
+// exit is surfaced even though no exit code is available.
+func Test_CommandService_ProcessTrackingErrorIsReported(t *testing.T) {
+	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	defer cancelExecCtx()
+
+	trackingErr := errors.New("could not track the process")
+	executor := &exitErrorExecutor{
+		TestProcessExecutor: testutil.NewTestProcessExecutor(execCtx),
+		exitErr:             trackingErr,
+	}
+	defer executor.Dispose()
+
+	svc := newTestCommandService(t, executor, 0)
+
+	require.ErrorIs(t, svc.Run(execCtx), trackingErr)
+}
+
+// exitErrorExecutor reports process exit with an error instead of an exit code, which happens when
+// the process could not be tracked to completion.
+type exitErrorExecutor struct {
+	*testutil.TestProcessExecutor
+	exitErr error
+}
+
+func (e *exitErrorExecutor) StartProcess(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	exitHandler process.ProcessExitHandler,
+	creationFlags process.ProcessCreationFlag,
+	sysCreateProcess process.SysCreateProcessFunc,
+) (process.ProcessHandle, func(), error) {
+	handle, startWaitForProcessExit, startErr := e.TestProcessExecutor.StartProcess(
+		ctx,
+		cmd,
+		exitHandler,
+		creationFlags,
+		sysCreateProcess,
+	)
+	if startErr != nil {
+		return handle, startWaitForProcessExit, startErr
+	}
+
+	return handle, func() {
+		startWaitForProcessExit()
+		exitHandler.OnProcessExited(handle.Pid, process.UnknownExitCode, e.exitErr)
+	}, nil
+}
+
+var _ process.Executor = (*exitErrorExecutor)(nil)

--- a/internal/hosting/command_service_test.go
+++ b/internal/hosting/command_service_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/microsoft/dcp/internal/testutil"
+	internal_testutil "github.com/microsoft/dcp/internal/testutil"
 	"github.com/microsoft/dcp/pkg/process"
+	"github.com/microsoft/dcp/pkg/testutil"
 )
 
 const (
-	commandServiceTestName = "test-service"
+	commandServiceTestName    = "test-service"
+	commandServiceTestTimeout = 10 * time.Second
 
 	// The test executor hands out sequential PIDs starting at 1, and every test uses its own executor.
 	firstTestProcessPID process.Pid_t = 1
@@ -45,7 +47,7 @@ func newTestCommandService(
 
 // waitForTestProcessStart blocks until the service has started its process, so the test can
 // simulate an exit for it.
-func waitForTestProcessStart(t *testing.T, ctx context.Context, executor *testutil.TestProcessExecutor) {
+func waitForTestProcessStart(t *testing.T, ctx context.Context, executor *internal_testutil.TestProcessExecutor) {
 	t.Helper()
 
 	ticker := time.NewTicker(time.Millisecond)
@@ -71,10 +73,10 @@ func runCommandServiceAsync(svc *CommandService, ctx context.Context) <-chan err
 }
 
 func Test_CommandService_CleanExitIsNotAnError(t *testing.T) {
-	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
 	defer cancelExecCtx()
 
-	executor := testutil.NewTestProcessExecutor(execCtx)
+	executor := internal_testutil.NewTestProcessExecutor(execCtx)
 	defer executor.Dispose()
 
 	svc := newTestCommandService(t, executor, 0)
@@ -90,10 +92,10 @@ func Test_CommandService_CleanExitIsNotAnError(t *testing.T) {
 // component the service was hosting: the process exits on its own with a non-zero code while the
 // service is still supposed to be running.
 func Test_CommandService_UnexpectedExitIsReported(t *testing.T) {
-	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
 	defer cancelExecCtx()
 
-	executor := testutil.NewTestProcessExecutor(execCtx)
+	executor := internal_testutil.NewTestProcessExecutor(execCtx)
 	defer executor.Dispose()
 
 	svc := newTestCommandService(t, executor, 0)
@@ -112,10 +114,10 @@ func Test_CommandService_UnexpectedExitIsReported(t *testing.T) {
 // report a failure. Terminating a process yields a non-zero exit code on most platforms, and that
 // is the expected outcome once the service context is cancelled.
 func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
-	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
 	defer cancelExecCtx()
 
-	executor := testutil.NewTestProcessExecutor(execCtx)
+	executor := internal_testutil.NewTestProcessExecutor(execCtx)
 	defer executor.Dispose()
 
 	svcCtx, cancelSvcCtx := context.WithCancel(execCtx)
@@ -126,7 +128,7 @@ func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
 
 	waitForTestProcessStart(t, execCtx, executor)
 	cancelSvcCtx()
-	executor.SimulateProcessExit(t, firstTestProcessPID, testutil.KilledProcessExitCode)
+	executor.SimulateProcessExit(t, firstTestProcessPID, internal_testutil.KilledProcessExitCode)
 
 	require.NoError(t, <-runResult)
 }
@@ -135,10 +137,10 @@ func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
 // services that outlive their context (CommandServiceRunOptionDontTerminate), which take a
 // different path out of Run.
 func Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated(t *testing.T) {
-	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
 	defer cancelExecCtx()
 
-	executor := testutil.NewTestProcessExecutor(execCtx)
+	executor := internal_testutil.NewTestProcessExecutor(execCtx)
 	defer executor.Dispose()
 
 	svc := newTestCommandService(t, executor, CommandServiceRunOptionDontTerminate)
@@ -155,12 +157,12 @@ func Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated(t *testing.T)
 // Test_CommandService_ProcessTrackingErrorIsReported verifies that a failure to observe the process
 // exit is surfaced even though no exit code is available.
 func Test_CommandService_ProcessTrackingErrorIsReported(t *testing.T) {
-	execCtx, cancelExecCtx := context.WithDeadline(createContext(t), time.Now().Add(time.Second*10))
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
 	defer cancelExecCtx()
 
 	trackingErr := errors.New("could not track the process")
 	executor := &exitErrorExecutor{
-		TestProcessExecutor: testutil.NewTestProcessExecutor(execCtx),
+		TestProcessExecutor: internal_testutil.NewTestProcessExecutor(execCtx),
 		exitErr:             trackingErr,
 	}
 	defer executor.Dispose()
@@ -173,7 +175,7 @@ func Test_CommandService_ProcessTrackingErrorIsReported(t *testing.T) {
 // exitErrorExecutor reports process exit with an error instead of an exit code, which happens when
 // the process could not be tracked to completion.
 type exitErrorExecutor struct {
-	*testutil.TestProcessExecutor
+	*internal_testutil.TestProcessExecutor
 	exitErr error
 }
 

--- a/internal/hosting/command_service_test.go
+++ b/internal/hosting/command_service_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	commandServiceTestName    = "test-service"
-	commandServiceTestTimeout = 10 * time.Second
+	commandServiceTestName = "test-service"
 
 	// The test executor hands out sequential PIDs starting at 1, and every test uses its own executor.
 	firstTestProcessPID process.Pid_t = 1
@@ -73,7 +72,7 @@ func runCommandServiceAsync(svc *CommandService, ctx context.Context) <-chan err
 }
 
 func Test_CommandService_CleanExitIsNotAnError(t *testing.T) {
-	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancelExecCtx()
 
 	executor := internal_testutil.NewTestProcessExecutor(execCtx)
@@ -92,7 +91,7 @@ func Test_CommandService_CleanExitIsNotAnError(t *testing.T) {
 // component the service was hosting: the process exits on its own with a non-zero code while the
 // service is still supposed to be running.
 func Test_CommandService_UnexpectedExitIsReported(t *testing.T) {
-	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancelExecCtx()
 
 	executor := internal_testutil.NewTestProcessExecutor(execCtx)
@@ -114,7 +113,7 @@ func Test_CommandService_UnexpectedExitIsReported(t *testing.T) {
 // report a failure. Terminating a process yields a non-zero exit code on most platforms, and that
 // is the expected outcome once the service context is cancelled.
 func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
-	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancelExecCtx()
 
 	executor := internal_testutil.NewTestProcessExecutor(execCtx)
@@ -137,7 +136,7 @@ func Test_CommandService_ExitAfterCancellationIsNotAnError(t *testing.T) {
 // services that outlive their context (CommandServiceRunOptionDontTerminate), which take a
 // different path out of Run.
 func Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated(t *testing.T) {
-	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancelExecCtx()
 
 	executor := internal_testutil.NewTestProcessExecutor(execCtx)
@@ -157,7 +156,7 @@ func Test_CommandService_UnexpectedExitIsReportedWhenNotTerminated(t *testing.T)
 // Test_CommandService_ProcessTrackingErrorIsReported verifies that a failure to observe the process
 // exit is surfaced even though no exit code is available.
 func Test_CommandService_ProcessTrackingErrorIsReported(t *testing.T) {
-	execCtx, cancelExecCtx := testutil.GetTestContext(t, commandServiceTestTimeout)
+	execCtx, cancelExecCtx := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancelExecCtx()
 
 	trackingErr := errors.New("could not track the process")

--- a/internal/hosting/hosting_test.go
+++ b/internal/hosting/hosting_test.go
@@ -11,14 +11,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+
+	"github.com/microsoft/dcp/pkg/testutil"
 )
 
+const hostingTestTimeout = 10 * time.Second
+
 func Test_Host_CanRunWithNoServices(t *testing.T) {
-	ctx, cancel := context.WithDeadline(createContext(t), time.Now().Add(time.Second*5))
+	ctx, cancel := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancel()
 
 	host := &Host{
@@ -30,7 +31,7 @@ func Test_Host_CanRunWithNoServices(t *testing.T) {
 }
 
 func Test_Host_DetectsDuplicates(t *testing.T) {
-	ctx, cancel := context.WithDeadline(createContext(t), time.Now().Add(time.Second*5))
+	ctx, cancel := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancel()
 
 	host := &Host{
@@ -45,7 +46,7 @@ func Test_Host_DetectsDuplicates(t *testing.T) {
 }
 
 func Test_Host_RunMultipleServices_HandlesExit(t *testing.T) {
-	ctx, cancel := context.WithDeadline(createContext(t), time.Now().Add(time.Second*5))
+	ctx, cancel := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancel()
 
 	started := make(chan struct{})
@@ -127,10 +128,15 @@ func Test_Host_RunMultipleServices_HandlesExit(t *testing.T) {
 }
 
 func Test_Host_RunMultipleServices_ShutdownTimeout(t *testing.T) {
-	ctx, cancel := context.WithDeadline(createContext(t), time.Now().Add(time.Second*5))
+	ctx, cancel := testutil.GetTestContext(t, hostingTestTimeout)
 	defer cancel()
 
 	started := make(chan struct{})
+
+	// The two services below stay blocked for the rest of the test binary's life on purpose. Once the
+	// host gives up waiting it closes the channel it collects service results on, so a service that
+	// finishes afterwards would panic trying to report its result. Do not release them at test cleanup.
+	neverTerminates := make(chan struct{})
 
 	host := &Host{
 		Services: []Service{
@@ -138,14 +144,14 @@ func Test_Host_RunMultipleServices_ShutdownTimeout(t *testing.T) {
 				// Does not terminate
 				started <- struct{}{}
 				<-c.Done()
-				time.Sleep(time.Second * 30)
+				<-neverTerminates
 				return nil
 			}),
 			NewFuncService("B", func(c context.Context) error {
 				// Does not terminate
 				started <- struct{}{}
 				<-c.Done()
-				time.Sleep(time.Second * 30)
+				<-neverTerminates
 				return nil
 			}),
 		},
@@ -197,8 +203,4 @@ func (s *FuncService) Run(ctx context.Context) error {
 	}
 
 	return s.run(ctx)
-}
-
-func createContext(t *testing.T) context.Context {
-	return logr.NewContext(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
 }

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -21,37 +21,40 @@ For each supported major version, DCP:
 
 `golang-migrate` does not serialize migrations across processes when using SQLite. Its `Driver` interface lets an implementation opt out of locking, and the SQLite driver does: `Lock` only flips an in-process flag on the driver instance. DCP builds a fresh migration runner for every `Open`, so that flag serializes nothing at all.
 
-The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read, repair, and migrate sequence. `golang-migrate` reads the current version and then writes the version marker in separate transactions, so instances that are not serialized can both read the same version, both decide to migrate, and both run the same migration — the loser fails to start or leaves a dirty marker behind.
+The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read schema version, repair, and migrate sequence. `golang-migrate` reads the current version and then writes the version marker in separate transactions, so instances that are not serialized can both read the same version, both decide to migrate, and both run the same migration — the loser fails to start or leaves a dirty marker behind.
 
-The lock is an advisory file lock held on an open file descriptor, so the operating system releases it when the owning process exits, including a crash. DCP waits for the lock rather than failing when another instance holds it, which also covers Windows releasing the lock asynchronously after a process dies. An interrupted migration therefore leaves a dirty version marker but never a permanently stuck lock, which is what lets the next DCP acquire the lock and repair the marker.
+The lock is an advisory file lock held on an open file descriptor, so the operating system releases it when the owning process exits, including a crash. DCP waits for the lock rather than failing when another instance holds it. An interrupted migration therefore leaves a dirty version marker but never a permanently stuck lock, which is what lets the next DCP acquire the lock and clear the marker.
 
-### Recovering a dirty version
+### How DCP handles failed migrations
 
-`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete. That happens when DCP is interrupted part way through a migration, and also when an older DCP re-runs a migration a newer DCP already applied: the older binary expects a version marker the newer layout no longer records, re-runs the migration, and its SQL fails because the schema change is already present.
+`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete. That can happen when DCP is interrupted part way through a migration. It also happens when a DCP that predates probe-based repair opens a store a newer DCP has already migrated: the older binary has no probes and advances its own migration stream unconditionally, so its SQL fails because the schema change is already present. `TestOpenRepairsSchemaDirtiedByOlderDcp` covers that case.
 
-DCP repairs a dirty version instead of failing startup. Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. DCP evaluates the probe for the dirty version and rewrites the version table:
+Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. DCP evaluates the probe for the dirty version(s) and rewrites the version table:
 
-- The probe reports true, so the migration committed. DCP records the dirty version as clean and continues with the following migration.
-- The probe reports false, so the migration never committed. DCP records the preceding version as clean, or empties the stream when the dirty version was the first migration, and the migration runs again.
+- If the probe reports true, the migration committed. DCP clears the dirty flag and continues with the following migration.
+- If the probe reports false, the migration never committed. DCP marks the preceding version as clean (or assumes no migrations happened if the dirty version was the first migration), clears the dirty flag for the failed migration, and re-applies it.
 
-DCP does not repair every dirty marker:
+DCP does not repair every dirty marker.
 
-- A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
-- An unknown major version fails startup whether it is dirty or clean. Major versions are reserved for changes that older binaries cannot use safely.
+A dirty minor version newer than any migration embedded in current binary cannot be probed--it was attempted by a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed. DCP logs the condition, leaves the dirty marker alone, and lets the binary that owns the migration repair it.
 
-### Why repairing a dirty version is safe
+An unknown major version fails startup whether it is dirty or clean. Major versions are reserved for changes that older binaries cannot use safely.
 
-A dirty marker for version *v* has exactly two possible meanings:
+### Migrations are atomic
 
-1. The migration's transaction never committed, so the schema is exactly at version *v-1*.
-2. The transaction committed but DCP stopped before clearing the dirty flag, so the schema is exactly at version *v*.
+Every DCP schema migration is atomic because it runs in a single transaction. Only two outcomes are possible:
 
-There is no third case where the schema sits part way between the two. That is what makes the probe result a reliable answer rather than a guess, and it holds because of two constraints this repository places on migration authoring, both enforced by unit tests:
+1. The migration's transaction failed to commit, so the schema is exactly at version *v-1*.
+2. The transaction committed, so the schema is exactly at version *v*.
+
+There is no third case where the schema sits part way between the two. This means the dirty flag `golang-migrate` maintains is not authoritative on its own--it is updated outside the migration transaction, so it can remain set even though the migration succeeded. DCP treats the flag as a signal to probe rather than as the schema state, which is why it can clear the flag automatically in the cases described above.
+
+The use of single transaction for each migration is also what makes the probe result a reliable answer rather than a guess, and it holds because of two constraints this repository places on migration authoring, both enforced by unit tests:
 
 - **Migration SQL never commits implicitly.** The SQLite migration driver wraps each migration in a single transaction, so `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` are rejected. `TestMigrationsAreTransactional` checks every embedded migration file. SQLite treats `END` as an alias for `COMMIT`, so only an `END` that closes a `CASE` expression is allowed. A migration that ended its transaction part way through would leave a schema that is neither version, and no probe could describe it.
-- **Every migration has an applied probe that discriminates.** The probe must report false before the migration runs and true afterwards. Without a probe DCP cannot tell which of the two cases it is in, and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
+- **Every migration has an applied probe that discriminates.** The probe must reliably report `false` before the migration is applied and `true` afterwards.
 
-Because the schema always matches one of the two versions exactly, DCP can determine the real migration state and record it. Repair only rewrites the version marker; it never edits schema or data. When the probe reports false the schema is exactly at *v-1*, so re-running the migration is an ordinary first application rather than a retry against a half-changed schema. DCP repairs the major version stream and each major version's minor stream the same way.
+Because the schema always matches one of the two versions exactly, DCP can determine the real migration state and record it. Repair only rewrites the version marker; it never edits schema or data. When the probe reports false the schema is exactly at *v-1*, so re-running the migration is an ordinary first application rather than a retry against a half-changed schema. DCP detects existing schema version for major and minor migrations in the same way, and clears the `golang-migrate` dirty flag for both.
 
 ### Accepting a newer clean minor version
 
@@ -82,7 +85,7 @@ Minor migrations must remain safe when an older DCP uses the database afterward:
 - Do not add unique indexes, check constraints, foreign keys, changed primary keys, or other constraints that can reject writes accepted by older binaries without an explicit compatibility design.
 - Preserve `resource_locks` so old and new DCP processes coordinate through the same lock records.
 - Preserve persistent resource tables and records so older binaries can continue reading and updating them.
-- Do not include `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`. These end the transaction the driver wraps the migration in, and [Why repairing a dirty version is safe](#why-repairing-a-dirty-version-is-safe) explains why that would make a dirty version unrecoverable. Only an `END` that closes a `CASE` expression is allowed.
+- Do not include `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`. These end the transaction the driver wraps the migration in, and [Migrations are atomic](#migrations-are-atomic) explains why that would make a failed migration potentially unrecoverable. Only an `END` that closes a `CASE` expression is allowed.
 
 ## Adding a breaking major migration
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -23,7 +23,7 @@ DCP repairs a dirty version instead of failing startup. The migration driver wra
 
 This repair depends on two invariants, both covered by unit tests:
 
-- Every migration has an applied probe. Without one, DCP cannot tell whether the migration committed and startup fails with the dirty version.
+- Every migration has an applied probe, and that probe reports false before the migration runs and true afterwards. Without a probe, DCP cannot tell whether the migration committed and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
 - Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected.
 
 A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -27,7 +27,7 @@ The lock is an advisory file lock held on an open file descriptor, so the operat
 
 ### How DCP handles failed migrations
 
-`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete. That can happen when DCP is interrupted part way through a migration. It also happens when a DCP that predates probe-based repair opens a store a newer DCP has already migrated: the older binary has no probes and advances its own migration stream unconditionally, so its SQL fails because the schema change is already present. `TestOpenRepairsSchemaDirtiedByOlderDcp` covers that case.
+`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete, normally because DCP was interrupted part way through one. A binary that predates the major and minor version split can also leave one behind, which is a transitional condition described in [Schema version 2 transition](#schema-version-2-transition).
 
 Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. DCP evaluates the probe for the dirty version(s) and rewrites the version table:
 
@@ -65,6 +65,10 @@ An older DCP may find a clean minor version newer than any migration embedded in
 The original migration layout used one sequence for every schema change: version 1 created the state store, and version 2 added workload IDs and persistent container and network tables. Version 2 was additive and remained compatible with DCP binaries that only knew version 1. However, recording version 2 in `schema_migrations` caused those older binaries to fail.
 
 The new layout classifies that change as major version 1, minor version 1. When DCP finds a clean database created by the old version 2 migration, it records minor version 1 in `schema_minor_migrations_v1` and changes the major marker from 2 back to 1. This only reclassifies an already-applied migration; it does not undo schema changes or delete data.
+
+Binaries built before this reclassification advance a single migration stream unconditionally and carry no applied probes. When one of them opens a store a current DCP has normalized, it tries to advance that stream to version 2 again, and its `ALTER TABLE` fails because `workload_id` is already present, leaving a dirty marker behind. Probe-based repair clears that marker the next time a current DCP opens the store; `TestOpenRepairsSchemaDirtiedByOlderDcp` covers it.
+
+Those binaries reached only Aspire's main and daily channels during a short window and were never part of a stable release. This is therefore the most common source of dirty markers at the time of writing but not a lasting one: it affects machines that ran one of those builds, and work that has not yet picked up the current layout, and it stops happening once those binaries fall out of use. Repair itself is not tied to this transition and remains in place for interrupted migrations generally.
 
 Major version 2 remains reserved for this transition. The next breaking schema change must use major version 3.
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -34,17 +34,24 @@ DCP repairs a dirty version instead of failing startup. Every migration register
 - The probe reports true, so the migration committed. DCP records the dirty version as clean and continues with the following migration.
 - The probe reports false, so the migration never committed. DCP records the preceding version as clean, or empties the stream when the dirty version was the first migration, and the migration runs again.
 
-This is sound because the migration driver wraps each migration in its own transaction. An interrupted migration either committed in full or never committed at all, so the schema always matches one of the two cases above and is never partially migrated. DCP repairs the major version stream and each major version's minor stream the same way.
-
-This repair depends on two invariants, both covered by unit tests:
-
-- Every migration has an applied probe, and that probe reports false before the migration runs and true afterwards. Without a probe, DCP cannot tell whether the migration committed and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
-- Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected. SQLite treats `END` as an alias for `COMMIT`; an `END` that closes a `CASE` expression is fine.
-
 DCP does not repair every dirty marker:
 
 - A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
 - An unknown major version fails startup whether it is dirty or clean. Major versions are reserved for changes that older binaries cannot use safely.
+
+### Why repairing a dirty version is safe
+
+A dirty marker for version *v* has exactly two possible meanings:
+
+1. The migration's transaction never committed, so the schema is exactly at version *v-1*.
+2. The transaction committed but DCP stopped before clearing the dirty flag, so the schema is exactly at version *v*.
+
+There is no third case where the schema sits part way between the two. That is what makes the probe result a reliable answer rather than a guess, and it holds because of two constraints this repository places on migration authoring, both enforced by unit tests:
+
+- **Migration SQL never commits implicitly.** The SQLite migration driver wraps each migration in a single transaction, so `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` are rejected. `TestMigrationsAreTransactional` checks every embedded migration file. SQLite treats `END` as an alias for `COMMIT`, so only an `END` that closes a `CASE` expression is allowed. A migration that ended its transaction part way through would leave a schema that is neither version, and no probe could describe it.
+- **Every migration has an applied probe that discriminates.** The probe must report false before the migration runs and true afterwards. Without a probe DCP cannot tell which of the two cases it is in, and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
+
+Because the schema always matches one of the two versions exactly, DCP can determine the real migration state and record it. Repair only rewrites the version marker; it never edits schema or data. When the probe reports false the schema is exactly at *v-1*, so re-running the migration is an ordinary first application rather than a retry against a half-changed schema. DCP repairs the major version stream and each major version's minor stream the same way.
 
 ### Accepting a newer clean minor version
 
@@ -75,7 +82,7 @@ Minor migrations must remain safe when an older DCP uses the database afterward:
 - Do not add unique indexes, check constraints, foreign keys, changed primary keys, or other constraints that can reject writes accepted by older binaries without an explicit compatibility design.
 - Preserve `resource_locks` so old and new DCP processes coordinate through the same lock records.
 - Preserve persistent resource tables and records so older binaries can continue reading and updating them.
-- Do not include `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`; the SQLite migration driver wraps each migration in a transaction and these statements would break its atomicity. SQLite treats `END` as an alias for `COMMIT`, so only an `END` that closes a `CASE` expression is allowed.
+- Do not include `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`. These end the transaction the driver wraps the migration in, and [Why repairing a dirty version is safe](#why-repairing-a-dirty-version-is-safe) explains why that would make a dirty version unrecoverable. Only an `END` that closes a `CASE` expression is allowed.
 
 ## Adding a breaking major migration
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -17,20 +17,38 @@ For each supported major version, DCP:
 2. Advances `schema_migrations` when moving to the next major version.
 3. Applies the new major version's minor migrations.
 
-`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete.
+### Serializing concurrent migrations
 
-DCP repairs a dirty version instead of failing startup. The migration driver wraps each migration in a transaction, so an interrupted migration either committed in full or never committed at all — the schema is never partially migrated. Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. When DCP finds a dirty version, it evaluates the probe and rewrites the version table to the version that actually matches the schema, then continues migrating normally.
+`golang-migrate` does not serialize migrations across processes when using SQLite. Its `Driver` interface lets an implementation opt out of locking, and the SQLite driver does: `Lock` only flips an in-process flag on the driver instance. DCP builds a fresh migration runner for every `Open`, so that flag serializes nothing at all.
+
+The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read, repair, and migrate sequence. `golang-migrate` reads the current version and then writes the version marker in separate transactions, so instances that are not serialized can both read the same version, both decide to migrate, and both run the same migration — the loser fails to start or leaves a dirty marker behind.
+
+The lock is an advisory file lock held on an open file descriptor, so the operating system releases it when the owning process exits, including a crash. DCP waits for the lock rather than failing when another instance holds it, which also covers Windows releasing the lock asynchronously after a process dies. An interrupted migration therefore leaves a dirty version marker but never a permanently stuck lock, which is what lets the next DCP acquire the lock and repair the marker.
+
+### Recovering a dirty version
+
+`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete. That happens when DCP is interrupted part way through a migration, and also when an older DCP re-runs a migration a newer DCP already applied: the older binary expects a version marker the newer layout no longer records, re-runs the migration, and its SQL fails because the schema change is already present.
+
+DCP repairs a dirty version instead of failing startup. Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. DCP evaluates the probe for the dirty version and rewrites the version table:
+
+- The probe reports true, so the migration committed. DCP records the dirty version as clean and continues with the following migration.
+- The probe reports false, so the migration never committed. DCP records the preceding version as clean, or empties the stream when the dirty version was the first migration, and the migration runs again.
+
+This is sound because the migration driver wraps each migration in its own transaction. An interrupted migration either committed in full or never committed at all, so the schema always matches one of the two cases above and is never partially migrated. DCP repairs the major version stream and each major version's minor stream the same way.
 
 This repair depends on two invariants, both covered by unit tests:
 
 - Every migration has an applied probe, and that probe reports false before the migration runs and true afterwards. Without a probe, DCP cannot tell whether the migration committed and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
 - Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected. SQLite treats `END` as an alias for `COMMIT`; an `END` that closes a `CASE` expression is fine.
 
-A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
+DCP does not repair every dirty marker:
+
+- A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
+- An unknown major version fails startup whether it is dirty or clean. Major versions are reserved for changes that older binaries cannot use safely.
+
+### Accepting a newer clean minor version
 
 An older DCP may find a clean minor version newer than any migration embedded in its binary. DCP accepts that version without invoking `golang-migrate`. Calling the library with an unknown current version would fail because the older binary does not contain that migration file. Accepting the version is safe only when every minor migration follows the compatibility rules below.
-
-DCP fails startup when it encounters an unknown major version, dirty or not. Major versions are reserved for changes that older binaries cannot use safely.
 
 ## Schema version 2 transition
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -17,11 +17,20 @@ For each supported major version, DCP:
 2. Advances `schema_migrations` when moving to the next major version.
 3. Applies the new major version's minor migrations.
 
-`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete. DCP fails startup for a dirty major or minor version rather than guessing which schema changes were applied.
+`golang-migrate` marks a version as dirty before running its SQL and clears the dirty flag after the SQL succeeds. A dirty version therefore means a migration did not complete.
+
+DCP repairs a dirty version instead of failing startup. The migration driver wraps each migration in a transaction, so an interrupted migration either committed in full or never committed at all — the schema is never partially migrated. Every migration registers an *applied probe* in `schema.go`: a SQL predicate that reports whether that migration's schema changes are present. When DCP finds a dirty version, it evaluates the probe and rewrites the version table to the version that actually matches the schema, then continues migrating normally.
+
+This repair depends on two invariants, both covered by unit tests:
+
+- Every migration has an applied probe. Without one, DCP cannot tell whether the migration committed and startup fails with the dirty version.
+- Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected.
+
+A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
 
 An older DCP may find a clean minor version newer than any migration embedded in its binary. DCP accepts that version without invoking `golang-migrate`. Calling the library with an unknown current version would fail because the older binary does not contain that migration file. Accepting the version is safe only when every minor migration follows the compatibility rules below.
 
-DCP fails startup when it encounters an unknown major version. Major versions are reserved for changes that older binaries cannot use safely.
+DCP fails startup when it encounters an unknown major version, dirty or not. Major versions are reserved for changes that older binaries cannot use safely.
 
 ## Schema version 2 transition
 
@@ -33,7 +42,9 @@ Major version 2 remains reserved for this transition. The next breaking schema c
 
 ## Adding a compatible minor migration
 
-Add compatible migrations beneath the major migration they extend. For example, migrations for major version 1 belong in `000001_initial/`. Use normal `golang-migrate` file names such as `000002_description.up.sql`, and update that major version's `latestMinorVersion` in `schema.go`.
+Add compatible migrations beneath the major migration they extend. For example, migrations for major version 1 belong in `000001_initial/`. Use normal `golang-migrate` file names such as `000002_description.up.sql`, update that major version's `latestMinorVersion` in `schema.go`, and add an applied probe for the new version to that major version's `minorProbes`.
+
+The applied probe must return a single boolean column that is true exactly when the migration's schema changes are present, and it must remain valid against both the pre-migration and post-migration schema. Probing `sqlite_master` for a new table or `pragma_table_info` for a new column works well.
 
 Minor migrations must remain safe when an older DCP uses the database afterward:
 
@@ -46,10 +57,10 @@ Minor migrations must remain safe when an older DCP uses the database afterward:
 - Do not add unique indexes, check constraints, foreign keys, changed primary keys, or other constraints that can reject writes accepted by older binaries without an explicit compatibility design.
 - Preserve `resource_locks` so old and new DCP processes coordinate through the same lock records.
 - Preserve persistent resource tables and records so older binaries can continue reading and updating them.
-- Do not include `BEGIN` or `COMMIT`; the SQLite migration driver wraps each migration in a transaction.
+- Do not include `BEGIN`, `COMMIT`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`; the SQLite migration driver wraps each migration in a transaction and these statements would break its atomicity.
 
 ## Adding a breaking major migration
 
 Use a new major version only when the resulting schema cannot remain safe for older DCP binaries.
 
-Add its migration at the migration root, register it in `schemaMajorMigrations`, and give it a dedicated minor migration table. Compatible follow-up migrations belong in a directory named after the major migration. Once the major marker advances, older DCP binaries will reject the database.
+Add its migration at the migration root, register it in `schemaMajorMigrations`, add an applied probe for the new version to `schemaMajorProbes`, and give it a dedicated minor migration table. Compatible follow-up migrations belong in a directory named after the major migration. Once the major marker advances, older DCP binaries will reject the database.

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -21,7 +21,7 @@ For each supported major version, DCP:
 
 `golang-migrate` does not serialize migrations across processes when using SQLite. Its `Driver` interface lets an implementation opt out of locking, and the SQLite driver does: `Lock` only flips an in-process flag on the driver instance. DCP builds a fresh migration runner for every `Open`, so that flag serializes nothing at all.
 
-The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read, repair, and migrate sequence.
+The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read, recover, and migrate sequence.
 
 The lock is an advisory file lock held on an open file descriptor, so the operating system releases it when the owning process exits, including a crash. DCP waits for the lock rather than failing when another instance holds it. An interrupted migration therefore leaves a dirty version marker but never a permanently stuck lock, which is what lets the next DCP acquire the lock and clear the marker.
 
@@ -34,9 +34,9 @@ Every migration registers an *applied probe* in `schema.go`: a SQL predicate tha
 - If the probe reports true, the migration committed. DCP clears the dirty flag and continues with the following migration.
 - If the probe reports false, the migration never committed. DCP marks the preceding version as clean (or assumes no migrations happened if the dirty version was the first migration), clears the dirty flag for the failed migration, and re-applies it.
 
-DCP does not repair every dirty marker.
+DCP does not clear every dirty marker.
 
-A dirty minor version newer than any migration embedded in current binary cannot be probed--it was attempted by a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed. DCP logs the condition, leaves the dirty marker alone, and lets the binary that owns the migration repair it.
+A dirty minor version newer than any migration embedded in current binary cannot be probed--it was attempted by a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed. DCP logs the condition, leaves the dirty marker alone, and lets the binary that owns the migration clear it.
 
 An unknown major version fails startup whether it is dirty or clean. Major versions are reserved for changes that older binaries cannot use safely.
 
@@ -54,7 +54,7 @@ The use of single transaction for each migration is also what makes the probe re
 - **Migration SQL never commits implicitly.** The SQLite migration driver wraps each migration in a single transaction, so `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` are rejected. `TestMigrationsAreTransactional` checks every embedded migration file. SQLite treats `END` as an alias for `COMMIT`, so only an `END` that closes a `CASE` expression is allowed. A migration that ended its transaction part way through would leave a schema that is neither version, and no probe could describe it.
 - **Every migration has an applied probe that discriminates.** The probe must reliably report `false` before the migration is applied and `true` afterwards.
 
-Because the schema always matches one of the two versions exactly, DCP can determine the real migration state and record it. Repair only rewrites the version marker; it never edits schema or data. When the probe reports false the schema is exactly at *v-1*, so re-running the migration is an ordinary first application rather than a retry against a half-changed schema. DCP detects existing schema version for major and minor migrations in the same way, and clears the `golang-migrate` dirty flag for both.
+Because the schema always matches one of the two versions exactly, DCP can determine the real migration state and record it. Recovery only rewrites the version marker; it never edits schema or data. When the probe reports false the schema is exactly at *v-1*, so re-running the migration is an ordinary first application rather than a retry against a half-changed schema. DCP detects existing schema version for major and minor migrations in the same way, and clears the `golang-migrate` dirty flag for both.
 
 ### Accepting a newer clean minor version
 
@@ -66,9 +66,9 @@ The original migration layout used one sequence for every schema change: version
 
 The new layout classifies that change as major version 1, minor version 1. When DCP finds a clean database created by the old version 2 migration, it records minor version 1 in `schema_minor_migrations_v1` and changes the major marker from 2 back to 1. This only reclassifies an already-applied migration; it does not undo schema changes or delete data.
 
-Binaries built before this reclassification advance a single migration stream unconditionally and carry no applied probes. When one of them opens a store a current DCP has normalized, it tries to advance that stream to version 2 again, and its `ALTER TABLE` fails because `workload_id` is already present, leaving a dirty marker behind. Probe-based repair clears that marker the next time a current DCP opens the store; `TestOpenRepairsSchemaDirtiedByOlderDcp` covers it.
+Binaries built before this reclassification advance a single migration stream unconditionally and carry no applied probes. When one of them opens a store a current DCP has normalized, it tries to advance that stream to version 2 again, and its `ALTER TABLE` fails because `workload_id` is already present, leaving a dirty marker behind. Probe-based recovery clears that marker the next time a current DCP opens the store; `TestOpenRecoversSchemaDirtiedByOlderDcp` covers it.
 
-Those binaries reached only Aspire's main and daily channels during a short window and were never part of a stable release. This is therefore the most common source of dirty markers at the time of writing but not a lasting one: it affects machines that ran one of those builds, and work that has not yet picked up the current layout, and it stops happening once those binaries fall out of use. Repair itself is not tied to this transition and remains in place for interrupted migrations generally.
+Those binaries reached only Aspire's main and daily channels during a short window and were never part of a stable release. This is therefore the most common source of dirty markers at the time of writing but not a lasting one: it affects machines that ran one of those builds, and work that has not yet picked up the current layout, and it stops happening once those binaries fall out of use. Recovery itself is not tied to this transition and remains in place for interrupted migrations generally.
 
 Major version 2 remains reserved for this transition. The next breaking schema change must use major version 3.
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -24,7 +24,7 @@ DCP repairs a dirty version instead of failing startup. The migration driver wra
 This repair depends on two invariants, both covered by unit tests:
 
 - Every migration has an applied probe, and that probe reports false before the migration runs and true afterwards. Without a probe, DCP cannot tell whether the migration committed and startup fails with the dirty version. A probe that does not distinguish the two states is worse: DCP would keep a version marker for a migration that never ran, permanently skipping it.
-- Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected.
+- Migration SQL never commits implicitly. `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, and `DETACH` would break migration atomicity and are rejected. SQLite treats `END` as an alias for `COMMIT`; an `END` that closes a `CASE` expression is fine.
 
 A dirty minor version newer than any migration embedded in this binary cannot be probed, because the migration belongs to a newer DCP. Minor migrations are additive, so every migration this binary needs is present regardless of whether the interrupted one committed; DCP logs the condition, leaves the marker alone, and lets the binary that owns the migration repair it.
 
@@ -57,7 +57,7 @@ Minor migrations must remain safe when an older DCP uses the database afterward:
 - Do not add unique indexes, check constraints, foreign keys, changed primary keys, or other constraints that can reject writes accepted by older binaries without an explicit compatibility design.
 - Preserve `resource_locks` so old and new DCP processes coordinate through the same lock records.
 - Preserve persistent resource tables and records so older binaries can continue reading and updating them.
-- Do not include `BEGIN`, `COMMIT`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`; the SQLite migration driver wraps each migration in a transaction and these statements would break its atomicity.
+- Do not include `BEGIN`, `COMMIT`, `END`, `ROLLBACK`, `VACUUM`, `PRAGMA`, `ATTACH`, or `DETACH`; the SQLite migration driver wraps each migration in a transaction and these statements would break its atomicity. SQLite treats `END` as an alias for `COMMIT`, so only an `END` that closes a `CASE` expression is allowed.
 
 ## Adding a breaking major migration
 

--- a/internal/statestore/migrations/README.md
+++ b/internal/statestore/migrations/README.md
@@ -21,7 +21,7 @@ For each supported major version, DCP:
 
 `golang-migrate` does not serialize migrations across processes when using SQLite. Its `Driver` interface lets an implementation opt out of locking, and the SQLite driver does: `Lock` only flips an in-process flag on the driver instance. DCP builds a fresh migration runner for every `Open`, so that flag serializes nothing at all.
 
-The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read schema version, repair, and migrate sequence. `golang-migrate` reads the current version and then writes the version marker in separate transactions, so instances that are not serialized can both read the same version, both decide to migrate, and both run the same migration — the loser fails to start or leaves a dirty marker behind.
+The lock DCP takes in `migrate` is therefore the only thing that keeps two DCP instances from migrating the same store at once, and it must stay wrapped around the whole read, repair, and migrate sequence.
 
 The lock is an advisory file lock held on an open file descriptor, so the operating system releases it when the owning process exits, including a crash. DCP waits for the lock rather than failing when another instance holds it. An interrupted migration therefore leaves a dirty version marker but never a permanently stuck lock, which is what lets the next DCP acquire the lock and clear the marker.
 

--- a/internal/statestore/schema.go
+++ b/internal/statestore/schema.go
@@ -194,6 +194,10 @@ func (s *Store) setSchemaVersion(ctx context.Context, tableName string, version 
 // migration actually committed, and returns the repaired version (noSchemaVersion when the stream is
 // left empty). It fails when no probe is registered for the dirty version, because the applied state
 // of an unknown migration cannot be determined.
+//
+// The caller must only pass a version that the migration driver marked dirty. Migrations are applied
+// in ascending order and a version is only marked dirty once the preceding one is recorded clean, so
+// version-1 is known to be applied and is a valid repair target when the probe reports false.
 func (s *Store) repairDirtySchemaVersion(
 	ctx context.Context,
 	tableName string,

--- a/internal/statestore/schema.go
+++ b/internal/statestore/schema.go
@@ -42,9 +42,10 @@ const (
 )
 
 // schemaMigrationProbe reports whether a single migration's schema changes are present in the database.
-// golang-migrate applies each migration inside its own transaction, so a dirty version marker means
-// the migration either committed in full or never committed at all. The probe tells the two apart so
-// a dirty marker can be repaired instead of failing startup.
+// golang-migrate applies each migration inside its own transaction, so a dirty version marker does not
+// necessarily mean the migration failed: it either committed in full or never committed at all. The
+// probe tells the two apart so the marker can be cleared, as long as a probe is registered for that
+// schema version.
 type schemaMigrationProbe struct {
 	version int
 	// appliedQuery must return a single boolean column that is true when the migration has been applied.
@@ -190,15 +191,15 @@ func (s *Store) setSchemaVersion(ctx context.Context, tableName string, version 
 	})
 }
 
-// repairDirtySchemaVersion clears a dirty migration marker by determining whether the interrupted
-// migration actually committed, and returns the repaired version (noSchemaVersion when the stream is
+// recoverDirtySchemaVersion clears a dirty migration marker by determining whether the interrupted
+// migration actually committed, and returns the recovered version (noSchemaVersion when the stream is
 // left empty). It fails when no probe is registered for the dirty version, because the applied state
 // of an unknown migration cannot be determined.
 //
 // The caller must only pass a version that the migration driver marked dirty. Migrations are applied
 // in ascending order and a version is only marked dirty once the preceding one is recorded clean, so
-// version-1 is known to be applied and is a valid repair target when the probe reports false.
-func (s *Store) repairDirtySchemaVersion(
+// version-1 is known to be applied and is a valid recovery target when the probe reports false.
+func (s *Store) recoverDirtySchemaVersion(
 	ctx context.Context,
 	tableName string,
 	version int,
@@ -215,27 +216,27 @@ func (s *Store) repairDirtySchemaVersion(
 		return 0, fmt.Errorf("could not determine whether dirty schema version %d was applied: %w", version, scanErr)
 	}
 
-	repairedVersion := version
+	recoveredVersion := version
 	if !applied {
-		repairedVersion = version - 1
-		if repairedVersion < 1 {
-			repairedVersion = noSchemaVersion
+		recoveredVersion = version - 1
+		if recoveredVersion < 1 {
+			recoveredVersion = noSchemaVersion
 		}
 	}
 
-	if setErr := s.setSchemaVersion(ctx, tableName, repairedVersion); setErr != nil {
-		return 0, fmt.Errorf("could not repair dirty schema version %d: %w", version, setErr)
+	if setErr := s.setSchemaVersion(ctx, tableName, recoveredVersion); setErr != nil {
+		return 0, fmt.Errorf("could not recover dirty schema version %d: %w", version, setErr)
 	}
 	s.log.Info(
-		"Repaired an interrupted state store migration",
+		"Recovered an interrupted state store migration",
 		"Table", tableName,
 		"DirtyVersion", version,
-		"RepairedVersion", repairedVersion,
+		"RecoveredVersion", recoveredVersion,
 	)
-	return repairedVersion, nil
+	return recoveredVersion, nil
 }
 
-// validateStoredSchemaMajorVersion repairs a dirty major version and rejects versions with no supported migration path.
+// validateStoredSchemaMajorVersion recovers a dirty major version and rejects versions with no supported migration path.
 func (s *Store) validateStoredSchemaMajorVersion(ctx context.Context) error {
 	version, found, dirty, readErr := readSchemaMajorVersion(ctx, s.db)
 	if readErr != nil {
@@ -245,14 +246,14 @@ func (s *Store) validateStoredSchemaMajorVersion(ctx context.Context) error {
 		return nil
 	}
 	if dirty {
-		repairedVersion, repairErr := s.repairDirtySchemaVersion(ctx, schemaMajorMigrationTableName, version, schemaMajorProbes)
-		if repairErr != nil {
-			return fmt.Errorf("schema major version %d is dirty: %w", version, repairErr)
+		recoveredVersion, recoverErr := s.recoverDirtySchemaVersion(ctx, schemaMajorMigrationTableName, version, schemaMajorProbes)
+		if recoverErr != nil {
+			return fmt.Errorf("schema major version %d is dirty: %w", version, recoverErr)
 		}
-		if repairedVersion == noSchemaVersion {
+		if recoveredVersion == noSchemaVersion {
 			return nil
 		}
-		version = repairedVersion
+		version = recoveredVersion
 	}
 	if version != legacySchemaVersion2 && !isSupportedSchemaMajorVersion(version) {
 		return fmt.Errorf("unsupported schema major version %d", version)
@@ -372,7 +373,7 @@ func (s *Store) runSchemaMajorMigration(ctx context.Context, busyTimeout time.Du
 	return errors.Join(sourceCloseErr, databaseCloseErr)
 }
 
-// runSchemaMinorMigrations repairs an interrupted migration and accepts a clean newer version
+// runSchemaMinorMigrations recovers an interrupted migration and accepts a clean newer version
 // without asking golang-migrate to resolve unknown files.
 func (s *Store) runSchemaMinorMigrations(
 	ctx context.Context,
@@ -384,19 +385,19 @@ func (s *Store) runSchemaMinorMigrations(
 		return fmt.Errorf("could not read schema major %d minor version: %w", migration.version, versionErr)
 	}
 	if dirty {
-		repairedVersion, repairErr := s.repairDirtySchemaVersion(
+		recoveredVersion, recoverErr := s.recoverDirtySchemaVersion(
 			ctx,
 			migration.minorTableName,
 			databaseVersion,
 			migration.minorProbes,
 		)
-		if repairErr != nil {
+		if recoverErr != nil {
 			// A dirty version this binary does not know about belongs to a newer DCP. Minor migrations
 			// are additive, so every migration this binary needs is already present regardless of
 			// whether the interrupted one committed. Leave the marker for the binary that owns it.
 			if databaseVersion > migration.latestMinorVersion {
 				s.log.Info(
-					"State store has an interrupted migration from a newer DCP version. A newer DCP will repair it.",
+					"State store has an interrupted migration from a newer DCP version. A newer DCP will recover it.",
 					"Table", migration.minorTableName,
 					"DirtyVersion", databaseVersion,
 					"SupportedVersion", migration.latestMinorVersion,
@@ -407,11 +408,11 @@ func (s *Store) runSchemaMinorMigrations(
 				"schema major %d minor version %d is dirty: %w",
 				migration.version,
 				databaseVersion,
-				repairErr,
+				recoverErr,
 			)
 		}
-		databaseVersion = repairedVersion
-		found = repairedVersion != noSchemaVersion
+		databaseVersion = recoveredVersion
+		found = recoveredVersion != noSchemaVersion
 	}
 	// A newer compatible migration implies that every older migration in this stream was applied.
 	if found && databaseVersion > migration.latestMinorVersion {

--- a/internal/statestore/schema.go
+++ b/internal/statestore/schema.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 
 	"github.com/microsoft/dcp/internal/lockfile"
+	"github.com/microsoft/dcp/pkg/slices"
 )
 
 const (
@@ -30,13 +31,32 @@ const (
 
 	schemaMajorMigrationTableName = "schema_migrations"
 	migrationLockFileSuffix       = ".migrate.lock"
+
+	// noSchemaVersion clears a golang-migrate version table, which is how the library
+	// represents a stream where no migration has been applied.
+	noSchemaVersion = -1
+
+	// Applied probes for individual migrations. Each query must return a single boolean column.
+	initialMigrationAppliedProbe     = `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'persistent_processes')`
+	workloadIDsMigrationAppliedProbe = `SELECT EXISTS(SELECT 1 FROM pragma_table_info('persistent_processes') WHERE name = 'workload_id')`
 )
+
+// schemaMigrationProbe reports whether a single migration's schema changes are present in the database.
+// golang-migrate applies each migration inside its own transaction, so a dirty version marker means
+// the migration either committed in full or never committed at all. The probe tells the two apart so
+// a dirty marker can be repaired instead of failing startup.
+type schemaMigrationProbe struct {
+	version int
+	// appliedQuery must return a single boolean column that is true when the migration has been applied.
+	appliedQuery string
+}
 
 type schemaMajorMigration struct {
 	version            int
 	path               string
 	minorTableName     string
 	latestMinorVersion int
+	minorProbes        []schemaMigrationProbe
 }
 
 func (m schemaMajorMigration) minorPath() string {
@@ -49,8 +69,18 @@ var (
 		path:               "migrations/000001_initial.up.sql",
 		minorTableName:     "schema_minor_migrations_v1",
 		latestMinorVersion: currentSchemaMinorVersion,
+		minorProbes: []schemaMigrationProbe{
+			{version: 1, appliedQuery: workloadIDsMigrationAppliedProbe},
+		},
 	}
 	schemaMajorMigrations = []schemaMajorMigration{schemaMajorVersion1Migration}
+
+	// schemaMajorProbes covers every version that can appear in schema_migrations, including the
+	// legacy version 2 marker written by the original single-stream migration layout.
+	schemaMajorProbes = []schemaMigrationProbe{
+		{version: currentSchemaMajorVersion, appliedQuery: initialMigrationAppliedProbe},
+		{version: legacySchemaVersion2, appliedQuery: workloadIDsMigrationAppliedProbe},
+	}
 )
 
 // migrationFiles embeds the SQL migration files into the DCP binary so runtime
@@ -103,18 +133,18 @@ type schemaVersionQueryer interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
-// readSchemaMajorVersion reads the current major migration version from schema_migrations.
-func readSchemaMajorVersion(ctx context.Context, queryer schemaVersionQueryer) (int, bool, bool, error) {
+// readSchemaVersion reads the current migration version recorded in a golang-migrate version table.
+func readSchemaVersion(ctx context.Context, queryer schemaVersionQueryer, tableName string) (int, bool, bool, error) {
 	tableRow := queryer.QueryRowContext(
 		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?
 		)`,
-		schemaMajorMigrationTableName,
+		tableName,
 	)
 	var tableExists bool
 	if scanErr := tableRow.Scan(&tableExists); scanErr != nil {
-		return 0, false, false, fmt.Errorf("could not inspect schema major migration table: %w", scanErr)
+		return 0, false, false, fmt.Errorf("could not inspect schema migration table '%s': %w", tableName, scanErr)
 	}
 	if !tableExists {
 		return 0, false, false, nil
@@ -122,7 +152,7 @@ func readSchemaMajorVersion(ctx context.Context, queryer schemaVersionQueryer) (
 
 	versionQuery := fmt.Sprintf(
 		`SELECT version, dirty FROM %s LIMIT 1`,
-		quoteSQLiteIdentifier(schemaMajorMigrationTableName),
+		quoteSQLiteIdentifier(tableName),
 	)
 	versionRow := queryer.QueryRowContext(ctx, versionQuery)
 	var version int
@@ -131,12 +161,77 @@ func readSchemaMajorVersion(ctx context.Context, queryer schemaVersionQueryer) (
 		if errors.Is(scanErr, sql.ErrNoRows) {
 			return 0, false, false, nil
 		}
-		return 0, false, false, fmt.Errorf("could not read schema major version: %w", scanErr)
+		return 0, false, false, fmt.Errorf("could not read schema version from table '%s': %w", tableName, scanErr)
 	}
 	return version, true, dirty, nil
 }
 
-// validateStoredSchemaMajorVersion rejects dirty major versions and versions with no supported migration path.
+// readSchemaMajorVersion reads the current major migration version from schema_migrations.
+func readSchemaMajorVersion(ctx context.Context, queryer schemaVersionQueryer) (int, bool, bool, error) {
+	return readSchemaVersion(ctx, queryer, schemaMajorMigrationTableName)
+}
+
+// setSchemaVersion rewrites a golang-migrate version table so it records a single clean version.
+// Passing noSchemaVersion clears the table, marking the stream as having no applied migration.
+func (s *Store) setSchemaVersion(ctx context.Context, tableName string, version int) error {
+	quotedTable := quoteSQLiteIdentifier(tableName)
+	return s.withImmediateTx(ctx, func(conn *sql.Conn) error {
+		if _, deleteErr := conn.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, quotedTable)); deleteErr != nil {
+			return fmt.Errorf("could not clear schema version table '%s': %w", tableName, deleteErr)
+		}
+		if version < 0 {
+			return nil
+		}
+		insertQuery := fmt.Sprintf(`INSERT INTO %s (version, dirty) VALUES (?, 0)`, quotedTable)
+		if _, insertErr := conn.ExecContext(ctx, insertQuery, version); insertErr != nil {
+			return fmt.Errorf("could not record schema version %d in table '%s': %w", version, tableName, insertErr)
+		}
+		return nil
+	})
+}
+
+// repairDirtySchemaVersion clears a dirty migration marker by determining whether the interrupted
+// migration actually committed, and returns the repaired version (noSchemaVersion when the stream is
+// left empty). It fails when no probe is registered for the dirty version, because the applied state
+// of an unknown migration cannot be determined.
+func (s *Store) repairDirtySchemaVersion(
+	ctx context.Context,
+	tableName string,
+	version int,
+	probes []schemaMigrationProbe,
+) (int, error) {
+	probeIndex := slices.IndexFunc(probes, func(probe schemaMigrationProbe) bool { return probe.version == version })
+	if probeIndex < 0 {
+		return 0, fmt.Errorf("no applied probe is registered for dirty schema version %d", version)
+	}
+
+	var applied bool
+	probeRow := s.db.QueryRowContext(ctx, probes[probeIndex].appliedQuery)
+	if scanErr := probeRow.Scan(&applied); scanErr != nil {
+		return 0, fmt.Errorf("could not determine whether dirty schema version %d was applied: %w", version, scanErr)
+	}
+
+	repairedVersion := version
+	if !applied {
+		repairedVersion = version - 1
+		if repairedVersion < 1 {
+			repairedVersion = noSchemaVersion
+		}
+	}
+
+	if setErr := s.setSchemaVersion(ctx, tableName, repairedVersion); setErr != nil {
+		return 0, fmt.Errorf("could not repair dirty schema version %d: %w", version, setErr)
+	}
+	s.log.Info(
+		"Repaired an interrupted state store migration",
+		"Table", tableName,
+		"DirtyVersion", version,
+		"RepairedVersion", repairedVersion,
+	)
+	return repairedVersion, nil
+}
+
+// validateStoredSchemaMajorVersion repairs a dirty major version and rejects versions with no supported migration path.
 func (s *Store) validateStoredSchemaMajorVersion(ctx context.Context) error {
 	version, found, dirty, readErr := readSchemaMajorVersion(ctx, s.db)
 	if readErr != nil {
@@ -146,7 +241,14 @@ func (s *Store) validateStoredSchemaMajorVersion(ctx context.Context) error {
 		return nil
 	}
 	if dirty {
-		return fmt.Errorf("schema major version %d is dirty", version)
+		repairedVersion, repairErr := s.repairDirtySchemaVersion(ctx, schemaMajorMigrationTableName, version, schemaMajorProbes)
+		if repairErr != nil {
+			return fmt.Errorf("schema major version %d is dirty: %w", version, repairErr)
+		}
+		if repairedVersion == noSchemaVersion {
+			return nil
+		}
+		version = repairedVersion
 	}
 	if version != legacySchemaVersion2 && !isSupportedSchemaMajorVersion(version) {
 		return fmt.Errorf("unsupported schema major version %d", version)
@@ -266,12 +368,52 @@ func (s *Store) runSchemaMajorMigration(ctx context.Context, busyTimeout time.Du
 	return errors.Join(sourceCloseErr, databaseCloseErr)
 }
 
-// runSchemaMinorMigrations accepts a clean newer version without asking golang-migrate to resolve unknown files.
+// runSchemaMinorMigrations repairs an interrupted migration and accepts a clean newer version
+// without asking golang-migrate to resolve unknown files.
 func (s *Store) runSchemaMinorMigrations(
 	ctx context.Context,
 	busyTimeout time.Duration,
 	migration schemaMajorMigration,
 ) error {
+	databaseVersion, found, dirty, versionErr := readSchemaVersion(ctx, s.db, migration.minorTableName)
+	if versionErr != nil {
+		return fmt.Errorf("could not read schema major %d minor version: %w", migration.version, versionErr)
+	}
+	if dirty {
+		repairedVersion, repairErr := s.repairDirtySchemaVersion(
+			ctx,
+			migration.minorTableName,
+			databaseVersion,
+			migration.minorProbes,
+		)
+		if repairErr != nil {
+			// A dirty version this binary does not know about belongs to a newer DCP. Minor migrations
+			// are additive, so every migration this binary needs is already present regardless of
+			// whether the interrupted one committed. Leave the marker for the binary that owns it.
+			if databaseVersion > migration.latestMinorVersion {
+				s.log.Info(
+					"State store has an interrupted migration from a newer DCP version. A newer DCP will repair it.",
+					"Table", migration.minorTableName,
+					"DirtyVersion", databaseVersion,
+					"SupportedVersion", migration.latestMinorVersion,
+				)
+				return nil
+			}
+			return fmt.Errorf(
+				"schema major %d minor version %d is dirty: %w",
+				migration.version,
+				databaseVersion,
+				repairErr,
+			)
+		}
+		databaseVersion = repairedVersion
+		found = repairedVersion != noSchemaVersion
+	}
+	// A newer compatible migration implies that every older migration in this stream was applied.
+	if found && databaseVersion > migration.latestMinorVersion {
+		return nil
+	}
+
 	migrationRunner, runnerErr := s.newMigrationRunner(
 		ctx,
 		busyTimeout,
@@ -282,28 +424,6 @@ func (s *Store) runSchemaMinorMigrations(
 		return runnerErr
 	}
 
-	databaseVersion, dirty, versionErr := migrationRunner.Version()
-	if versionErr != nil && !errors.Is(versionErr, gomigrate.ErrNilVersion) {
-		sourceCloseErr, databaseCloseErr := migrationRunner.Close()
-		return errors.Join(
-			fmt.Errorf("could not read schema major %d minor version: %w", migration.version, versionErr),
-			sourceCloseErr,
-			databaseCloseErr,
-		)
-	}
-	if dirty {
-		sourceCloseErr, databaseCloseErr := migrationRunner.Close()
-		return errors.Join(
-			fmt.Errorf("schema major %d minor version %d is dirty", migration.version, databaseVersion),
-			sourceCloseErr,
-			databaseCloseErr,
-		)
-	}
-	// A newer compatible migration implies that every older migration in this stream was applied.
-	if versionErr == nil && int(databaseVersion) > migration.latestMinorVersion {
-		sourceCloseErr, databaseCloseErr := migrationRunner.Close()
-		return errors.Join(sourceCloseErr, databaseCloseErr)
-	}
 	migrationErr := migrationRunner.Migrate(uint(migration.latestMinorVersion))
 	sourceCloseErr, databaseCloseErr := migrationRunner.Close()
 	if migrationErr != nil && !errors.Is(migrationErr, gomigrate.ErrNoChange) {

--- a/internal/statestore/store.go
+++ b/internal/statestore/store.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	_ "modernc.org/sqlite"
 
 	"github.com/microsoft/dcp/internal/dcppaths"
@@ -52,11 +53,15 @@ type Options struct {
 
 	// BusyTimeout is the SQLite busy timeout used when another process holds a database lock.
 	BusyTimeout time.Duration
+
+	// Log receives messages about schema maintenance, such as repairs of interrupted migrations.
+	Log logr.Logger
 }
 
 type Store struct {
 	db   *sql.DB
 	path string
+	log  logr.Logger
 }
 
 func DefaultPath() (string, error) {
@@ -113,6 +118,11 @@ func Open(ctx context.Context, options Options) (*Store, error) {
 		busyTimeout = DefaultBusyTimeout
 	}
 
+	log := options.Log
+	if log.GetSink() == nil {
+		log = logr.Discard()
+	}
+
 	db, openErr := openSQLiteDB(ctx, absPath, busyTimeout)
 	if openErr != nil {
 		return nil, fmt.Errorf("could not initialize state store database '%s': %w", absPath, openErr)
@@ -121,6 +131,7 @@ func Open(ctx context.Context, options Options) (*Store, error) {
 	store := &Store{
 		db:   db,
 		path: absPath,
+		log:  log,
 	}
 
 	if configureErr := store.configure(ctx, busyTimeout); configureErr != nil {

--- a/internal/statestore/store.go
+++ b/internal/statestore/store.go
@@ -54,7 +54,7 @@ type Options struct {
 	// BusyTimeout is the SQLite busy timeout used when another process holds a database lock.
 	BusyTimeout time.Duration
 
-	// Log receives messages about schema maintenance, such as repairs of interrupted migrations.
+	// Log receives messages about schema maintenance, such as recovery of interrupted migrations.
 	Log logr.Logger
 }
 

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -1586,15 +1586,101 @@ func TestAppliedProbesDetectTheirOwnMigration(t *testing.T) {
 	}
 }
 
+// sqlCommentPattern matches SQL line and block comments. They are removed before looking for
+// transaction statements so that prose does not trip the check.
+var sqlCommentPattern = regexp.MustCompile(`(?s)--[^\n]*|/\*.*?\*/`)
+
+// sqlWordPattern matches a whole SQL identifier or keyword, so an identifier that merely contains a
+// keyword (a "commit_sha" column, for example) is not mistaken for the keyword.
+var sqlWordPattern = regexp.MustCompile(`[A-Za-z0-9_]+`)
+
+var transactionBreakingStatements = []string{
+	"BEGIN", "COMMIT", "END", "ROLLBACK", "VACUUM", "PRAGMA", "ATTACH", "DETACH",
+}
+
+// findTransactionBreakingStatement returns the first statement in migrationSQL that would end the
+// transaction the migration driver wraps around each migration, or an empty string when there is
+// none. SQLite treats END as an alias for COMMIT, but END also closes a CASE expression, so an END
+// is only reported when no CASE is open.
+func findTransactionBreakingStatement(migrationSQL string) string {
+	withoutComments := sqlCommentPattern.ReplaceAllString(migrationSQL, " ")
+
+	caseDepth := 0
+	for _, word := range sqlWordPattern.FindAllString(withoutComments, -1) {
+		upperWord := strings.ToUpper(word)
+		switch upperWord {
+		case "CASE":
+			caseDepth++
+		case "END":
+			if caseDepth > 0 {
+				caseDepth--
+				continue
+			}
+			return upperWord
+		default:
+			if slices.Contains(transactionBreakingStatements, upperWord) {
+				return upperWord
+			}
+		}
+	}
+	return ""
+}
+
+// TestFindTransactionBreakingStatement covers the guard that TestMigrationsAreTransactional relies
+// on, including the SQL that legitimately uses the keywords it looks for.
+func TestFindTransactionBreakingStatement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		sql      string
+		expected string
+	}{
+		{name: "plain DDL", sql: "CREATE TABLE t (a TEXT NOT NULL);", expected: ""},
+		{name: "commit", sql: "UPDATE t SET a = 1;\nCOMMIT;", expected: "COMMIT"},
+		{name: "begin", sql: "BEGIN;\nUPDATE t SET a = 1;", expected: "BEGIN"},
+		{name: "end as commit alias", sql: "UPDATE t SET a = 1;\nEND;", expected: "END"},
+		{name: "end transaction", sql: "END TRANSACTION;", expected: "END"},
+		{name: "pragma", sql: "PRAGMA foreign_keys = ON;", expected: "PRAGMA"},
+		{
+			name:     "case expression is allowed",
+			sql:      "UPDATE t SET a = CASE WHEN b IS NULL THEN 0 ELSE b END;",
+			expected: "",
+		},
+		{
+			name:     "nested case expressions are allowed",
+			sql:      "UPDATE t SET a = CASE WHEN b THEN CASE WHEN c THEN 1 ELSE 2 END ELSE 3 END;",
+			expected: "",
+		},
+		{
+			name:     "end after a closed case still reports",
+			sql:      "UPDATE t SET a = CASE WHEN b THEN 1 ELSE 2 END;\nEND;",
+			expected: "END",
+		},
+		{
+			name:     "keywords inside identifiers are allowed",
+			sql:      "CREATE TABLE t (commit_sha TEXT, begin_time INTEGER, appended TEXT, end2 TEXT);",
+			expected: "",
+		},
+		{name: "keywords inside a line comment are allowed", sql: "-- no COMMIT needed at the end\nSELECT 1;", expected: ""},
+		{name: "keywords inside a block comment are allowed", sql: "/* do not\nVACUUM here */\nSELECT 1;", expected: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, testCase.expected, findTransactionBreakingStatement(testCase.sql))
+		})
+	}
+}
+
 // TestMigrationsAreTransactional guards the invariant that lets an interrupted migration be repaired:
 // the migration driver wraps every migration in a transaction, so a migration either commits in full
 // or not at all. Statements that commit implicitly would break that invariant.
 func TestMigrationsAreTransactional(t *testing.T) {
 	t.Parallel()
 
-	// Match whole words only so identifiers that merely contain a keyword (a "commit_sha" column,
-	// for example) are not reported as forbidden statements.
-	forbiddenStatements := regexp.MustCompile(`(?i)\b(BEGIN|COMMIT|ROLLBACK|VACUUM|PRAGMA|ATTACH|DETACH)\b`)
 	walkErr := fs.WalkDir(migrationFiles, "migrations", func(path string, entry fs.DirEntry, entryErr error) error {
 		if entryErr != nil {
 			return entryErr
@@ -1604,13 +1690,13 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		}
 		contents, readErr := fs.ReadFile(migrationFiles, path)
 		require.NoError(t, readErr)
-		match := forbiddenStatements.FindString(string(contents))
+		statement := findTransactionBreakingStatement(string(contents))
 		require.Empty(
 			t,
-			match,
+			statement,
 			"migration '%s' must not use %s; it breaks migration atomicity",
 			path,
-			match,
+			statement,
 		)
 		return nil
 	})

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -13,14 +13,15 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
 
+	"github.com/go-logr/logr"
 	gomigrate "github.com/golang-migrate/migrate/v4"
 	migratesqlite "github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
@@ -31,6 +32,7 @@ import (
 	"github.com/microsoft/dcp/pkg/osutil"
 	"github.com/microsoft/dcp/pkg/process"
 	"github.com/microsoft/dcp/pkg/resiliency"
+	"github.com/microsoft/dcp/pkg/slices"
 	"github.com/microsoft/dcp/pkg/testutil"
 )
 
@@ -669,6 +671,46 @@ func TestOpenRepairsDirtySchemaVersion2WhenMigrationNotApplied(t *testing.T) {
 	requireSchemaMajorVersion(t, ctx, store, currentSchemaMajorVersion)
 	requireSchemaMinorVersion(t, ctx, store, currentSchemaMinorVersion)
 	requireWorkloadIDColumn(t, ctx, store.db, true)
+}
+
+// TestOpenRepairsSchemaDirtiedByOlderDcp covers how a dirty marker is produced in practice: a store
+// this binary normalized to major version 1 is opened by an older DCP, whose single-stream migration
+// layout re-applies the workload ID migration. That migration fails because the column already
+// exists, leaving the dirty version 2 marker behind for this binary to repair.
+func TestOpenRepairsSchemaDirtiedByOlderDcp(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store := openTestStore(t, ctx, storePath)
+	requireSchemaMajorVersion(t, ctx, store, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, store, currentSchemaMinorVersion)
+	require.NoError(t, store.Close())
+
+	// An older DCP sees major version 1 and tries to advance its own stream to version 2.
+	legacyErr := runLegacyMigrationRunner(ctx, storePath, legacyMigrationFixture(t, true))
+	require.ErrorContains(t, legacyErr, "duplicate column name: workload_id")
+
+	dirtyDB := openRawSQLiteDB(t, ctx, storePath)
+	row := dirtyDB.QueryRowContext(ctx, `SELECT version, dirty FROM schema_migrations LIMIT 1`)
+	var version int
+	var dirty bool
+	require.NoError(t, row.Scan(&version, &dirty))
+	require.Equal(t, legacySchemaVersion2, version)
+	require.True(t, dirty)
+	require.NoError(t, dirtyDB.Close())
+	require.NoError(
+		t,
+		usvc_io.EnsureRestrictedDirectory(filepath.Dir(storePath), osutil.PermissionOnlyOwnerReadWriteTraverse),
+	)
+
+	repaired := openTestStore(t, ctx, storePath)
+
+	requireSchemaMajorVersion(t, ctx, repaired, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, repaired, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, repaired.db, true)
 }
 
 func TestOpenWithExplicitPathRejectsPermissiveExistingParentDirectory(t *testing.T) {
@@ -1382,14 +1424,14 @@ func TestEveryMigrationHasAnAppliedProbe(t *testing.T) {
 	for _, version := range majorVersions {
 		require.True(
 			t,
-			slices.ContainsFunc(schemaMajorProbes, func(probe schemaMigrationProbe) bool { return probe.version == version }),
+			slices.Any(schemaMajorProbes, func(probe schemaMigrationProbe) bool { return probe.version == version }),
 			"schemaMajorProbes has no probe for major version %d",
 			version,
 		)
 	}
 	require.True(
 		t,
-		slices.ContainsFunc(schemaMajorProbes, func(probe schemaMigrationProbe) bool {
+		slices.Any(schemaMajorProbes, func(probe schemaMigrationProbe) bool {
 			return probe.version == legacySchemaVersion2
 		}),
 		"schemaMajorProbes has no probe for the legacy schema version 2 marker",
@@ -1409,7 +1451,7 @@ func TestEveryMigrationHasAnAppliedProbe(t *testing.T) {
 		for _, version := range minorVersions {
 			require.True(
 				t,
-				slices.ContainsFunc(migration.minorProbes, func(probe schemaMigrationProbe) bool {
+				slices.Any(migration.minorProbes, func(probe schemaMigrationProbe) bool {
 					return probe.version == version
 				}),
 				"major version %d has no probe for minor version %d",
@@ -1420,13 +1462,139 @@ func TestEveryMigrationHasAnAppliedProbe(t *testing.T) {
 	}
 }
 
+// newUnmigratedTestStore opens a store database without running any migration, so a test can
+// drive individual migration streams to a specific version.
+func newUnmigratedTestStore(t *testing.T, ctx context.Context, path string) *Store {
+	t.Helper()
+
+	require.NoError(t, usvc_io.EnsureRestrictedDirectory(filepath.Dir(path), osutil.PermissionOnlyOwnerReadWriteTraverse))
+	db, openErr := openSQLiteDB(ctx, path, 500*time.Millisecond)
+	require.NoError(t, openErr)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return &Store{db: db, path: path, log: logr.Discard()}
+}
+
+// migrateStreamTo advances a single migration stream to the requested version.
+// Passing noSchemaVersion leaves the stream untouched.
+func migrateStreamTo(
+	t *testing.T,
+	ctx context.Context,
+	store *Store,
+	sourcePath string,
+	tableName string,
+	version int,
+) {
+	t.Helper()
+
+	if version <= 0 {
+		return
+	}
+	migrationRunner, runnerErr := store.newMigrationRunner(ctx, 500*time.Millisecond, sourcePath, tableName)
+	require.NoError(t, runnerErr)
+	migrationErr := migrationRunner.Migrate(uint(version))
+	sourceCloseErr, databaseCloseErr := migrationRunner.Close()
+	require.NoError(t, sourceCloseErr)
+	require.NoError(t, databaseCloseErr)
+	if migrationErr != nil && !errors.Is(migrationErr, gomigrate.ErrNoChange) {
+		require.NoError(t, migrationErr)
+	}
+}
+
+func evaluateAppliedProbe(t *testing.T, ctx context.Context, store *Store, probe schemaMigrationProbe) bool {
+	t.Helper()
+
+	var applied bool
+	require.NoError(t, store.db.QueryRowContext(ctx, probe.appliedQuery).Scan(&applied))
+	return applied
+}
+
+// TestAppliedProbesDetectTheirOwnMigration verifies that each probe actually distinguishes its
+// migration having been applied from not. A probe that is always true (a copy of a neighboring
+// migration's probe, for example) satisfies TestEveryMigrationHasAnAppliedProbe but makes
+// repairDirtySchemaVersion keep a version marker for a migration that never ran, permanently
+// skipping it and corrupting the schema.
+func TestAppliedProbesDetectTheirOwnMigration(t *testing.T) {
+	t.Parallel()
+
+	type probedStream struct {
+		name       string
+		sourcePath string
+		tableName  string
+		probes     []schemaMigrationProbe
+		// prepare brings the database to the state this stream starts migrating from.
+		prepare func(t *testing.T, ctx context.Context, store *Store)
+	}
+
+	streams := []probedStream{{
+		name:       "major",
+		sourcePath: "migrations",
+		tableName:  schemaMajorMigrationTableName,
+		probes:     schemaMajorProbes,
+	}}
+	for _, migration := range schemaMajorMigrations {
+		streams = append(streams, probedStream{
+			name:       fmt.Sprintf("major-%d-minor", migration.version),
+			sourcePath: migration.minorPath(),
+			tableName:  migration.minorTableName,
+			probes:     migration.minorProbes,
+			prepare: func(t *testing.T, ctx context.Context, store *Store) {
+				migrateStreamTo(t, ctx, store, "migrations", schemaMajorMigrationTableName, migration.version)
+			},
+		})
+	}
+
+	for _, stream := range streams {
+		for _, version := range migrationVersionsInDir(t, stream.sourcePath) {
+			t.Run(fmt.Sprintf("%s-%d", stream.name, version), func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+				defer cancel()
+
+				probeIndex := slices.IndexFunc(stream.probes, func(probe schemaMigrationProbe) bool {
+					return probe.version == version
+				})
+				require.GreaterOrEqual(t, probeIndex, 0, "no probe registered for %s version %d", stream.name, version)
+				probe := stream.probes[probeIndex]
+
+				store := newUnmigratedTestStore(t, ctx, filepath.Join(t.TempDir(), "state.sqlite3"))
+				if stream.prepare != nil {
+					stream.prepare(t, ctx, store)
+				}
+
+				migrateStreamTo(t, ctx, store, stream.sourcePath, stream.tableName, version-1)
+				require.False(
+					t,
+					evaluateAppliedProbe(t, ctx, store, probe),
+					"probe for %s version %d reports applied before the migration ran",
+					stream.name,
+					version,
+				)
+
+				migrateStreamTo(t, ctx, store, stream.sourcePath, stream.tableName, version)
+				require.True(
+					t,
+					evaluateAppliedProbe(t, ctx, store, probe),
+					"probe for %s version %d reports not applied after the migration ran",
+					stream.name,
+					version,
+				)
+			})
+		}
+	}
+}
+
 // TestMigrationsAreTransactional guards the invariant that lets an interrupted migration be repaired:
 // the migration driver wraps every migration in a transaction, so a migration either commits in full
 // or not at all. Statements that commit implicitly would break that invariant.
 func TestMigrationsAreTransactional(t *testing.T) {
 	t.Parallel()
 
-	forbiddenStatements := []string{"BEGIN", "COMMIT", "ROLLBACK", "VACUUM", "PRAGMA", "ATTACH", "DETACH"}
+	// Match whole words only so identifiers that merely contain a keyword (a "commit_sha" column,
+	// for example) are not reported as forbidden statements.
+	forbiddenStatements := regexp.MustCompile(`(?i)\b(BEGIN|COMMIT|ROLLBACK|VACUUM|PRAGMA|ATTACH|DETACH)\b`)
 	walkErr := fs.WalkDir(migrationFiles, "migrations", func(path string, entry fs.DirEntry, entryErr error) error {
 		if entryErr != nil {
 			return entryErr
@@ -1436,17 +1604,14 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		}
 		contents, readErr := fs.ReadFile(migrationFiles, path)
 		require.NoError(t, readErr)
-		upperContents := strings.ToUpper(string(contents))
-		for _, statement := range forbiddenStatements {
-			require.NotContains(
-				t,
-				upperContents,
-				statement,
-				"migration '%s' must not use %s; it breaks migration atomicity",
-				path,
-				statement,
-			)
-		}
+		match := forbiddenStatements.FindString(string(contents))
+		require.Empty(
+			t,
+			match,
+			"migration '%s' must not use %s; it breaks migration atomicity",
+			path,
+			match,
+		)
 		return nil
 	})
 	require.NoError(t, walkErr)

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -450,7 +450,7 @@ func TestOpenAcceptsDirtyNewerSchemaMinorVersion(t *testing.T) {
 	require.Equal(t, 999, version)
 }
 
-func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationApplied(t *testing.T) {
+func TestOpenRecoversDirtySchemaMinorVersionWhenMigrationApplied(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -472,7 +472,7 @@ func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationApplied(t *testing.T) {
 	requireWorkloadIDColumn(t, ctx, reopenedStore.db, true)
 }
 
-func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationNotApplied(t *testing.T) {
+func TestOpenRecoversDirtySchemaMinorVersionWhenMigrationNotApplied(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -503,7 +503,7 @@ func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationNotApplied(t *testing.T)
 	requireWorkloadIDColumn(t, ctx, reopenedStore.db, true)
 }
 
-func TestOpenRepairsDirtyInitialSchemaMajorVersion(t *testing.T) {
+func TestOpenRecoversDirtyInitialSchemaMajorVersion(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -608,7 +608,7 @@ func TestOpenRejectsUnknownSchemaMajorVersion(t *testing.T) {
 	require.True(t, hasLegacyOwnerColumn)
 }
 
-func TestOpenRepairsDirtySchemaVersion2WhenMigrationApplied(t *testing.T) {
+func TestOpenRecoversDirtySchemaVersion2WhenMigrationApplied(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -647,7 +647,7 @@ func TestOpenRepairsDirtySchemaVersion2WhenMigrationApplied(t *testing.T) {
 	require.Equal(t, "workload-a", workloadID)
 }
 
-func TestOpenRepairsDirtySchemaVersion2WhenMigrationNotApplied(t *testing.T) {
+func TestOpenRecoversDirtySchemaVersion2WhenMigrationNotApplied(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -673,11 +673,11 @@ func TestOpenRepairsDirtySchemaVersion2WhenMigrationNotApplied(t *testing.T) {
 	requireWorkloadIDColumn(t, ctx, store.db, true)
 }
 
-// TestOpenRepairsSchemaDirtiedByOlderDcp covers how a dirty marker is produced in practice: a store
+// TestOpenRecoversSchemaDirtiedByOlderDcp covers how a dirty marker is produced in practice: a store
 // this binary normalized to major version 1 is opened by an older DCP, whose single-stream migration
 // layout re-applies the workload ID migration. That migration fails because the column already
-// exists, leaving the dirty version 2 marker behind for this binary to repair.
-func TestOpenRepairsSchemaDirtiedByOlderDcp(t *testing.T) {
+// exists, leaving the dirty version 2 marker behind for this binary to recover.
+func TestOpenRecoversSchemaDirtiedByOlderDcp(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -706,11 +706,11 @@ func TestOpenRepairsSchemaDirtiedByOlderDcp(t *testing.T) {
 		usvc_io.EnsureRestrictedDirectory(filepath.Dir(storePath), osutil.PermissionOnlyOwnerReadWriteTraverse),
 	)
 
-	repaired := openTestStore(t, ctx, storePath)
+	recovered := openTestStore(t, ctx, storePath)
 
-	requireSchemaMajorVersion(t, ctx, repaired, currentSchemaMajorVersion)
-	requireSchemaMinorVersion(t, ctx, repaired, currentSchemaMinorVersion)
-	requireWorkloadIDColumn(t, ctx, repaired.db, true)
+	requireSchemaMajorVersion(t, ctx, recovered, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, recovered, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, recovered.db, true)
 }
 
 func TestOpenWithExplicitPathRejectsPermissiveExistingParentDirectory(t *testing.T) {
@@ -1414,7 +1414,7 @@ func migrationVersionsInDir(t *testing.T, dir string) []int {
 	return versions
 }
 
-// TestEveryMigrationHasAnAppliedProbe guards the repair of interrupted migrations: without a probe
+// TestEveryMigrationHasAnAppliedProbe guards recovery of interrupted migrations: without a probe
 // for every migration, a dirty version marker cannot be resolved and startup fails.
 func TestEveryMigrationHasAnAppliedProbe(t *testing.T) {
 	t.Parallel()
@@ -1513,7 +1513,7 @@ func evaluateAppliedProbe(t *testing.T, ctx context.Context, store *Store, probe
 // TestAppliedProbesDetectTheirOwnMigration verifies that each probe actually distinguishes its
 // migration having been applied from not. A probe that is always true (a copy of a neighboring
 // migration's probe, for example) satisfies TestEveryMigrationHasAnAppliedProbe but makes
-// repairDirtySchemaVersion keep a version marker for a migration that never ran, permanently
+// recoverDirtySchemaVersion keep a version marker for a migration that never ran, permanently
 // skipping it and corrupting the schema.
 func TestAppliedProbesDetectTheirOwnMigration(t *testing.T) {
 	t.Parallel()
@@ -1675,7 +1675,7 @@ func TestFindTransactionBreakingStatement(t *testing.T) {
 	}
 }
 
-// TestMigrationsAreTransactional guards the invariant that lets an interrupted migration be repaired:
+// TestMigrationsAreTransactional guards the invariant that lets an interrupted migration be recovered:
 // the migration driver wraps every migration in a transaction, so a migration either commits in full
 // or not at all. Statements that commit implicitly would break that invariant.
 func TestMigrationsAreTransactional(t *testing.T) {

--- a/internal/statestore/store_test.go
+++ b/internal/statestore/store_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -129,6 +131,15 @@ func requireSchemaMigrationVersion(
 	require.NoError(t, row.Scan(&version, &dirty))
 	require.Equal(t, expectedVersion, version)
 	require.False(t, dirty)
+}
+
+func requireWorkloadIDColumn(t *testing.T, ctx context.Context, db *sql.DB, expected bool) {
+	t.Helper()
+
+	row := db.QueryRowContext(ctx, workloadIDsMigrationAppliedProbe)
+	var hasColumn bool
+	require.NoError(t, row.Scan(&hasColumn))
+	require.Equal(t, expected, hasColumn)
 }
 
 func resourceLocksHasColumn(ctx context.Context, conn *sql.Conn, columnName string) (bool, error) {
@@ -407,7 +418,7 @@ func TestOpenIgnoresUnknownSchemaMinorMigrations(t *testing.T) {
 	requireSchemaMinorVersion(t, ctx, reopenedStore, 999)
 }
 
-func TestOpenRejectsDirtyNewerSchemaMinorVersion(t *testing.T) {
+func TestOpenAcceptsDirtyNewerSchemaMinorVersion(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -422,12 +433,121 @@ func TestOpenRejectsDirtyNewerSchemaMinorVersion(t *testing.T) {
 	_, updateErr := store.db.ExecContext(ctx, updateQuery, 999)
 	require.NoError(t, updateErr)
 
+	reopenedStore := openTestStore(t, ctx, storePath)
+
+	// The interrupted migration belongs to a newer DCP, which is the only binary that can decide
+	// whether it was applied. Everything this binary needs is present either way.
+	version, found, dirty, readErr := readSchemaVersion(
+		ctx,
+		reopenedStore.db,
+		schemaMajorVersion1Migration.minorTableName,
+	)
+	require.NoError(t, readErr)
+	require.True(t, found)
+	require.True(t, dirty)
+	require.Equal(t, 999, version)
+}
+
+func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationApplied(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store := openTestStore(t, ctx, storePath)
+	updateQuery := fmt.Sprintf(
+		`UPDATE %s SET dirty = 1`,
+		quoteSQLiteIdentifier(schemaMajorVersion1Migration.minorTableName),
+	)
+	_, updateErr := store.db.ExecContext(ctx, updateQuery)
+	require.NoError(t, updateErr)
+
+	reopenedStore := openTestStore(t, ctx, storePath)
+
+	requireSchemaMajorVersion(t, ctx, reopenedStore, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, reopenedStore, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, reopenedStore.db, true)
+}
+
+func TestOpenRepairsDirtySchemaMinorVersionWhenMigrationNotApplied(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	store := openTestStore(t, ctx, storePath)
+	// Undo the minor migration's schema changes to simulate a migration that never committed,
+	// leaving only the dirty marker behind.
+	_, revertErr := store.db.ExecContext(
+		ctx,
+		`DROP INDEX idx_persistent_processes_workload_id;
+		 ALTER TABLE persistent_processes DROP COLUMN workload_id;`,
+	)
+	require.NoError(t, revertErr)
+	updateQuery := fmt.Sprintf(
+		`UPDATE %s SET dirty = 1`,
+		quoteSQLiteIdentifier(schemaMajorVersion1Migration.minorTableName),
+	)
+	_, updateErr := store.db.ExecContext(ctx, updateQuery)
+	require.NoError(t, updateErr)
+	requireWorkloadIDColumn(t, ctx, store.db, false)
+
+	reopenedStore := openTestStore(t, ctx, storePath)
+
+	requireSchemaMajorVersion(t, ctx, reopenedStore, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, reopenedStore, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, reopenedStore.db, true)
+}
+
+func TestOpenRepairsDirtyInitialSchemaMajorVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	db := openRawSQLiteDB(t, ctx, storePath)
+	_, createErr := db.ExecContext(
+		ctx,
+		`CREATE TABLE schema_migrations (version uint64, dirty bool);
+		 CREATE UNIQUE INDEX version_unique ON schema_migrations (version);
+		 INSERT INTO schema_migrations (version, dirty) VALUES (1, 1);`,
+	)
+	require.NoError(t, createErr)
+	require.NoError(t, db.Close())
+
+	store := openTestStore(t, ctx, storePath)
+
+	requireSchemaMajorVersion(t, ctx, store, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, store, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, store.db, true)
+}
+
+func TestOpenRejectsDirtyUnknownSchemaMajorVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	require.NoError(t, runLegacyMigrationRunner(ctx, storePath, legacyMigrationFixture(t, false)))
+	db := openRawSQLiteDB(t, ctx, storePath)
+	_, updateErr := db.ExecContext(ctx, `UPDATE schema_migrations SET version = 3, dirty = 1`)
+	require.NoError(t, updateErr)
+	require.NoError(t, db.Close())
+	require.NoError(
+		t,
+		usvc_io.EnsureRestrictedDirectory(filepath.Dir(storePath), osutil.PermissionOnlyOwnerReadWriteTraverse),
+	)
+
 	_, openErr := Open(ctx, Options{
 		Path:        storePath,
 		BusyTimeout: 500 * time.Millisecond,
 	})
 
-	require.ErrorContains(t, openErr, "minor version 999 is dirty")
+	require.ErrorContains(t, openErr, "schema major version 3 is dirty")
 }
 
 func TestOpenRejectsUnknownSchemaMajorVersion(t *testing.T) {
@@ -486,7 +606,7 @@ func TestOpenRejectsUnknownSchemaMajorVersion(t *testing.T) {
 	require.True(t, hasLegacyOwnerColumn)
 }
 
-func TestOpenRejectsDirtySchemaVersion2(t *testing.T) {
+func TestOpenRepairsDirtySchemaVersion2WhenMigrationApplied(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
@@ -495,6 +615,13 @@ func TestOpenRejectsDirtySchemaVersion2(t *testing.T) {
 	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
 	require.NoError(t, runLegacyMigrationRunner(ctx, storePath, legacyMigrationFixture(t, true)))
 	schemaVersion2DB := openRawSQLiteDB(t, ctx, storePath)
+	_, insertErr := schemaVersion2DB.ExecContext(
+		ctx,
+		`INSERT INTO persistent_processes (
+			resource_key, lifecycle_key, pid, identity_time, run_id, stdout_file, stderr_file, updated_at_unix_nano, workload_id
+		 ) VALUES ('executable/existing', 'lifecycle', 1234, '', 'run', '', '', 0, 'workload-a')`,
+	)
+	require.NoError(t, insertErr)
 	_, updateErr := schemaVersion2DB.ExecContext(ctx, `UPDATE schema_migrations SET dirty = 1`)
 	require.NoError(t, updateErr)
 	require.NoError(t, schemaVersion2DB.Close())
@@ -503,12 +630,45 @@ func TestOpenRejectsDirtySchemaVersion2(t *testing.T) {
 		usvc_io.EnsureRestrictedDirectory(filepath.Dir(storePath), osutil.PermissionOnlyOwnerReadWriteTraverse),
 	)
 
-	_, openErr := Open(ctx, Options{
-		Path:        storePath,
-		BusyTimeout: 500 * time.Millisecond,
-	})
+	store := openTestStore(t, ctx, storePath)
 
-	require.ErrorContains(t, openErr, "schema major version 2 is dirty")
+	requireSchemaMajorVersion(t, ctx, store, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, store, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, store.db, true)
+	row := store.db.QueryRowContext(
+		ctx,
+		`SELECT workload_id FROM persistent_processes WHERE resource_key = ?`,
+		"executable/existing",
+	)
+	var workloadID string
+	require.NoError(t, row.Scan(&workloadID))
+	require.Equal(t, "workload-a", workloadID)
+}
+
+func TestOpenRepairsDirtySchemaVersion2WhenMigrationNotApplied(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testutil.GetTestContext(t, stateStoreTestTimeout)
+	defer cancel()
+
+	// Only the initial legacy migration committed, but the version marker already advanced to the
+	// dirty version 2 that the interrupted migration was about to apply.
+	storePath := filepath.Join(t.TempDir(), "state.sqlite3")
+	require.NoError(t, runLegacyMigrationRunner(ctx, storePath, legacyMigrationFixture(t, false)))
+	schemaVersion1DB := openRawSQLiteDB(t, ctx, storePath)
+	_, updateErr := schemaVersion1DB.ExecContext(ctx, `UPDATE schema_migrations SET version = 2, dirty = 1`)
+	require.NoError(t, updateErr)
+	require.NoError(t, schemaVersion1DB.Close())
+	require.NoError(
+		t,
+		usvc_io.EnsureRestrictedDirectory(filepath.Dir(storePath), osutil.PermissionOnlyOwnerReadWriteTraverse),
+	)
+
+	store := openTestStore(t, ctx, storePath)
+
+	requireSchemaMajorVersion(t, ctx, store, currentSchemaMajorVersion)
+	requireSchemaMinorVersion(t, ctx, store, currentSchemaMinorVersion)
+	requireWorkloadIDColumn(t, ctx, store.db, true)
 }
 
 func TestOpenWithExplicitPathRejectsPermissiveExistingParentDirectory(t *testing.T) {
@@ -1188,4 +1348,106 @@ func TestPersistentNetworkRecordRoundTripByWorkloadID(t *testing.T) {
 	records, listErr = store.ListPersistentNetworksByWorkloadID(ctx, record.WorkloadID)
 	require.NoError(t, listErr)
 	require.Empty(t, records)
+}
+
+// migrationVersionsInDir returns the migration versions declared by the up migration files
+// directly under the given embedded directory.
+func migrationVersionsInDir(t *testing.T, dir string) []int {
+	t.Helper()
+
+	entries, readErr := fs.ReadDir(migrationFiles, dir)
+	require.NoError(t, readErr)
+
+	versions := []int{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".up.sql") {
+			continue
+		}
+		versionText, _, found := strings.Cut(entry.Name(), "_")
+		require.True(t, found, "migration file '%s' does not start with a version prefix", entry.Name())
+		version, parseErr := strconv.Atoi(versionText)
+		require.NoError(t, parseErr)
+		versions = append(versions, version)
+	}
+	return versions
+}
+
+// TestEveryMigrationHasAnAppliedProbe guards the repair of interrupted migrations: without a probe
+// for every migration, a dirty version marker cannot be resolved and startup fails.
+func TestEveryMigrationHasAnAppliedProbe(t *testing.T) {
+	t.Parallel()
+
+	majorVersions := migrationVersionsInDir(t, "migrations")
+	require.NotEmpty(t, majorVersions)
+	for _, version := range majorVersions {
+		require.True(
+			t,
+			slices.ContainsFunc(schemaMajorProbes, func(probe schemaMigrationProbe) bool { return probe.version == version }),
+			"schemaMajorProbes has no probe for major version %d",
+			version,
+		)
+	}
+	require.True(
+		t,
+		slices.ContainsFunc(schemaMajorProbes, func(probe schemaMigrationProbe) bool {
+			return probe.version == legacySchemaVersion2
+		}),
+		"schemaMajorProbes has no probe for the legacy schema version 2 marker",
+	)
+
+	for _, migration := range schemaMajorMigrations {
+		minorVersions := migrationVersionsInDir(t, migration.minorPath())
+		require.Equal(
+			t,
+			len(minorVersions),
+			migration.latestMinorVersion,
+			"major version %d declares latestMinorVersion %d but has %d minor migration files",
+			migration.version,
+			migration.latestMinorVersion,
+			len(minorVersions),
+		)
+		for _, version := range minorVersions {
+			require.True(
+				t,
+				slices.ContainsFunc(migration.minorProbes, func(probe schemaMigrationProbe) bool {
+					return probe.version == version
+				}),
+				"major version %d has no probe for minor version %d",
+				migration.version,
+				version,
+			)
+		}
+	}
+}
+
+// TestMigrationsAreTransactional guards the invariant that lets an interrupted migration be repaired:
+// the migration driver wraps every migration in a transaction, so a migration either commits in full
+// or not at all. Statements that commit implicitly would break that invariant.
+func TestMigrationsAreTransactional(t *testing.T) {
+	t.Parallel()
+
+	forbiddenStatements := []string{"BEGIN", "COMMIT", "ROLLBACK", "VACUUM", "PRAGMA", "ATTACH", "DETACH"}
+	walkErr := fs.WalkDir(migrationFiles, "migrations", func(path string, entry fs.DirEntry, entryErr error) error {
+		if entryErr != nil {
+			return entryErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			return nil
+		}
+		contents, readErr := fs.ReadFile(migrationFiles, path)
+		require.NoError(t, readErr)
+		upperContents := strings.ToUpper(string(contents))
+		for _, statement := range forbiddenStatements {
+			require.NotContains(
+				t,
+				upperContents,
+				statement,
+				"migration '%s' must not use %s; it breaks migration atomicity",
+				path,
+				statement,
+			)
+		}
+		return nil
+	})
+	require.NoError(t, walkErr)
 }


### PR DESCRIPTION
Backport of #224 to release/0.25

/cc @danegsta

## Customer Impact

## Testing

## Risk

## Regression?