### PR TITLE
Remove Publish-Build-Assets variable group from release/0.23

### DIFF
--- a/.azure/pipelines/common-build.yml
+++ b/.azure/pipelines/common-build.yml
@@ -658,7 +658,6 @@ stages:
     displayName: 'Build Arcade Manifest'
     pool: ${{ parameters.windowsPool }}
     variables:
-    - group: Publish-Build-Assets
     - name: gitVersionPreReleaseTag
       value: $[ stageDependencies.Build.Version.outputs['version.preReleaseTag'] ]
     templateContext:
@@ -696,7 +695,6 @@ stages:
     dependsOn:
     - ArcadeManifestBuild
     variables:
-    - group: Publish-Build-Assets
     templateContext:
       inputs:
       - input: pipelineArtifact
@@ -742,7 +740,6 @@ stages:
     dependsOn:
     - ArcadeManifestPublish
     variables:
-    - group: Publish-Build-Assets
     - name: barBuildId
       value: $[ dependencies.ArcadeManifestPublish.outputs['BARSVariables.barBuildId'] ]
     - name: gitVersionPreReleaseTag


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `.azure/pipelines/common-build.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131